### PR TITLE
refactor(courses): remove full course list from course detail pages

### DIFF
--- a/src/pages-templates/courses/CoursesDetailPage.astro
+++ b/src/pages-templates/courses/CoursesDetailPage.astro
@@ -13,7 +13,6 @@
 import Breadcrumbs, { type BreadcrumbItem } from "@components/Breadcrumbs.astro";
 import Paginator from "@components/Paginator.astro";
 import PostList from "@components/PostList.astro";
-import TaxonomyListGrouped from "@components/TaxonomyListGrouped.astro";
 import Title from "@components/Title.astro";
 import Layout from "@layouts/Layout.astro";
 import { t } from "@locales";
@@ -40,10 +39,6 @@ interface Props {
   totalItems: number; // Total items across all pages
   contact: ContactItem[];
   hasTargetContent: boolean;
-  coursesWithCounts: Array<{
-    item: CollectionEntry<"courses">;
-    count: number;
-  }>;
 }
 
 const {
@@ -55,7 +50,6 @@ const {
   totalItems,
   contact,
   hasTargetContent,
-  coursesWithCounts,
 } = Astro.props;
 
 const pageTitle = `${t(lang, "pages.course")}: ${course.data.name}`;
@@ -121,12 +115,4 @@ const itemListSchema = generateItemListSchema(
   </div>
 
   <Paginator currentPage={currentPage} totalPages={totalPages} basePath={basePath} lang={lang} />
-
-  <TaxonomyListGrouped
-    items={coursesWithCounts}
-    title={t(lang, "allCourses")}
-    lang={lang}
-    routeKey="courses"
-    slugField="course_slug"
-  />
 </Layout>


### PR DESCRIPTION
## Summary
- Removes `TaxonomyListGrouped` component from course detail pages
- This component was displaying the full list of all courses at the bottom of each course detail page
- The feature was previously disabled on other taxonomy pages but was accidentally left enabled on courses

## Changes
- **File**: `src/pages-templates/courses/CoursesDetailPage.astro`
- Removed `TaxonomyListGrouped` import (line 16)
- Removed `coursesWithCounts` prop from Props interface (lines 43-46)
- Removed `coursesWithCounts` destructuring (line 58)
- Removed `TaxonomyListGrouped` component rendering (lines 125-131)

## Testing
- ✅ Unit tests: 1453/1453 passing
- ✅ E2E tests: 535/535 passing
- ✅ Format/lint/typecheck: passing

## Why
The course list component at the bottom of detail pages was providing little value and was inconsistent with other taxonomy detail pages (genres, authors, etc.) where this feature was already disabled.