### PR TITLE
refactor(content): remove date-based publication gate

### DIFF
--- a/src/__tests__/utils/blog/collections.test.ts
+++ b/src/__tests__/utils/blog/collections.test.ts
@@ -5,7 +5,6 @@ import {
   sortByDate,
   filterByLanguage,
   groupByYear,
-  isPublished,
   type CollectionItem,
   type GroupedByYear,
 } from "@/utils/blog/collections";
@@ -225,35 +224,6 @@ describe("groupByYear", () => {
       expect(grouped[0].items[0]).toHaveProperty("slug");
       expect(grouped[0].items[0]).toHaveProperty("data");
     });
-  });
-});
-
-describe("isPublished", () => {
-  const PAST = new Date("2020-01-01");
-  const FUTURE = new Date("2099-01-01");
-  const TODAY = new Date();
-
-  // NOTE: The test environment (happy-dom via Vitest) sets import.meta.env.DEV = true,
-  // which mirrors the local dev server behaviour — future-dated content is always visible.
-  // Production behaviour (DEV = false) is verified by the logic in the source.
-
-  it("should return true for a past date", () => {
-    expect(isPublished(PAST)).toBe(true);
-  });
-
-  it("should return true for today's date", () => {
-    expect(isPublished(TODAY)).toBe(true);
-  });
-
-  it("should return true for a future date in DEV mode (test env = dev)", () => {
-    // In the test environment DEV is true, so all content is considered published
-    expect(isPublished(FUTURE)).toBe(true);
-  });
-
-  it("should accept a Date object as argument", () => {
-    expect(() => isPublished(PAST)).not.toThrow();
-    expect(() => isPublished(FUTURE)).not.toThrow();
-    expect(() => isPublished(TODAY)).not.toThrow();
   });
 });
 

--- a/src/__tests__/utils/content/getLatestPosts.test.ts
+++ b/src/__tests__/utils/content/getLatestPosts.test.ts
@@ -110,33 +110,6 @@ describe("getLatestPosts utility", () => {
     });
   });
 
