### PR TITLE
fix: use processed image URL for meta tags and preload hints in detail pages

### DIFF
--- a/src/__tests__/pages-templates/detail-pages-cover-image.test.ts
+++ b/src/__tests__/pages-templates/detail-pages-cover-image.test.ts
@@ -1,0 +1,71 @@
+// Tests for cover image URL handling in detail page templates
+// Verifies that processed image URLs (from ImageMetadata.src) are used
+// for meta tags and preload hints instead of raw frontmatter paths,
+// which would cause 404 errors since assets live in src/assets/ not public/
+
+import fs from "fs";
+import path from "path";
+
+import { describe, it, expect } from "vitest";
+
+const TEMPLATES = [
+  {
+    name: "TutorialsDetailPage",
+    file: "../../pages-templates/tutorials/TutorialsDetailPage.astro",
+    coverVar: "coverImage",
+    rawPathVar: "coverImagePath",
+  },
+  {
+    name: "PostsDetailPage",
+    file: "../../pages-templates/posts/PostsDetailPage.astro",
+    coverVar: "coverImage",
+    rawPathVar: "coverImagePath",
+  },
+];
+
+describe("Detail page templates — cover image URL for meta tags", () => {
+  for (const template of TEMPLATES) {
+    describe(template.name, () => {
+      const filePath = path.resolve(__dirname, template.file);
+
+      it("should exist", () => {
+        expect(fs.existsSync(filePath)).toBe(true);
+      });
+
+      it("should use processed image src for preloadImage prop (not raw frontmatter path)", () => {
+        const content = fs.readFileSync(filePath, "utf-8");
+
+        // preloadImage must use the .src from ImageMetadata (the Astro-processed URL),
+        // not the raw /images/... path from the frontmatter which doesn't exist in public/
+        expect(content).toMatch(/preloadImage=\{coverImage\.src\}/);
+      });
+
+      it("should use processed image src for Layout image prop (OG/Twitter meta)", () => {
+        const content = fs.readFileSync(filePath, "utf-8");
+
+        // Same requirement for the OG image meta tag
+        expect(content).toMatch(/image=\{coverImage\.src\}/);
+      });
+
+      it("should use processed image src for JSON-LD schema image field", () => {
+        const content = fs.readFileSync(filePath, "utf-8");
+
+        // JSON-LD schema.org image field must also point to the real processed URL
+        expect(content).toMatch(/image:\s*coverImage\.src/);
+      });
+
+      it("should NOT use raw coverImagePath for preloadImage", () => {
+        const content = fs.readFileSync(filePath, "utf-8");
+
+        // Ensure the old broken pattern is gone
+        expect(content).not.toMatch(/preloadImage=\{coverImagePath\}/);
+      });
+
+      it("should NOT use raw coverImagePath for Layout image prop", () => {
+        const content = fs.readFileSync(filePath, "utf-8");
+
+        expect(content).not.toMatch(/image=\{coverImagePath\}/);
+      });
+    });
+  }
+});

--- a/src/pages-templates/books/BooksDetailPage.astro
+++ b/src/pages-templates/books/BooksDetailPage.astro
@@ -177,11 +177,11 @@ const genreLabel = lang === "en" ? "Genre" : "Género";
   title={`${book.title} - ${t(lang, "book.review")}`}
   contact={contact}
   translationSlug={book.i18n}
-  image={book.book_cover || book.cover}
+  image={bookCoverImage.src}
   type="book"
   schema={bookSchema}
   hasTargetContent={hasTargetContent}
-  preloadImage={book.book_cover || book.cover}
+  preloadImage={bookCoverImage.src}
 >
   <Breadcrumbs items={breadcrumbs} lang={lang} />
   <main class="book">

--- a/src/pages-templates/posts/PostsDetailPage.astro
+++ b/src/pages-templates/posts/PostsDetailPage.astro
@@ -41,8 +41,9 @@ const categories = findCategoriesBySlug(allCategories, post.categories);
 
 // Cover image with fallback (returns ImageMetadata for optimization)
 const coverImage = getPostCoverImage(post.cover);
