### PR TITLE
feat(tutorials): add working-with-git-remotes tutorial (ES + EN)

### DIFF
--- a/src/content/tutorials/trabajando-con-remotos-git.mdx
+++ b/src/content/tutorials/trabajando-con-remotos-git.mdx
@@ -1,0 +1,230 @@
+---
+title: "Trabajando con remotos en Git"
+post_slug: "trabajando-con-remotos-git"
+date: "2026-03-10"
+excerpt: "Aprende a gestionar remotos en Git: añadir, eliminar, renombrar y explorar remotos con git remote. Entiende qué son las tracking branches y cómo trabajar con múltiples remotos."
+language: "es"
+categories: ["git"]
+course: "domina-git-desde-cero"
+order: 15
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "working-with-git-remotes"
+---
+
+Llevas ya unos cuantos tutoriales haciendo `git push origin master` como si tal cosa. Funciona, el código llega a GitHub, y todos contentos. Pero si alguien te preguntara ahora mismo qué es exactamente `origin`, ¿sabrías responder sin titubear? ¿O tienes esa sensación de que lo usas "por fe"?
+
+No te preocupes, es lo más normal del mundo. La mayoría de la gente lleva años usando Git sin entender del todo qué hay detrás de ese `origin`. Vamos a cambiar eso hoy.
+
+## ¿Qué sabe Git de tus remotos?
+
+Un remoto en Git es simplemente un **alias para una URL**. Nada más. `origin` no es una entidad mística ni un servidor especial: es un nombre que apunta a una dirección, igual que un contacto en tu teléfono tiene un nombre que apunta a un número.
+
+Para ver qué remotos tienes configurados:
+
+```bash
+git remote -v
+```
+
+```
+origin  git@github.com:tuusuario/mi-proyecto.git (fetch)
+origin  git@github.com:tuusuario/mi-proyecto.git (push)
+```
+
+Cada remoto aparece dos veces: una para `fetch` (recibir) y otra para `push` (enviar). En casi todos los casos apuntan a la misma URL, pero Git los trata de forma independiente. Esto te permite, en teoría, hacer `fetch` de un sitio y `push` a otro —útil en setups raros que probablemente nunca necesitarás, pero que es bueno saber que existen.
+
+`origin` es el nombre por defecto que Git asigna cuando haces `git clone`. No tiene nada de especial. Podrías llamarlo `github`, `remoto-principal`, o `patata` y funcionaría exactamente igual.
+
+Si solo quieres ver los nombres sin las URLs:
+
+```bash
+git remote
+```
+
+```
+origin
+```
+
+## Añadir y eliminar remotos
+
+### Añadir un remoto
+
+```bash
+git remote add <nombre> <url>
+```
+
+Por ejemplo, si quieres añadir un segundo remoto llamado `backup`:
+
+```bash
+git remote add backup git@github.com:tuusuario/mi-proyecto-backup.git
+```
+
+Ahora tienes dos:
+
+```bash
+git remote -v
+```
+
+```
+backup  git@github.com:tuusuario/mi-proyecto-backup.git (fetch)
+backup  git@github.com:tuusuario/mi-proyecto-backup.git (push)
+origin  git@github.com:tuusuario/mi-proyecto.git (fetch)
+origin  git@github.com:tuusuario/mi-proyecto.git (push)
+```
+
+### Eliminar un remoto
+
+```bash
+git remote remove backup
+```
+
+O su alias equivalente (porque en Git siempre hay dos formas de hacer lo mismo):
+
+```bash
+git remote rm backup
+```
+
+Esto elimina solo la configuración local —el repositorio remoto en el servidor sigue existiendo, tranquilo.
+
+### Renombrar un remoto
+
+```bash
+git remote rename origin github
+```
+
+A partir de ahí tendrías que usar `git push github master`. Útil cuando tienes varios remotos y quieres nombres más descriptivos que `origin`, `origin2` y `origin-ese-que-no-sé-para-qué-sirve`.
+
+### Cambiar la URL de un remoto
+
+Si en su día clonaste con HTTPS y ahora quieres pasar a SSH (para no teclear tu contraseña cada dos por tres), no hace falta borrar y volver a añadir el remoto:
+
+```bash
+git remote set-url origin git@github.com:tuusuario/mi-proyecto.git
+```
+
+Verifica que el cambio se aplicó:
+
+```bash
+git remote -v
+```
+
+```
+origin  git@github.com:tuusuario/mi-proyecto.git (fetch)
+origin  git@github.com:tuusuario/mi-proyecto.git (push)
+```
+
+## Inspeccionando un remoto en detalle
+
+`git remote -v` te da las URLs, pero si quieres una radiografía completa de lo que está pasando con un remoto:
+
+```bash
+git remote show origin
+```
+
+```
+* remote origin
+  Fetch URL: git@github.com:tuusuario/mi-proyecto.git
+  Push  URL: git@github.com:tuusuario/mi-proyecto.git
+  HEAD branch: master
+  Remote branches:
+    develop tracked
+    master  tracked
+  Local branch configured for 'git pull':
+    master merges with remote master
+  Local refs configured for 'git push':
+    master pushes to master (up to date)
+    develop pushes to develop (local out of date)
+```
+
+Eso último —`local out of date`— es la parte importante: antes de ponerte a trabajar en `develop`, ya sabes que alguien ha pusheado cambios que tú no tienes. Sin este comando, lo descubrirías después de intentar hacer `push` y recibir un error críptico.
+
+## Múltiples remotos: origin y upstream
+
+El caso más habitual de tener más de un remoto es cuando trabajas con **forks**. Imagina que quieres contribuir a un proyecto open source —digamos, el propio Git, o cualquier librería que uses a diario:
+
+1. Haces un fork del repositorio en GitHub (ahora tienes tu copia en `tuusuario/proyecto`)
+2. Clonas tu fork: `git clone git@github.com:tuusuario/proyecto.git`
+3. Git configura `origin` apuntando a **tu fork**
+
+El problema: el proyecto original sigue avanzando sin ti, y necesitas traerte esos cambios periódicamente. Para eso añades el repositorio original como un segundo remoto. La convención universal (y que todo el mundo sigue para que nadie se vuelva loco) es llamarlo `upstream`:
+
+```bash
+git remote add upstream git@github.com:autor-original/proyecto.git
+```
+
+Resultado:
+
+```bash
+git remote -v
+```
+
+```
+origin    git@github.com:tuusuario/proyecto.git (fetch)
+origin    git@github.com:tuusuario/proyecto.git (push)
+upstream  git@github.com:autor-original/proyecto.git (fetch)
+upstream  git@github.com:autor-original/proyecto.git (push)
+```
+
+El flujo de trabajo habitual:
+
+```bash
+# Traerse los últimos cambios del proyecto original
+git fetch upstream
+
+# Integrarlos en tu rama principal
+git merge upstream/master
+```
+
+Tu `origin` sigue siendo tu fork. `upstream` es solo para leer: en la práctica no tendrás permisos de push allí, y aunque los tuvieras, no deberías pushear directamente al repositorio original (eso es para lo que están los pull requests).
+
+## Tracking branches: la conexión entre local y remoto
+
+Cuando clonas un repositorio o haces `git push -u origin master`, Git crea algo llamado **tracking branch**: una referencia que conecta tu rama local con su equivalente en el remoto. Es lo que permite que Git sepa adónde mandar los cambios cuando haces un `git push` sin más argumentos.
+
+Para ver qué tracking branches tienes configuradas:
+
+```bash
+git branch -vv
+```
+
+```
+* master  a3f8c21 [origin/master] Añade validación de formulario
+  develop e1b9d44 [origin/develop: ahead 2] Integra módulo de pagos
+```
+
+Entre corchetes aparece la rama remota rastreada. `ahead 2` significa que tienes 2 commits locales que todavía no están en el remoto. Muy útil antes de hacer un `git push` para saber exactamente qué vas a enviar.
+
+Cuando creas una rama nueva y la subes por primera vez, estableces el tracking con `-u` (de `--set-upstream`):
+
+```bash
+git push -u origin nueva-feature
+```
+
+A partir de ahí, `git push` y `git pull` desde esa rama funcionan sin argumentos adicionales. Si olvidas el `-u`, Git te recordará cortésmente que no sabe adónde pushear con un mensaje de error que muchos desarrolladores copian en Google sin leerlo.
+
+## Casos prácticos
+
+### Limpiar referencias a ramas remotas eliminadas
+
+Con el tiempo, tus compañeros eliminan ramas en el remoto después de un merge, pero esas referencias siguen apareciendo en tu local como fantasmas del pasado. Para limpiarlas:
+
+```bash
+git fetch --prune
+```
+
+O configúralo de forma global para que ocurra automáticamente cada vez que hagas `fetch`:
+
+```bash
+git config --global fetch.prune true
+```
+
+Recomiendo activar esta opción. Tener referencias a ramas que ya no existen solo genera confusión, especialmente en proyectos con mucha actividad.
+
+---
+
+Con esto ya entiendes qué hay detrás de ese `origin` que llevabas tiempo usando sin cuestionarte. Los remotos son alias, no magia. Puedes añadir los que necesites, inspeccionarlos, cambiar sus URLs, y entender exactamente qué tracking branches los conectan con tu trabajo local.
+
+En el próximo tutorial veremos cómo sincronizar tu repositorio con esos remotos: `git clone` para empezar desde cero con un repositorio existente, y `git pull` para mantener tu copia local al día.
+
+**💡 Challenge**: Añade un segundo remoto a un repositorio existente (puede apuntar a la misma URL que `origin`, con un nombre diferente). Ejecuta `git remote show` en ambos y compara la salida. Después elimínalo. Bonus: activa `fetch.prune` globalmente si aún no lo tienes.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/working-with-git-remotes.mdx
+++ b/src/content/tutorials/working-with-git-remotes.mdx
@@ -1,0 +1,230 @@
+---
+title: "Working with Git Remotes"
+post_slug: "working-with-git-remotes"
+date: "2026-03-10"
+excerpt: "Learn to manage Git remotes: add, remove, rename, and inspect them with git remote. Understand tracking branches and how to work with multiple remotes."
+language: "en"
+categories: ["git"]
+course: "mastering-git-from-scratch"
+order: 15
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "trabajando-con-remotos-git"
+---
+
+You've been typing `git push origin master` for a while now. It works, the code lands on GitHub, everyone's happy. But if someone asked you right now what exactly `origin` is, could you answer without hesitating? Or do you use it "on faith" — the kind of faith where you pray the command works and don't ask too many questions?
+
+Don't worry. Most people use Git for years without fully understanding what's behind that `origin`. Let's fix that today.
+
+## What does Git know about your remotes?
+
+A remote in Git is simply an **alias for a URL**. That's it. `origin` is not a mystical entity or a special server: it's a name pointing to an address, just like a contact in your phone has a name pointing to a number.
+
+To see which remotes you have configured:
+
+```bash
+git remote -v
+```
+
+```
+origin  git@github.com:youruser/my-project.git (fetch)
+origin  git@github.com:youruser/my-project.git (push)
+```
+
+Each remote appears twice: once for `fetch` (receiving) and once for `push` (sending). In almost every case they point to the same URL, but Git treats them independently. This lets you, in theory, fetch from one place and push to another — useful in weird setups you'll probably never need, but good to know exist.
+
+`origin` is the default name Git assigns when you run `git clone`. There's nothing special about it. You could call it `github`, `main-remote`, or `potato` and it would work exactly the same.
+
+If you only want the names without the URLs:
+
+```bash
+git remote
+```
+
+```
+origin
+```
+
+## Adding and removing remotes
+
+### Adding a remote
+
+```bash
+git remote add <name> <url>
+```
+
+For example, to add a second remote called `backup`:
+
+```bash
+git remote add backup git@github.com:youruser/my-project-backup.git
+```
+
+Now you have two:
+
+```bash
+git remote -v
+```
+
+```
+backup  git@github.com:youruser/my-project-backup.git (fetch)
+backup  git@github.com:youruser/my-project-backup.git (push)
+origin  git@github.com:youruser/my-project.git (fetch)
+origin  git@github.com:youruser/my-project.git (push)
+```
+
+### Removing a remote
+
+```bash
+git remote remove backup
+```
+
+Or its equivalent alias (because in Git there's always two ways to do the same thing):
+
+```bash
+git remote rm backup
+```
+
+This removes only the local configuration — the remote repository on the server keeps existing, don't worry.
+
+### Renaming a remote
+
+```bash
+git remote rename origin github
+```
+
+From that point you'd use `git push github master` instead. Useful when you have multiple remotes and want more descriptive names than `origin`, `origin2`, and `origin-that-one-I-dont-know-what-it-does`.
+
+### Changing a remote's URL
+
+If you originally cloned with HTTPS and now want to switch to SSH (so you stop typing your password every five minutes), you don't need to delete and re-add the remote:
+
+```bash
+git remote set-url origin git@github.com:youruser/my-project.git
+```
+
+Verify the change was applied:
+
+```bash
+git remote -v
+```
+
+```
+origin  git@github.com:youruser/my-project.git (fetch)
+origin  git@github.com:youruser/my-project.git (push)
+```
+
+## Inspecting a remote in detail
+
+`git remote -v` gives you the URLs, but if you want a full picture of what's happening with a remote:
+
+```bash
+git remote show origin
+```
+
+```
+* remote origin
+  Fetch URL: git@github.com:youruser/my-project.git
+  Push  URL: git@github.com:youruser/my-project.git
+  HEAD branch: master
+  Remote branches:
+    develop tracked
+    master  tracked
+  Local branch configured for 'git pull':
+    master merges with remote master
+  Local refs configured for 'git push':
+    master pushes to master (up to date)
+    develop pushes to develop (local out of date)
+```
+
+That last part — `local out of date` — is the important bit: before you start working on `develop`, you already know someone pushed changes you don't have. Without this command, you'd find out after trying to push and getting a cryptic error.
+
+## Multiple remotes: origin and upstream
+
+The most common reason to have more than one remote is when you work with **forks**. Say you want to contribute to an open source project — the Git project itself, or any library you use daily:
+
+1. You fork the repository on GitHub (now you have your own copy at `youruser/project`)
+2. You clone your fork: `git clone git@github.com:youruser/project.git`
+3. Git configures `origin` pointing to **your fork**
+
+The problem: the original project keeps moving forward without you, and you need to bring those changes in periodically. For that you add the original repository as a second remote. The universal convention (that everyone follows so nobody goes crazy) is to call it `upstream`:
+
+```bash
+git remote add upstream git@github.com:original-author/project.git
+```
+
+Result:
+
+```bash
+git remote -v
+```
+
+```
+origin    git@github.com:youruser/project.git (fetch)
+origin    git@github.com:youruser/project.git (push)
+upstream  git@github.com:original-author/project.git (fetch)
+upstream  git@github.com:original-author/project.git (push)
+```
+
+The typical workflow:
+
+```bash
+# Bring in the latest changes from the original project
+git fetch upstream
+
+# Integrate them into your main branch
+git merge upstream/master
+```
+
+Your `origin` stays as your fork. `upstream` is read-only in practice — you won't have push permissions there, and even if you did, you shouldn't push directly to the original repository (that's what pull requests are for).
+
+## Tracking branches: the link between local and remote
+
+When you clone a repository or run `git push -u origin master`, Git creates something called a **tracking branch**: a reference that connects your local branch to its counterpart on the remote. This is what lets Git know where to send changes when you run `git push` with no extra arguments.
+
+To see which tracking branches you have configured:
+
+```bash
+git branch -vv
+```
+
+```
+* master  a3f8c21 [origin/master] Add form validation
+  develop e1b9d44 [origin/develop: ahead 2] Integrate payments module
+```
+
+In brackets you see the remote branch being tracked. `ahead 2` means you have 2 local commits that aren't on the remote yet. Very useful before a `git push` to know exactly what you're about to send.
+
+When you create a new branch and push it for the first time, you set up the tracking with `-u` (short for `--set-upstream`):
+
+```bash
+git push -u origin new-feature
+```
+
+From that point on, `git push` and `git pull` from that branch work without extra arguments. If you forget the `-u`, Git will politely remind you it doesn't know where to push — with an error message that a lot of developers copy into Google without reading it.
+
+## Practical cases
+
+### Cleaning up references to deleted remote branches
+
+Over time, teammates delete branches on the remote after a merge, but those references keep showing up in your local as ghosts of branches past. To clean them up:
+
+```bash
+git fetch --prune
+```
+
+Or configure it globally so it happens automatically on every fetch:
+
+```bash
+git config --global fetch.prune true
+```
+
+I recommend enabling this. Having references to branches that no longer exist only creates confusion, especially in high-activity projects.
+
+---
+
+Now you understand what's behind that `origin` you'd been using without questioning. Remotes are aliases, not magic. You can add as many as you need, inspect them, change their URLs, and know exactly which tracking branches connect them to your local work.
+
+In the next tutorial we'll look at how to synchronize your repository with those remotes: `git clone` to start from scratch with an existing repository, and `git pull` to keep your local copy up to date.
+
+**💡 Challenge**: Add a second remote to an existing repository (it can point to the same URL as `origin`, just with a different name). Run `git remote show` on both and compare the output. Then remove it. Bonus: enable `fetch.prune` globally if you haven't already.
+
+Never stop coding!

--- a/src/styles/components/tutorial.scss
+++ b/src/styles/components/tutorial.scss
@@ -15,6 +15,7 @@
       @include text-area-images;
       @include text-area-headers;
       @include text-area-tables;
+      @include blockquote-style;
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds lesson 15 of the Git course: working with remotes (ES + EN pair)
- Covers `git remote` add/remove/rename/set-url, `git remote show`, multiple remotes (origin/upstream), tracking branches, and `fetch --prune`
- Minor SCSS fix: adds `blockquote-style` mixin to tutorial component