-  describe("Publication Filtering", () => {
-    test("should import isPublished from utils", () => {
-      const content = fs.readFileSync(utilPath, "utf-8");
-
-      expect(content).toContain("isPublished");
-      expect(content).toContain("@utils/blog");
-    });
-
-    test("should filter posts by publication date", () => {
-      const content = fs.readFileSync(utilPath, "utf-8");
-
-      expect(content).toMatch(/filterByLanguage\(allPosts,\s*language\)\.filter\(.*isPublished/s);
-    });
-
-    test("should filter tutorials by publication date", () => {
-      const content = fs.readFileSync(utilPath, "utf-8");
-
-      expect(content).toMatch(/filterByLanguage\(allTutorials,\s*language\)\.filter\(.*isPublished/s);
-    });
-
-    test("should filter books by publication date", () => {
-      const content = fs.readFileSync(utilPath, "utf-8");
-
-      expect(content).toMatch(/filterByLanguage\(allBooks,\s*language\)\.filter\(.*isPublished/s);
-    });
-  });
-
   describe("Data Mapping", () => {
     test("should map posts with correct structure", () => {
       const content = fs.readFileSync(utilPath, "utf-8");

--- a/src/components/blog/BookLink.astro
+++ b/src/components/blog/BookLink.astro
@@ -17,8 +17,6 @@
 import { findBook, generateDisplayTitle, generateBookUrl, detectLanguageFromUrl } from "@utils/bookLinkHelpers";
 import { getCollection } from "astro:content";
 
-import { isPublished } from "@/utils/blog";
-
 interface Props {
   title: string;
   full?: boolean;
@@ -30,9 +28,8 @@ const detectedLang = detectLanguageFromUrl(Astro.url.pathname);
 
 const { title, full = false, lang = detectedLang } = Astro.props;
 
-// Query all books and find the matching one, excluding future-dated content
-const allBooksRaw = await getCollection("books");
-const allBooks = allBooksRaw.filter((book) => isPublished(book.data.date));
+// Query all books and find the matching one
+const allBooks = await getCollection("books");
 const book = findBook(allBooks, title, lang);
 
 // Generate display text and URL

--- a/src/components/blog/BookStatsContainer.astro
+++ b/src/components/blog/BookStatsContainer.astro
@@ -9,7 +9,6 @@ import { getCollection } from "astro:content";
 
 import type { LanguageKey } from "@/config/languages";
 import { getTranslations } from "@/locales";
-import { isPublished } from "@/utils/blog";
 import {
   getActiveChallenges,
   getAuthorsByGender,
@@ -40,9 +39,8 @@ const { lang } = Astro.props;
 // Get translations
 const t = getTranslations(lang);
 
-// Load all collections once and filter future-dated content
-const allBooksRaw = await getCollection("books");
-const allBooks = allBooksRaw.filter((book) => isPublished(book.data.date));
+// Load all collections once
+const allBooks = await getCollection("books");
 const allAuthors = await getCollection("authors");
 const allGenres = await getCollection("genres");
 const allPublishers = await getCollection("publishers");

--- a/src/components/blog/BooksReadInYear.astro
+++ b/src/components/blog/BooksReadInYear.astro
@@ -2,7 +2,6 @@
 import { getCollection, getEntry } from "astro:content";
 
 import { getDefaultLanguageCode, type LanguageKey } from "@/config/languages";
-import { isPublished } from "@/utils/blog";
 
 import BookLink from "./BookLink.astro";
 
@@ -13,10 +12,10 @@ interface Props {
 
 const { year, language = getDefaultLanguageCode() } = Astro.props;
 
-// Get all books from the specified year and language, excluding future-dated content
+// Get all books from the specified year and language
 const allBooks = await getCollection("books", ({ data }) => {
   const bookYear = new Date(data.date).getFullYear();
-  return bookYear === year && data.language === language && isPublished(new Date(data.date));
+  return bookYear === year && data.language === language;
 });
 
 // Sort by date (chronological order)

--- a/src/components/blog/ChallengeBookList.astro
+++ b/src/components/blog/ChallengeBookList.astro
@@ -1,8 +1,6 @@
 ---
 import { getCollection } from "astro:content";
 
-import { isPublished } from "@/utils/blog";
-
 import BookLink from "./BookLink.astro";
 
 interface Props {
@@ -11,9 +9,8 @@ interface Props {
 
 const { challenge } = Astro.props;
 
-// Get all books from the collection, excluding future-dated content
-const allBooksRaw = await getCollection("books");
-const allBooks = allBooksRaw.filter((book) => isPublished(book.data.date));
+// Get all books from the collection
+const allBooks = await getCollection("books");
 
 // Filter books by challenge and sort by date
 const booksInChallenge = allBooks

--- a/src/components/blog/GenreBreakdown.astro
+++ b/src/components/blog/GenreBreakdown.astro
@@ -10,7 +10,6 @@ import { getCollection } from "astro:content";
 import Icon from "@/components/Icon.astro";
 import type { LanguageKey } from "@/config/languages";
 import { getTranslations } from "@/locales";
-import { isPublished } from "@/utils/blog";
 import type { GenresWithCountByType } from "@/utils/blog/book-stats";
 import { buildGenreUrl, buildGenresIndexUrl } from "@/utils/routes";
 
@@ -31,9 +30,8 @@ const nonFictionTop5 = genresWithCount.nonFiction.slice(0, TOP_LIMIT);
 const fictionTotal = genresWithCount.fiction.length;
 const nonFictionTotal = genresWithCount.nonFiction.length;
 
-// Get all books to count unique books per type, excluding future-dated content
-const allBooksRaw = await getCollection("books");
-const allBooks = allBooksRaw.filter((book) => isPublished(book.data.date));
+// Get all books to count unique books per type
+const allBooks = await getCollection("books");
 const booksInLanguage = allBooks.filter((book) => book.data.language === lang);
 
 // Get unique fiction books (books that have at least one fiction genre)

--- a/src/components/blog/SkillBarChallenge.astro
+++ b/src/components/blog/SkillBarChallenge.astro
@@ -2,7 +2,6 @@
 import { getCollection } from "astro:content";
 
 import { getChallengeConfig } from "@/config/challenges";
-import { isPublished } from "@/utils/blog";
 
 import SkillBar from "./SkillBar.astro";
 
@@ -16,9 +15,8 @@ const { challenge } = Astro.props;
 const config = getChallengeConfig(challenge);
 const { goal, color, completedColor } = config;
 
-// Get all books from the collection, excluding future-dated content
-const allBooksRaw = await getCollection("books");
-const allBooks = allBooksRaw.filter((book) => isPublished(book.data.date));
+// Get all books from the collection
+const allBooks = await getCollection("books");
 
 // Filter books by challenge
 const booksInChallenge = allBooks.filter((book) => {

--- a/src/components/blog/SkillBarYear.astro
+++ b/src/components/blog/SkillBarYear.astro
@@ -2,8 +2,6 @@
 import { SKILL_COLORS } from "@constants/colors";
 import { getCollection } from "astro:content";
 
-import { isPublished } from "@/utils/blog";
-
 import SkillBar from "./SkillBar.astro";
 
 interface Props {
@@ -23,9 +21,8 @@ const challenges: Record<string, number> = {
   "2021": 6,
 };
 
-// Get all books from the collection, excluding future-dated content
-const allBooksRaw = await getCollection("books");
-const allBooks = allBooksRaw.filter((book) => isPublished(book.data.date));
+// Get all books from the collection
+const allBooks = await getCollection("books");
 
 // Filter books by year
 const booksInYear = allBooks.filter((book) => {

--- a/src/pages-templates/tutorials/TutorialsDetailPage.astro
+++ b/src/pages-templates/tutorials/TutorialsDetailPage.astro
@@ -22,7 +22,7 @@ import { getImage } from "astro:assets";
 import { getCollection, render, type CollectionEntry } from "astro:content";
 
 import type { ContactItem } from "@/types/content";
-import { findCategoriesBySlug, isPublished } from "@/utils/blog";
+import { findCategoriesBySlug } from "@/utils/blog";
 import { getCourseTutorialNavigation } from "@/utils/blog/tutorials";
 import { getCollectionByLanguage } from "@/utils/content/getCollectionByLanguage";
 
@@ -56,14 +56,9 @@ let previousTutorial = null;
 let nextTutorial = null;
 
 if (tutorial.course && tutorial.order !== undefined) {
-  // Get all tutorials from the same course, excluding future-dated content
+  // Get all tutorials from the same course
   const allTutorials = await getCollection("tutorials", (t) => {
-    return (
-      t.data.language === lang &&
-      t.data.course === tutorial.course &&
-      t.data.order !== undefined &&
-      isPublished(t.data.date)
-    );
+    return t.data.language === lang && t.data.course === tutorial.course && t.data.order !== undefined;
   });
 
   // Resolve prev/next by sorted position — supports decimal orders and non-consecutive gaps

--- a/src/pages/en/books/shelf.astro
+++ b/src/pages/en/books/shelf.astro
@@ -6,7 +6,6 @@ import Icon from "@/components/Icon.astro";
 import { shelf } from "@/content/shelf";
 import Layout from "@/layouts/Layout.astro";
 import { t } from "@/locales";
-import { isPublished } from "@/utils/blog";
 import { classifyBooksByReviewLanguage } from "@/utils/bookLinkHelpers";
 import { getContact } from "@/utils/content/contact";
 import { buildBookUrl, buildIndexUrl } from "@/utils/routes";
@@ -14,9 +13,8 @@ import { buildBookUrl, buildIndexUrl } from "@/utils/routes";
 const lang = "en";
 const contact = getContact(lang);
 
-// Get all books (all languages) for review detection, excluding future-dated content
-const allBooksRaw = await getCollection("books");
-const allBooks = allBooksRaw.filter((book) => isPublished(book.data.date));
+// Get all books (all languages) for review detection
+const allBooks = await getCollection("books");
 
 // Breadcrumbs
 const breadcrumbs = [

--- a/src/pages/es/libros/estanteria.astro
+++ b/src/pages/es/libros/estanteria.astro
@@ -6,7 +6,6 @@ import Icon from "@/components/Icon.astro";
 import { shelf } from "@/content/shelf";
 import Layout from "@/layouts/Layout.astro";
 import { t } from "@/locales";
-import { isPublished } from "@/utils/blog";
 import { classifyBooksByReviewLanguage } from "@/utils/bookLinkHelpers";
 import { getContact } from "@/utils/content/contact";
 import { buildBookUrl, buildIndexUrl } from "@/utils/routes";
@@ -14,9 +13,8 @@ import { buildBookUrl, buildIndexUrl } from "@/utils/routes";
 const lang = "es";
 const contact = getContact(lang);
 
-// Get all books (all languages) for review detection, excluding future-dated content
-const allBooksRaw = await getCollection("books");
-const allBooks = allBooksRaw.filter((book) => isPublished(book.data.date));
+// Get all books (all languages) for review detection
+const allBooks = await getCollection("books");
 
 // Breadcrumbs
 const breadcrumbs = [

--- a/src/utils/blog/collections.ts
+++ b/src/utils/blog/collections.ts
@@ -4,26 +4,6 @@
 
 import type { LanguageKey } from "@/types";
 
-/**
- * Determines whether a piece of content should be publicly visible.
- *
- * Content is published when its date is in the past or today (i.e. the build
- * date is on or after the content date).  In development mode every entry is
- * considered published so future-dated content can be previewed locally.
- *
- * @param date - The publication date from the content frontmatter
- * @returns `true` if the content should appear in production listings
- *
- * @example
- * isPublished(new Date("2020-01-01")) // true  – past date
- * isPublished(new Date("2099-01-01")) // false – future date (prod)
- * isPublished(new Date("2099-01-01")) // true  – future date (dev)
- */
-export function isPublished(date: Date): boolean {
-  if (import.meta.env.DEV) return true;
-  return date <= new Date();
-}
-
 export interface CollectionItem {
   id?: string; // Astro 5 uses id
   slug?: string; // Legacy property for compatibility

--- a/src/utils/blog/index.ts
+++ b/src/utils/blog/index.ts
@@ -10,14 +10,7 @@ export { slugify } from "./slugify";
 export { getPageCount, paginateItems, getPaginationInfo, type PaginationInfo } from "./pagination";
 
 // Collection utilities
-export {
-  sortByDate,
-  filterByLanguage,
-  groupByYear,
-  isPublished,
-  type CollectionItem,
-  type GroupedByYear,
-} from "./collections";
+export { sortByDate, filterByLanguage, groupByYear, type CollectionItem, type GroupedByYear } from "./collections";
 
 // Book utilities
 export {

--- a/src/utils/booksPages.ts
+++ b/src/utils/booksPages.ts
@@ -3,19 +3,12 @@
  * Used by both /es/libros/ and /en/books/
  */
 
-import { getCollection, type CollectionEntry } from "astro:content";
+import { getCollection } from "astro:content";
 
 import { PAGINATION_CONFIG } from "@/config/pagination";
 import type { LanguageKey } from "@/types";
 import type { ContactItem } from "@/types/content";
-import {
-  filterByLanguage,
-  findAuthorBySlug,
-  isPublished,
-  prepareBookSummary,
-  sortByDate,
-  type BookSummary,
-} from "@/utils/blog";
+import { filterByLanguage, findAuthorBySlug, prepareBookSummary, sortByDate, type BookSummary } from "@/utils/blog";
 import { generateDetailPaths, generatePaginationPaths } from "@/utils/pagination/generator";
 
 export const BOOKS_PER_PAGE = PAGINATION_CONFIG.books;
@@ -29,8 +22,8 @@ export async function getAllBooksForLanguage(lang: string): Promise<BookSummary[
   const allAuthors = await getCollection("authors");
   const allSeries = await getCollection("series");
 
-  // Filter by language and exclude future-dated content
-  const langBooks = filterByLanguage(allBooks, lang as LanguageKey).filter((book) => isPublished(book.data.date));
+  // Filter by language
+  const langBooks = filterByLanguage(allBooks, lang as LanguageKey);
 
   // Sort by date (newest first)
   const sortedBooks = sortByDate(langBooks, "desc");
@@ -60,17 +53,12 @@ export async function generateBooksPaginationPaths(lang: string, contact: Contac
 
 /**
  * Generate static paths for book detail pages
- * Only generates paths for published (non-future-dated) books
  */
 export async function generateBookDetailPaths(lang: string, contact: ContactItem[]) {
   const books = await getCollection("books");
-  const publishedBooks = books.filter((book: CollectionEntry<"books">) =>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Astro 5 data type inference limitation
-    isPublished((book.data as any).date),
-  );
 
   return generateDetailPaths({
-    entries: publishedBooks,
+    entries: books,
     lang,
     contact,
     entryKey: "bookEntry",

--- a/src/utils/content/getLatestPosts.ts
+++ b/src/utils/content/getLatestPosts.ts
@@ -2,7 +2,7 @@
  * Get Latest Posts Utility
  *
  * Queries all content collections (posts, tutorials, books), filters by language,
- * excludes drafts, and returns the N most recent items sorted by date.
+ * and returns the N most recent items sorted by date.
  *
  * This utility was extracted from the LatestPosts component to make the logic
  * reusable across different parts of the application.
@@ -10,7 +10,7 @@
  * @module utils/content/getLatestPosts
  */
 
-import { filterByLanguage, isPublished } from "@utils/blog";
+import { filterByLanguage } from "@utils/blog";
 import type { PostSummary } from "@utils/blog";
 import { getCollection } from "astro:content";
 
@@ -43,11 +43,11 @@ export async function getLatestPosts(language: LanguageKey, maxItems: number = 4
   const allTutorials = await getCollection("tutorials");
   const allBooks = await getCollection("books");
 
-  // Filter by language and exclude future-dated content
-  const langPosts = filterByLanguage(allPosts, language).filter((post) => isPublished(post.data.date));
-  const langTutorials = filterByLanguage(allTutorials, language).filter((tutorial) => isPublished(tutorial.data.date));
+  // Filter by language
+  const langPosts = filterByLanguage(allPosts, language);
+  const langTutorials = filterByLanguage(allTutorials, language);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Dynamic content collection access requires any
-  const langBooks = filterByLanguage(allBooks, language).filter((book) => isPublished(book.data.date)) as any;
+  const langBooks = filterByLanguage(allBooks, language) as any;
 
   // Prepare combined content with unified structure
 

--- a/src/utils/postsPages.ts
+++ b/src/utils/postsPages.ts
@@ -3,7 +3,7 @@
  * Used by both /es/publicaciones/ and /en/posts/
  */
 
-import { getCollection, type CollectionEntry } from "astro:content";
+import { getCollection } from "astro:content";
 
 import { getAlternateLang } from "@/config/languages";
 import { PAGINATION_CONFIG } from "@/config/pagination";
@@ -11,7 +11,6 @@ import type { ContactItem, LanguageKey } from "@/types";
 import {
   filterByLanguage,
   getPageCount,
-  isPublished,
   paginateItems,
   prepareBookSummary,
   preparePostSummary,
@@ -33,10 +32,10 @@ export async function getAllContentForLanguage(lang: LanguageKey): Promise<Conte
   const allCourses = await getCollection("courses");
   const allSeries = await getCollection("series");
 
-  // Filter by language and exclude future-dated content
-  const langPosts = filterByLanguage(allPosts, lang).filter((post) => isPublished(post.data.date));
-  const langTutorials = filterByLanguage(allTutorials, lang).filter((tutorial) => isPublished(tutorial.data.date));
-  const langBooks = filterByLanguage(allBooks, lang).filter((book) => isPublished(book.data.date));
+  // Filter by language
+  const langPosts = filterByLanguage(allPosts, lang);
+  const langTutorials = filterByLanguage(allTutorials, lang);
+  const langBooks = filterByLanguage(allBooks, lang);
 
   // Prepare summaries with course/series context
   const postSummaries = langPosts.map((post) => preparePostSummary(post));
@@ -95,14 +94,12 @@ export async function generatePostsPaginationPaths(lang: LanguageKey, contact: C
 
 /**
  * Generate static paths for post detail pages
- * Only generates paths for published (non-future-dated) posts
  */
 export async function generatePostDetailPaths(lang: string, contact: ContactItem[]) {
   const posts = await getCollection("posts");
-  const publishedPosts = posts.filter((post: CollectionEntry<"posts">) => isPublished(post.data.date));
 
   return generateDetailPaths({
-    entries: publishedPosts,
+    entries: posts,
     lang,
     contact,
     entryKey: "postEntry",

--- a/src/utils/rss/generator.ts
+++ b/src/utils/rss/generator.ts
@@ -7,7 +7,6 @@ import type { CollectionEntry } from "astro:content";
 
 import { getDefaultLanguageCode, getUrlSegment } from "@/config/languages";
 import type { LanguageKey } from "@/types";
-import { isPublished } from "@/utils/blog";
 
 /**
  * Configuration for RSS feed metadata
@@ -47,15 +46,6 @@ export interface RSSFeedOutput {
 type ContentItem = CollectionEntry<"books"> | CollectionEntry<"posts"> | CollectionEntry<"tutorials">;
 
 /**
- * Filters out future-dated content
- * @param items - Collection items
- * @returns Items whose publication date is today or in the past
- */
-function excludeUnpublished(items: ContentItem[]): ContentItem[] {
-  return items.filter((item) => isPublished(item.data.date));
-}
-
-/**
  * Builds the correct URL for a content item based on its collection type and language
  *
  * @param item - Content item from Astro collections
@@ -93,8 +83,8 @@ export function generateSingleCollectionFeed(items: ContentItem[], config: RSSFe
     throw new Error("Language is required for single collection feed");
   }
 
-  // Filter items by language, exclude future-dated content, and sort by date (newest first)
-  const filteredItems = excludeUnpublished(items)
+  // Filter items by language and sort by date (newest first)
+  const filteredItems = items
     .filter((item) => item.data.language === language)
     .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 
@@ -127,8 +117,9 @@ export function generateMultiCollectionFeed(collections: ContentItem[][], config
     throw new Error("Language is required for multi-collection feed");
   }
 
-  // Combine all collections, exclude future-dated content, filter by language, and sort by date
-  const allContent = excludeUnpublished(collections.flat())
+  // Combine all collections, filter by language, and sort by date
+  const allContent = collections
+    .flat()
     .filter((item) => item.data.language === language)
     .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 
@@ -161,10 +152,10 @@ export function generateBilingualFeed(
 ): RSSFeedOutput {
   const { title, description, site } = config;
 
-  // Combine all collections, exclude future-dated content, and sort by date (no language filter)
-  const allContent = excludeUnpublished(collections.flat()).sort(
-    (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
-  );
+  // Combine all collections and sort by date (no language filter)
+  const allContent = collections
+    .flat()
+    .sort((a: ContentItem, b: ContentItem) => b.data.date.valueOf() - a.data.date.valueOf());
 
   return {
     title,

--- a/src/utils/taxonomyPages.ts
+++ b/src/utils/taxonomyPages.ts
@@ -4,13 +4,7 @@ import { getCollection } from "astro:content";
 import { getAlternateLang } from "@/config/languages";
 import { PAGINATION_CONFIG } from "@/config/pagination";
 import type { ContactItem, LanguageKey } from "@/types";
-import {
-  filterByLanguage,
-  isPublished,
-  prepareBookSummary,
-  preparePostSummary,
-  prepareTutorialSummary,
-} from "@/utils/blog";
+import { filterByLanguage, prepareBookSummary, preparePostSummary, prepareTutorialSummary } from "@/utils/blog";
 import type { BookSummary, PostSummary } from "@/utils/blog";
 import { extractContentDate } from "@/utils/content-date";
 
@@ -89,15 +83,15 @@ export async function getAllTaxonomyItems(config: TaxonomyConfig, lang: Language
 }
 
 /**
- * Get all content that uses a specific taxonomy, excluding future-dated content
+ * Get all content that uses a specific taxonomy
  */
 export async function getAllContentForTaxonomy(config: TaxonomyConfig, lang: LanguageKey) {
   const allContent: Array<CollectionEntry<"posts"> | CollectionEntry<"tutorials"> | CollectionEntry<"books">> = [];
 
   for (const collectionName of config.contentCollections) {
     const collection = await getCollection(collectionName);
-    // Filter by language and exclude future-dated content
-    const filtered = filterByLanguage(collection, lang).filter((item) => isPublished(item.data.date));
+    // Filter by language
+    const filtered = filterByLanguage(collection, lang);
     allContent.push(...filtered);
   }
 

--- a/src/utils/tutorialsPages.ts
+++ b/src/utils/tutorialsPages.ts
@@ -3,11 +3,11 @@
  * Used by both /es/tutoriales/ and /en/tutorials/
  */
 
-import { getCollection, type CollectionEntry } from "astro:content";
+import { getCollection } from "astro:content";
 
 import { PAGINATION_CONFIG } from "@/config/pagination";
 import type { ContactItem } from "@/types/content";
-import { filterByLanguage, isPublished, prepareTutorialSummary, sortByDate, type TutorialSummary } from "@/utils/blog";
+import { filterByLanguage, prepareTutorialSummary, sortByDate, type TutorialSummary } from "@/utils/blog";
 import { generateDetailPaths, generatePaginationPaths } from "@/utils/pagination/generator";
 
 export const TUTORIALS_PER_PAGE = PAGINATION_CONFIG.tutorials;
@@ -24,11 +24,9 @@ export async function getAllTutorialsForLanguage(lang: string): Promise<Tutorial
   // @ts-expect-error - Astro 5 CollectionEntry type compatibility
   const langCourses = filterByLanguage(allCourses, lang);
 
-  // Filter by language and exclude future-dated content
+  // Filter by language
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Astro content collection type inference limitation
-  const langTutorials = filterByLanguage(allTutorials, lang as any).filter((tutorial) =>
-    isPublished(tutorial.data.date),
-  );
+  const langTutorials = filterByLanguage(allTutorials, lang as any);
 
   // Sort by date (newest first)
   const sortedTutorials = sortByDate(langTutorials, "desc");
@@ -54,16 +52,12 @@ export async function generateTutorialsPaginationPaths(lang: string, contact: Co
 
 /**
  * Generate static paths for tutorial detail pages
- * Only generates paths for published (non-future-dated) tutorials
  */
 export async function generateTutorialDetailPaths(lang: string, contact: ContactItem[]) {
   const tutorials = await getCollection("tutorials");
-  const publishedTutorials = tutorials.filter((tutorial: CollectionEntry<"tutorials">) =>
-    isPublished(tutorial.data.date),
-  );
 
   return generateDetailPaths({
-    entries: publishedTutorials,
+    entries: tutorials,
     lang,
     contact,
     entryKey: "tutorialEntry",


### PR DESCRIPTION
## Summary

- Removes `isPublished()` and `excludeUnpublished()` entirely from the codebase
- Drops all `.filter(isPublished(...))` calls across utils, components, and pages
- Cleans up associated tests and orphaned imports (`CollectionEntry`, etc.)

## Why

Publication control is now the merge itself. Whatever lands on `master` is live; content in a PR is not. The date-based gate added timezone complexity (Cloudflare builds in UTC, author is UTC+1/UTC+2) with no real benefit given that merges are always manual.

## Impact

- 1702 tests passing (9 removed — all were testing `isPublished` behaviour)
- TypeScript strict: no errors
- No behaviour change for already-published content