-// Keep original path for meta tags (Layout expects string)
-const coverImagePath = post.cover || "/images/defaults/post-default.jpg";
+// Use the processed image URL (coverImage.src) for meta tags and preload hints.
+// The raw frontmatter path (/images/posts/...) does not exist in public/ —
+// Astro processes assets from src/assets/ into /_astro/*.webp at build time.
 
 // Share component data
 const baseUrl = t(lang, "metaData.url");
@@ -56,7 +57,7 @@ const articleSchema: Record<string, unknown> = {
   "@type": "BlogPosting",
   headline: post.title,
   description: post.excerpt,
-  image: coverImagePath,
+  image: coverImage.src,
   datePublished: post.date.toISOString(),
   author: {
     "@type": "Person",
@@ -81,10 +82,10 @@ if (post.updated) {
   description={post.excerpt}
   contact={contact}
   translationSlug={post.i18n}
-  image={coverImagePath}
+  image={coverImage.src}
   type="article"
   schema={articleSchema}
-  preloadImage={coverImagePath}
+  preloadImage={coverImage.src}
 >
   <main class="post">
     <section class="post__content">

--- a/src/pages-templates/tutorials/TutorialsDetailPage.astro
+++ b/src/pages-templates/tutorials/TutorialsDetailPage.astro
@@ -40,8 +40,9 @@ const categories = findCategoriesBySlug(allCategories, tutorial.categories);
 
 // Cover image with fallback (returns ImageMetadata for optimization)
 const coverImage = getTutorialCoverImage(tutorial.cover);
-// Keep original path for meta tags (Layout expects string)
-const coverImagePath = tutorial.cover || "/images/defaults/tutorial-default.jpg";
+// Use the processed image URL (coverImage.src) for meta tags and preload hints.
+// The raw frontmatter path (/images/tutorials/...) does not exist in public/ —
+// Astro processes assets from src/assets/ into /_astro/*.webp at build time.
 
 // Get course info if exists (filtered by language)
 const allCourses = tutorial.course ? await getCollectionByLanguage("courses", lang) : [];
@@ -107,7 +108,7 @@ const tutorialSchema: Record<string, unknown> = {
   "@type": "TechArticle",
   headline: tutorial.title,
   description: tutorial.excerpt,
-  image: coverImagePath,
+  image: coverImage.src,
   datePublished: tutorial.date.toISOString(),
   author: {
     "@type": "Person",
@@ -140,10 +141,10 @@ if (course) {
   description={tutorial.excerpt}
   contact={contact}
   translationSlug={tutorial.i18n}
-  image={coverImagePath}
+  image={coverImage.src}
   type="article"
   schema={tutorialSchema}
-  preloadImage={coverImagePath}
+  preloadImage={coverImage.src}
 >
   <Breadcrumbs items={breadcrumbs} lang={lang} />
   <main class="tutorial">


### PR DESCRIPTION
## Root cause

Cover images live in `src/assets/` and are processed by Astro at build time into `/_astro/*.webp`. The detail page templates were passing the **raw frontmatter path** (`/images/tutorials/foo.jpg`) — which does not exist in `public/` — to:

- `<Layout image={...}>` → Open Graph / Twitter Card meta tag
- `<Layout preloadImage={...}>` → `<link rel="preload">` hint
- JSON-LD schema `image` field

This caused a **404 network request on every detail page load**, visible in Chrome DevTools Performance panel and flagged by Lighthouse Best Practices (96 instead of 100).

## Fix

Replace `coverImagePath` (raw string from frontmatter) with `coverImage.src` (the actual `/_astro/...` URL from `ImageMetadata`) in all three detail page templates: tutorials, posts and books.

## Tests

- New `src/__tests__/pages-templates/detail-pages-cover-image.test.ts` — 12 TDD tests verifying the fix across tutorials and posts templates
- 1511 unit tests passing
- 535/535 e2e tests passing

## Lighthouse impact (expected)

- Best Practices: 96 → **100** on all detail pages