### PR TITLE
feat: add Cloudflare Pages middleware for root language detection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.6",
         "@axe-core/playwright": "^4.11.1",
+        "@cloudflare/workers-types": "^4.20260210.0",
         "@eslint/js": "^9.24.0",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@lhci/cli": "^0.15.1",
@@ -124,6 +125,8 @@
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260210.0", "", {}, "sha512-zHaF0RZVYUQwNCJCECnNAJdMur72Lk3FMiD6wU78Dx3Bv7DQRcuXNmPNuJmsGnosVZCcWintHlPTQ/4BEiDG5w=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,0 +1,34 @@
+/// <reference types="@cloudflare/workers-types" />
+
+export const onRequest: PagesFunction = async (context) => {
+  const { request, next } = context;
+  const url = new URL(request.url);
+
+  // Only handle root path — all other routes pass through
+  if (url.pathname !== "/" && url.pathname !== "") {
+    return next();
+  }
+
+  // Check cookie preference first (set on previous visit)
+  const cookie = request.headers.get("Cookie") ?? "";
+  const cookieMatch = cookie.match(/preferred-language=(es|en)/);
+  if (cookieMatch) {
+    return Response.redirect(new URL(`/${cookieMatch[1]}/`, url), 302);
+  }
+
+  // Fall back to Accept-Language header
+  const acceptLanguage = request.headers.get("Accept-Language") ?? "";
+  const preferSpanish = /^es\b/i.test(acceptLanguage);
+  const lang = preferSpanish ? "es" : "en";
+
+  const redirectResponse = Response.redirect(new URL(`/${lang}/`, url), 302);
+
+  // Set cookie so subsequent visits skip the header check
+  const headers = new Headers(redirectResponse.headers);
+  headers.set("Set-Cookie", `preferred-language=${lang}; Path=/; Max-Age=31536000; SameSite=Lax; Secure`);
+
+  return new Response(null, {
+    status: 302,
+    headers,
+  });
+};

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.6",
     "@axe-core/playwright": "^4.11.1",
+    "@cloudflare/workers-types": "^4.20260210.0",
     "@eslint/js": "^9.24.0",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@lhci/cli": "^0.15.1",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,15 @@
 ---
-// Detect browser language from Accept-Language header
-// If Spanish is detected -> /es/, otherwise -> /en/
-const acceptLanguage = Astro.request.headers.get("accept-language") || "";
-const isSpanish = acceptLanguage.toLowerCase().includes("es");
-const targetLang = isSpanish ? "es" : "en";
-
-// Server-side redirect (better for SEO and performance)
-return Astro.redirect(`/${targetLang}/`, 302);
+// Static fallback for local dev — in production, Cloudflare middleware handles this.
+// Redirects to /es/ by default; the middleware does proper Accept-Language detection.
 ---
+
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0;url=/es/" />
+    <link rel="canonical" href="/es/" />
+  </head>
+  <body>
+    <p>Redirecting to <a href="/es/">/es/</a></p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Add `functions/_middleware.ts` — Cloudflare Pages Function that intercepts requests to `/` and redirects to `/es/` or `/en/`
- Cookie preference (`preferred-language`) takes priority on repeat visits
- Falls back to `Accept-Language` header; defaults to `/en/` for unrecognized languages
- Update `src/pages/index.astro` to a static `meta-refresh` fallback (used in local dev where the middleware doesn't run)
- Add `@cloudflare/workers-types` as devDependency for proper TypeScript types

## How it works

1. Request hits `/`
2. Middleware checks for `preferred-language` cookie → redirects immediately if present
3. Otherwise parses `Accept-Language` header (`^es\b` → `/es/`, anything else → `/en/`)
4. Sets `preferred-language` cookie (1 year) so subsequent visits skip the header check
5. Returns `302` redirect