### PR TITLE
fix(ci): use PAT token in dependabot workflow to trigger CI re-runs

### DIFF
--- a/.github/workflows/dependabot-lockfile-fix.yml
+++ b/.github/workflows/dependabot-lockfile-fix.yml
@@ -14,22 +14,22 @@ jobs:
     name: Update bun.lock
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
-    
+
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-      
+          token: ${{ secrets.PAT_TOKEN }}
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      
+
       - name: Install dependencies and update lockfile
         run: bun install
-      
+
       - name: Check for lockfile changes
         id: check
         run: |
@@ -40,7 +40,7 @@ jobs:
             echo "Lockfile needs update 🔧"
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
-      
+
       - name: Commit updated lockfile
         if: steps.check.outputs.changed == 'true'
         run: |
@@ -49,15 +49,15 @@ jobs:
           git add bun.lock
           git commit -m "chore: update bun.lock for dependency sync"
           git push
-      
+
       - name: Comment on PR
         if: steps.check.outputs.changed == 'true'
         run: |
           gh pr comment "$PR_URL" --body "🤖 **Lockfile Auto-Fix**
-          
+
           I've automatically updated \`bun.lock\` to sync with the dependency changes in \`package.json\`.
-          
+
           The CI checks will now re-run with the updated lockfile."
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
## Problem

When Dependabot creates a PR, the lockfile fix workflow updates `bun.lock` and pushes a second commit. However, when `github-actions[bot]` pushes using `GITHUB_TOKEN`, GitHub doesn't trigger subsequent workflows as a security measure to prevent infinite loops.

This causes the CI workflow to never re-run after the lockfile is fixed, leaving the PR with failed checks.

## Solution

Replace `GITHUB_TOKEN` with a Personal Access Token (PAT) in:
1. The checkout step
2. The gh CLI authentication

When using a PAT, GitHub treats the push as coming from a real user, properly triggering CI workflows.

## Changes

- `.github/workflows/dependabot-lockfile-fix.yml`:
  - Line 23: `GITHUB_TOKEN` → `PAT_TOKEN` in checkout
  - Line 63: `GITHUB_TOKEN` → `PAT_TOKEN` in GH_TOKEN

## Testing

After merging, this will be tested with PR #11 (Dependabot globals update):
1. Close and reopen PR #11 to trigger the workflow
2. Verify lockfile fix runs
3. Verify CI re-runs automatically after lockfile commit

## References

- GitHub Actions docs on triggering workflows: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow