### PR TITLE
feat(ci): add conditional Cloudflare Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - "package.json"
+      - "bun.lock"
+      - ".github/**"
+      - "README.md"
+      - "docs/**"
+  workflow_dispatch: # Allow manual deploy
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Pages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build site
+        run: bun run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=website


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow to deploy to Cloudflare Pages only when there are real content or code changes, preventing unnecessary builds from dependency updates.

## Changes

- ✅ New workflow: `.github/workflows/deploy.yml`
- ✅ Deploys only on push to `master` with content/code changes
- ✅ Ignores dependency-only updates (`package.json`, `bun.lock`)
- ✅ Ignores documentation changes (`README.md`, `docs/**`)
- ✅ Ignores workflow changes (`.github/**`)
- ✅ Supports manual deployment via `workflow_dispatch`

## Why?

Without this, Cloudflare Pages builds on **every** push and PR, including Dependabot updates. This quickly exhausts the free tier limit of 500 builds/month.

## How it works

### ✅ WILL deploy when:
- Content changes: `src/content/**/*.mdx`
- Code changes: `src/**/*.astro`, `*.ts`, `*.scss`
- Asset changes: `public/**`
- Any combination of the above with dependency updates

### ❌ WON'T deploy when ONLY:
- `package.json` and `bun.lock` change (Dependabot PRs)
- `README.md` changes
- `docs/**` changes
- `.github/**` changes

## Testing

After merge:
1. Cloudflare Pages automatic builds will be disabled
2. GitHub Actions will handle all deployments
3. First deployment will happen on next content/code push to master

## Requirements

- ✅ `CLOUDFLARE_API_TOKEN` secret configured
- ✅ `CLOUDFLARE_ACCOUNT_ID` secret configured
- ⏳ After merge: disable automatic builds in Cloudflare Pages settings