### PR TITLE
fix: render Umami script tag unconditionally

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -74,8 +74,6 @@ const nextPageUrl =
       ? `${basePath}/pagina/${currentPage + 1}`
       : `${basePath.replace(/\/pagina\/\d+$/, "")}/pagina/${currentPage + 1}`
     : null;
-
-const umamiWebsiteId: string | undefined = import.meta.env.PUBLIC_UMAMI_WEBSITE_ID;
 ---
 
 <!doctype html>
@@ -149,19 +147,14 @@ const umamiWebsiteId: string | undefined = import.meta.env.PUBLIC_UMAMI_WEBSITE_
       )
     }
 
-    <!-- Umami Analytics: only in production, ~2KB, no cookies, GDPR compliant -->
-    {
-      umamiWebsiteId && (
-        <script
-          is:inline
-          defer
-          src="https://cloud.umami.is/script.js"
-          data-website-id={umamiWebsiteId}
-          data-auto-track="false"
-          data-domains="fjp.es"
-        />
-      )
-    }
+    <!-- Umami Analytics: ~2KB, no cookies, GDPR compliant. data-domains limits tracking to fjp.es only -->
+    <script
+      is:inline
+      defer
+      src="https://cloud.umami.is/script.js"
+      data-website-id="426f751f-3947-4965-a78d-a4573516bd8c"
+      data-auto-track="false"
+      data-domains="fjp.es"></script>
 
     <ViewTransitions />
     <style is:global lang="scss">


### PR DESCRIPTION
## Problem

Umami tracker script was never included in the HTML output. Astro silently drops `<script is:inline>` tags placed inside JSX conditional expressions (`{ condition && (<script />) }`), so the `PUBLIC_UMAMI_WEBSITE_ID` guard was causing the tag to be omitted entirely.

## Fix

Replace the conditional block with an unconditional `<script>` tag. The `website-id` is a public value (visible in page source regardless) and `data-domains="fjp.es"` already prevents tracking on other domains (dev, preview, etc.).