### PR TITLE
fix(ci): remove approval from Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,7 +26,6 @@ jobs:
           steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
           steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: |
-          gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Problem

All new Dependabot PRs (#42-#49) are failing auto-merge with:

```
failed to create review: GraphQL: GitHub Actions is not permitted 
to approve pull requests. (addPullRequestReview)
```

## Root Cause

GitHub Actions has a security restriction: **GITHUB_TOKEN cannot approve PRs**.

The workflow was trying to:
1. Approve the PR ❌ (not allowed)
2. Enable auto-merge ✅ (allowed)

## Solution

Remove the `gh pr review --approve` step.

**Why this works:**
- Branch protection requires **0 approvals** (verified)
- Auto-merge only needs checks to pass
- No approval is technically required

## Changes

```diff
- gh pr review --approve "$PR_URL"
  gh pr merge --auto --squash "$PR_URL"
```

## Testing

After merge:
1. Existing PRs will re-run the workflow
2. Auto-merge will be enabled automatically
3. When CI passes, PRs will merge

## Impact

✅ Minor/patch updates will auto-merge when tests pass  
⚠️ Major updates still require manual review (as designed)