### PR TITLE
feat(tutorials): add pushing-and-fetching-git tutorial (ES + EN)

### DIFF
--- a/src/content/tutorials/push-fetch-git.mdx
+++ b/src/content/tutorials/push-fetch-git.mdx
@@ -1,0 +1,179 @@
+---
+title: "Push y fetch en Git: sincronizando con el remoto"
+post_slug: "push-fetch-git"
+date: "2026-03-12"
+excerpt: "Aprende a enviar y recibir cambios en Git con git push y git fetch. Entiende la diferencia entre fetch y pull, cómo usar --force-with-lease, y por qué git push --force es mala idea."
+language: "es"
+categories: ["git"]
+course: "domina-git-desde-cero"
+order: 17
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "pushing-and-fetching-git"
+---
+
+Ya sabes que los remotos son alias para URLs, y que `origin` no tiene nada de especial. Pero tener el remoto configurado no es suficiente: la gracia está en sincronizar tu trabajo con él. ¿Cuándo se usa `git push`? ¿Cuándo `git fetch`? ¿Y qué diferencia hay exactamente entre `git fetch` y `git pull`? Hay gente que lleva años usando Git sin tener esto del todo claro (sin juicios, yo incluido al principio).
+
+Vamos a resolverlo hoy, y de paso veremos por qué `git push --force` es una de las formas más eficientes de ganarte la enemistad de tus compañeros de equipo.
+
+## Enviando cambios al remoto: git push
+
+`git push` envía tus commits locales a un repositorio remoto. La forma básica:
+
+```bash
+git push origin master
+```
+
+Esto envía la rama `master` local al remoto `origin`. Si el remoto no tiene esa rama todavía, la crea. Si ya existe y tus commits son continuación directa de los suyos (es decir, no hay divergencia), el push funciona sin problema.
+
+### Establecer el upstream con -u
+
+La primera vez que subes una rama nueva, añade `-u` para establecer el tracking:
+
+```bash
+git push -u origin nueva-feature
+```
+
+Después de eso, desde esa rama puedes simplemente escribir:
+
+```bash
+git push
+```
+
+Y Git ya sabe adónde ir. Sin el `-u`, Git te pedirá que especifiques remoto y rama cada vez, con un mensaje de error que mucha gente copia en Google sin leerlo entero.
+
+### ¿Qué pasa si el push es rechazado?
+
+Si alguien más ha pusheado cambios a la misma rama mientras tú trabajabas, verás algo así:
+
+```
+ ! [rejected]        master -> master (fetch first)
+error: failed to push some refs to 'git@github.com:tuusuario/mi-proyecto.git'
+hint: Updates were rejected because the remote contains work that you do
+hint: not have locally. Integrate the remote changes (e.g.
+hint: 'git pull ...') before pushing again.
+```
+
+Git se niega a sobrescribir trabajo ajeno. La solución: traerte los cambios del remoto primero, integrarlos, y entonces hacer push. Lo veremos en detalle en la siguiente sección.
+
+## Recibiendo cambios: fetch vs pull
+
+Aquí es donde la confusión surge con más frecuencia. Hay dos formas de traer cambios del remoto:
+
+- `git fetch`: descarga los cambios pero **no los aplica**
+- `git pull`: descarga los cambios **y los aplica** (es `fetch` + `merge` en uno)
+
+### git fetch
+
+```bash
+git fetch origin
+```
+
+Esto actualiza tus referencias remotas locales (`origin/master`, `origin/develop`, etc.) con lo que hay en el servidor, pero **no toca tu rama de trabajo**. Es como mirar el correo sin abrirlo.
+
+Después de un fetch, puedes ver qué ha cambiado:
+
+```bash
+git log master..origin/master --oneline
+```
+
+```
+a7f3c21 Fix authentication bug
+b2e9d14 Add user profile endpoint
+```
+
+Eso te muestra los commits que están en `origin/master` pero todavía no en tu `master` local. Puedes inspeccionarlos con calma antes de decidir integrarlos.
+
+Para integrarlos cuando estés listo:
+
+```bash
+git merge origin/master
+```
+
+### git pull
+
+```bash
+git pull origin master
+```
+
+Equivale a hacer `git fetch origin` seguido de `git merge origin/master`. Es más rápido de escribir, pero te quita el paso de inspección intermedio.
+
+En proyectos propios o cuando tienes confianza en lo que hay en el remoto, `git pull` es perfecto. En proyectos de equipo con mucha actividad, hacer un `fetch` primero te da más control sobre qué estás integrando y cuándo.
+
+```
+fetch + merge manual     git pull
+─────────────────        ─────────
+git fetch origin    ←→   git pull origin master
+git log master..origin/master
+git merge origin/master
+```
+
+Ninguna opción es universalmente mejor. Es cuestión de cuánto quieres ver antes de integrar.
+
+## El peligro de --force
+
+Cuando un push es rechazado porque el remoto tiene cambios que tú no tienes, la tentación es usar `--force`:
+
+```bash
+# ⚠️ Peligroso en ramas compartidas
+git push --force origin master
+```
+
+`--force` sobrescribe el historial del remoto con el tuyo, ignorando cualquier commit que haya allí. Si estás trabajando solo en una rama de feature que solo tú tocas, puede ser válido. En una rama compartida, es como borrar el trabajo de tus compañeros sin preguntar.
+
+### --force-with-lease: la alternativa sensata
+
+```bash
+git push --force-with-lease origin master
+```
+
+`--force-with-lease` hace la misma operación que `--force`, pero con una comprobación previa: falla si el remoto tiene commits que tú no tienes en tu copia local. Es decir, te protege de sobrescribir trabajo ajeno que no has visto.
+
+La diferencia práctica:
+
+```
+--force            # "Sobreescribe pase lo que pase"
+--force-with-lease # "Sobreescribe solo si el remoto no ha cambiado desde mi último fetch"
+```
+
+¿Cuándo se usa force (con lease)? El caso más común es después de un `git rebase`: al reescribir el historial, tus commits tienen hashes nuevos y Git los ve como divergentes del remoto, aunque el contenido sea prácticamente el mismo. Si la rama es solo tuya, `--force-with-lease` es seguro.
+
+En ramas compartidas como `master` o `main`: nunca, salvo en situaciones muy específicas y con coordinación explícita del equipo.
+
+## Caso práctico: el flujo completo
+
+Un flujo típico en un proyecto con más de una persona trabajando en la misma rama:
+
+```bash
+# 1. Traer los últimos cambios antes de empezar
+git fetch origin
+git log master..origin/master --oneline  # ¿qué hay de nuevo?
+
+# 2. Integrar si hay cambios
+git merge origin/master
+
+# 3. Trabajar y hacer commits locales
+git add .
+git commit -m "feat: add search functionality"
+
+# 4. Antes de pushear, comprobar si alguien más ha pusheado mientras trabajabas
+git fetch origin
+git log master..origin/master --oneline
+
+# 5. Si hay cambios nuevos, integrarlos primero
+git merge origin/master  # o git rebase origin/master, según el proyecto
+
+# 6. Ahora sí, push
+git push origin master
+```
+
+Esto parece largo, pero con práctica se vuelve automático. Y evita el 90% de los conflictos en remoto.
+
+---
+
+Con esto ya tienes el ciclo completo: entiendes cómo enviar cambios al remoto, cómo recibirlos con control, y por qué `--force-with-lease` existe (y `--force` sin más debería darte cierto respeto).
+
+En el próximo tutorial, lección 18, veremos cómo deshacer commits: desde correcciones menores con `--amend` hasta revertir cambios ya pusheados sin romper el historial compartido.
+
+**💡 Challenge**: En un repositorio tuyo, haz `git fetch origin` y luego `git log HEAD..origin/master --oneline`. ¿Hay commits en el remoto que no tienes localmente? Si no los hay, crea un commit directamente en GitHub y repite el ejercicio. Después integra con `git merge`.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/pushing-and-fetching-git.mdx
+++ b/src/content/tutorials/pushing-and-fetching-git.mdx
@@ -1,0 +1,179 @@
+---
+title: "Push and fetch in Git: syncing with the remote"
+post_slug: "pushing-and-fetching-git"
+date: "2026-03-12"
+excerpt: "Learn to send and receive changes in Git with git push and git fetch. Understand the difference between fetch and pull, how to use --force-with-lease, and why git push --force is a bad idea."
+language: "en"
+categories: ["git"]
+course: "mastering-git-from-scratch"
+order: 17
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "push-fetch-git"
+---
+
+You already know that remotes are aliases for URLs, and that `origin` has nothing special about it. But having the remote configured isn't enough — the whole point is to synchronize your work with it. When do you use `git push`? When do you use `git fetch`? And what exactly is the difference between `git fetch` and `git pull`? There are people who've been using Git for years without having this fully clear (no judgment — me included when I started).
+
+Let's fix that today, and along the way we'll see why `git push --force` is one of the most efficient ways to make your teammates hate you.
+
+## Sending changes to the remote: git push
+
+`git push` sends your local commits to a remote repository. The basic form:
+
+```bash
+git push origin master
+```
+
+This sends the local `master` branch to the `origin` remote. If the remote doesn't have that branch yet, it creates it. If it already exists and your commits are a direct continuation of its history (no divergence), the push works without issue.
+
+### Setting the upstream with -u
+
+The first time you push a new branch, add `-u` to set up tracking:
+
+```bash
+git push -u origin new-feature
+```
+
+After that, from that branch you can just type:
+
+```bash
+git push
+```
+
+And Git already knows where to go. Without `-u`, Git will ask you to specify the remote and branch every time, with an error message that a lot of people copy into Google without reading it in full.
+
+### What happens when a push is rejected?
+
+If someone else pushed changes to the same branch while you were working, you'll see something like:
+
+```
+ ! [rejected]        master -> master (fetch first)
+error: failed to push some refs to 'git@github.com:youruser/my-project.git'
+hint: Updates were rejected because the remote contains work that you do
+hint: not have locally. Integrate the remote changes (e.g.
+hint: 'git pull ...') before pushing again.
+```
+
+Git refuses to overwrite someone else's work. The fix: bring in the remote changes first, integrate them, then push. We'll cover this in detail in the next section.
+
+## Receiving changes: fetch vs pull
+
+This is where confusion is most common. There are two ways to bring changes from the remote:
+
+- `git fetch`: downloads the changes but **doesn't apply them**
+- `git pull`: downloads the changes **and applies them** (it's `fetch` + `merge` in one shot)
+
+### git fetch
+
+```bash
+git fetch origin
+```
+
+This updates your local remote references (`origin/master`, `origin/develop`, etc.) with what's on the server, but **doesn't touch your working branch**. It's like checking your mail without opening it.
+
+After a fetch, you can see what changed:
+
+```bash
+git log master..origin/master --oneline
+```
+
+```
+a7f3c21 Fix authentication bug
+b2e9d14 Add user profile endpoint
+```
+
+That shows you the commits that are in `origin/master` but not yet in your local `master`. You can inspect them at your own pace before deciding to integrate them.
+
+When you're ready to integrate:
+
+```bash
+git merge origin/master
+```
+
+### git pull
+
+```bash
+git pull origin master
+```
+
+This is equivalent to running `git fetch origin` followed by `git merge origin/master`. Faster to type, but it removes the intermediate inspection step.
+
+On personal projects or when you trust what's on the remote, `git pull` is perfectly fine. On team projects with high activity, fetching first gives you more control over what you're integrating and when.
+
+```
+fetch + manual merge      git pull
+────────────────────      ─────────
+git fetch origin     ←→   git pull origin master
+git log master..origin/master
+git merge origin/master
+```
+
+Neither option is universally better. It comes down to how much you want to see before integrating.
+
+## The danger of --force
+
+When a push is rejected because the remote has changes you don't have, the temptation is to use `--force`:
+
+```bash
+# ⚠️ Dangerous on shared branches
+git push --force origin master
+```
+
+`--force` overwrites the remote's history with yours, ignoring any commits that are there. If you're working alone on a feature branch that only you touch, it can be valid. On a shared branch, it's like deleting your teammates' work without asking.
+
+### --force-with-lease: the sensible alternative
+
+```bash
+git push --force-with-lease origin master
+```
+
+`--force-with-lease` does the same operation as `--force`, but with a prior check: it fails if the remote has commits you don't have in your local copy. In other words, it protects you from overwriting someone else's work that you haven't seen.
+
+The practical difference:
+
+```
+--force            # "Overwrite no matter what"
+--force-with-lease # "Overwrite only if the remote hasn't changed since my last fetch"
+```
+
+When do you use force (with lease)? The most common case is after a `git rebase`: by rewriting history, your commits get new hashes and Git sees them as diverging from the remote, even though the content is essentially the same. If the branch is yours alone, `--force-with-lease` is safe.
+
+On shared branches like `master` or `main`: never, except in very specific situations with explicit team coordination.
+
+## Practical case: the full workflow
+
+A typical flow in a project where more than one person is working on the same branch:
+
+```bash
+# 1. Bring in the latest changes before starting
+git fetch origin
+git log master..origin/master --oneline  # what's new?
+
+# 2. Integrate if there are changes
+git merge origin/master
+
+# 3. Do your work and commit locally
+git add .
+git commit -m "feat: add search functionality"
+
+# 4. Before pushing, check if someone else pushed while you worked
+git fetch origin
+git log master..origin/master --oneline
+
+# 5. If there are new changes, integrate them first
+git merge origin/master  # or git rebase origin/master, depending on the project
+
+# 6. Now push
+git push origin master
+```
+
+This looks like a lot of steps, but with practice it becomes automatic. And it prevents 90% of remote conflicts.
+
+---
+
+With this you have the full cycle: you know how to send changes to the remote, how to receive them with control, and why `--force-with-lease` exists (and bare `--force` should give you pause).
+
+In the next tutorial, lesson 18, we'll look at how to undo commits: from minor fixes with `--amend` to reverting already-pushed changes without breaking shared history.
+
+**💡 Challenge**: In one of your repositories, run `git fetch origin` and then `git log HEAD..origin/master --oneline`. Are there commits on the remote that you don't have locally? If not, create a commit directly on GitHub and repeat the exercise. Then integrate with `git merge`.
+
+Never stop coding!


### PR DESCRIPTION
## Summary

- Adds Git lesson 17 tutorial in Spanish (`push-fetch-git.mdx`) and English (`pushing-and-fetching-git.mdx`)
- Covers `git push`, upstream tracking with `-u`, push rejection, `git fetch` vs `git pull`, and `--force-with-lease`
- Paired via `i18n` frontmatter field