### PR TITLE
feat(tutorials): add Surviving Vim - The Absolute Basics (ES + EN)

### DIFF
--- a/src/content/tutorials/sobrevivir-en-vim-lo-basico.mdx
+++ b/src/content/tutorials/sobrevivir-en-vim-lo-basico.mdx
@@ -1,0 +1,194 @@
+---
+title: "Sobrevivir en Vim: lo absolutamente básico"
+post_slug: "sobrevivir-en-vim-lo-basico"
+date: "2026-03-24"
+excerpt: "Ya tienes Neovim y LazyVim instalados. ¿Y ahora qué? Aprende los comandos esenciales para abrir archivos, editar texto, guardar tu trabajo y, sí, salir de Vim sin buscarlo en Google."
+language: "es"
+categories: ["vim"]
+course: "domina-vim-desde-cero"
+order: 3
+cover: "/images/tutorials/cabecera-vim-curso.jpg"
+i18n: "surviving-vim-the-basics"
+---
+
+Abres Neovim. Escribes algo. No aparece nada. Pulsas `Backspace`. Nada. Pruebas `Ctrl+C`. Nada. Intentas hacer clic. El ratón aquí es irrelevante. Pulsas `Esc` diecisiete veces y al final consigues salir cerrando la terminal.
+
+¿Te suena?
+
+No es que seas torpe. Así funciona Vim. Y cuando entiendas el modelo que hay detrás, esos momentos de "¿qué narices está pasando?" se convierten en otra cosa completamente diferente: precisión. En este tutorial vamos a ver el mínimo indispensable para sobrevivir en Vim sin querer lanzar el ordenador por la ventana.
+
+## Los cuatro modos (y por qué existen)
+
+Todos los editores de texto que has usado hasta ahora operan en un único modo: escribes y aparece texto. Vim es diferente. Separa el **acto de escribir** del **acto de navegar y editar**. Este es el modelo de edición modal, y es la idea central de todo el curso.
+
+Vim tiene cuatro modos principales:
+
+| Modo        | Cómo entrar            | Qué haces aquí                                |
+| ----------- | ---------------------- | --------------------------------------------- |
+| **Normal**  | `Esc` o `Ctrl+[`       | Navegar, copiar, pegar, borrar                |
+| **Insert**  | `i`, `a`, `o`, y otros | Escribir texto como en un editor normal       |
+| **Visual**  | `v`, `V`, `Ctrl+v`     | Seleccionar texto                             |
+| **Command** | `:`                    | Ejecutar comandos (guardar, salir, buscar...) |
+
+Cuando abres Neovim, estás en **modo Normal**. Es intencional. Vim asume que pasas la mayor parte del tiempo navegando y editando código, no escribiendo texto nuevo desde cero. El modo Normal es tu base de operaciones.
+
+Piénsalo como un cirujano: no camina por el quirófano con el bisturí en la mano todo el tiempo. La herramienta solo aparece cuando hace falta. El modo Normal es "manos vacías, observando". El modo Insert es "bisturí fuera, cortando".
+
+### Cambiar entre modos
+
+La tecla más importante en Vim es `Esc`. Te lleva de vuelta al modo Normal desde cualquier lugar. Si alguna vez te pierdes, pulsa `Esc` (una vez, o dos para asegurarte) y estás en casa.
+
+```
+Normal ──(i / a / o)──→ Insert
+Normal ──(:)──────────→ Command
+Normal ──(v / V)──────→ Visual
+
+Insert ──(Esc)────────→ Normal
+Command ──(Esc / Enter)→ Normal
+Visual ──(Esc)────────→ Normal
+```
+
+Memoriza esto: **`Esc` siempre te devuelve al modo Normal.**
+
+## Salir de Vim (el meme eterno)
+
+Primero lo primero: resolvamos el problema más famoso del desarrollo de software.
+
+En modo Normal, escribe `:` para entrar al modo Command. Verás que aparece un `:` en la parte inferior de la pantalla. Ahora escribe:
+
+- `:q` — salir (solo funciona si no hay cambios sin guardar)
+- `:q!` — salir **sin guardar** (el `!` lo fuerza)
+- `:w` — guardar (write) el archivo
+- `:wq` — guardar y salir
+- `:x` — guardar y salir (solo escribe si hay cambios reales)
+- `ZZ` — guardar y salir (atajo, sin `:`)
+
+Para el escenario de "solo quiero salir de aquí": **`:q!`**. Esa es tu vía de escape. Siempre.
+
+```vim
+:q!
+```
+
+```
+(Neovim se cierra. Eres libre.)
+```
+
+⚠️ `:q!` descarta todos los cambios sin guardar. Si llevas una hora editando un archivo y escribes `:q!`, se pierde todo. Usa `:w` primero si quieres conservar tu trabajo.
+
+## Navegación básica: hjkl
+
+En modo Normal, navegas con el teclado — sin ratón, sin flechas (bueno, las flechas también funcionan, pero los usuarios de Vim lo desaprueban). Las teclas de navegación en la fila central son:
+
+| Tecla | Dirección |
+| ----- | --------- |
+| `h`   | Izquierda |
+| `j`   | Abajo     |
+| `l`   | Derecha   |
+| `k`   | Arriba    |
+
+¿Por qué `hjkl`? Porque están en la fila central de un teclado QWERTY, justo bajo la mano derecha. Nunca tienes que mover la mano hasta el grupo de teclas de flechas. Suena una tontería hasta que llevas unas semanas así y las manos nunca abandonan el teclado.
+
+Si no recuerdas cuál es cuál: `j` parece una flecha apuntando hacia abajo. `h` está a la izquierda (está a la izquierda de `j`). A partir de ahí, `k` tiene que ser arriba y `l` derecha.
+
+```
+     k
+   h   l
+     j
+```
+
+**No te fuerces a usar solo `hjkl` desde el primer día.** Si necesitas las flechas por ahora, úsalas. Con la práctica irás cambiando de forma natural.
+
+### Más comandos de navegación
+
+Cuando `hjkl` esté en tu memoria muscular, querrás formas más rápidas de moverte:
+
+- `0` — ir al inicio de la línea
+- `$` — ir al final de la línea
+- `gg` — ir a la primera línea del archivo
+- `G` — ir a la última línea del archivo
+- `Ctrl+d` — bajar media página
+- `Ctrl+u` — subir media página
+
+Para saltar a un número de línea concreto, escribe `:<número>` y pulsa Enter. Para ir a la línea 42:
+
+```vim
+:42
+```
+
+## Entrar al modo Insert
+
+Ahora que puedes navegar, vamos a escribir algo de texto. Hay varias formas de entrar al modo Insert, cada una coloca el cursor en un sitio diferente:
+
+- `i` — insertar **antes** del cursor
+- `a` — insertar **después** del cursor
+- `I` — insertar al **inicio de la línea**
+- `A` — insertar al **final de la línea**
+- `o` — abrir una nueva línea **debajo** y entrar al modo Insert
+- `O` — abrir una nueva línea **encima** y entrar al modo Insert
+
+Por ahora, con `i` (antes) y `o` (nueva línea abajo) tienes el 80% de la edición diaria cubierta.
+
+Una vez en modo Insert, verás `-- INSERT --` en la parte inferior de la pantalla. Ahora puedes escribir con normalidad. Pulsa `Esc` cuando hayas terminado para volver al modo Normal.
+
+El flujo de trabajo es este:
+
+1. Navega hasta donde quieres editar (modo Normal)
+2. Pulsa `i` o `o` para entrar al modo Insert
+3. Escribe el texto
+4. Pulsa `Esc` para volver al modo Normal
+5. Navega hasta lo siguiente que quieres cambiar
+6. Repite
+
+Al principio parece lento. No lo es. Una vez que está en tus manos, es dramáticamente más rápido que tener los dedos en el ratón — pero eso llega con la práctica.
+
+## Edición básica
+
+Todavía en modo Normal, puedes borrar y manipular texto sin entrar al modo Insert:
+
+- `x` — borrar el carácter bajo el cursor
+- `dd` — borrar la línea actual completa
+- `u` — deshacer el último cambio
+- `Ctrl+r` — rehacer (deshacer el deshacer)
+
+Estos funcionan al instante, sin necesidad del modo Insert. Navega hasta un carácter, pulsa `x`, desaparece.
+
+### Tu primera edición real
+
+Pongámoslo todo junto. Abre Neovim con un archivo nuevo:
+
+```bash
+nvim practica.txt
+```
+
+Ahora sigue estos pasos:
+
+1. Estás en modo Normal. Pulsa `i` para entrar al modo Insert.
+2. Escribe: `¡Hola, Vim!`
+3. Pulsa `Esc` para volver al modo Normal.
+4. Pulsa `o` para abrir una nueva línea debajo.
+5. Escribe: `Esta es mi primera edición.`
+6. Pulsa `Esc`.
+7. Escribe `:w` y pulsa Enter para guardar.
+8. Navega hacia arriba con `k`, luego borra la línea con `dd`.
+9. Pulsa `u` para deshacer el borrado.
+10. Escribe `:wq` para guardar y salir.
+
+Enhorabuena: acabas de sobrevivir en Vim.
+
+## Conceptos clave de esta lección
+
+- Vim tiene **cuatro modos**: Normal, Insert, Visual, Command. Empiezas en Normal.
+- `Esc` siempre te devuelve al modo Normal.
+- **`:q!`** sale sin guardar. **`:wq`** guarda y sale.
+- **`hjkl`** para navegar: h←, j↓, k↑, l→
+- **`i`** inserta antes del cursor, **`o`** abre una nueva línea abajo.
+- **`dd`** borra una línea, **`u`** deshace, **`Ctrl+r`** rehace.
+- El modo Normal es el hogar. Vives ahí. Visitas el modo Insert brevemente.
+
+---
+
+Ya puedes abrir Neovim, hacer ediciones, guardar tu trabajo y salir sin entrar en pánico. Eso es un avance real — la mayoría de la gente abandona Vim antes de llegar aquí.
+
+Pero solo hemos arañado la superficie de lo que puede hacer el modo Normal. En el próximo tutorial exploraremos **el verdadero poder del modo Normal**: movimientos por palabras, la gramática de Vim (operador + movimiento) y cómo combinar un puñado de comandos da combinaciones de edición casi infinitas.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/surviving-vim-the-basics.mdx
+++ b/src/content/tutorials/surviving-vim-the-basics.mdx
@@ -1,0 +1,194 @@
+---
+title: "Surviving Vim: The Absolute Basics"
+post_slug: "surviving-vim-the-basics"
+date: "2026-03-24"
+excerpt: "You've installed Neovim and LazyVim. Now what? Learn the essential commands to open files, edit text, save your work, and — yes — quit Vim without Googling it."
+language: "en"
+categories: ["vim"]
+course: "mastering-vim-from-scratch"
+order: 3
+cover: "/images/tutorials/cabecera-vim-curso.jpg"
+i18n: "sobrevivir-en-vim-lo-basico"
+---
+
+You open Neovim. You type something. Nothing appears. You press `Backspace`. Nothing. You try `Ctrl+C`. Nothing. You try clicking. Your mouse is irrelevant here. You press `Esc` seventeen times and finally manage to exit by closing the terminal.
+
+Sound familiar?
+
+You're not stupid. This is just how Vim works. And once you understand the model behind it, these "WTF moments" transform into something else entirely: precision. In this tutorial we're going to cover the absolute minimum you need to survive Vim without wanting to throw your computer out the window.
+
+## The four modes (and why they exist)
+
+Every text editor you've ever used operates in a single mode: you type, and text appears. Vim is different. It separates the **act of typing** from the **act of navigating and editing**. This is the modal editing model, and it's the core idea of the whole course.
+
+Vim has four main modes:
+
+| Mode        | How to enter              | What you do here                     |
+| ----------- | ------------------------- | ------------------------------------ |
+| **Normal**  | `Esc` or `Ctrl+[`         | Navigate, copy, paste, delete        |
+| **Insert**  | `i`, `a`, `o`, and others | Type text like a normal editor       |
+| **Visual**  | `v`, `V`, `Ctrl+v`        | Select text                          |
+| **Command** | `:`                       | Run commands (save, quit, search...) |
+
+When you open Neovim, you're in **Normal mode**. This is intentional. Vim assumes you spend most of your time navigating and editing code — not typing new text from scratch. Normal mode is home base.
+
+Think of it like a surgeon: they don't walk around the operating room with a scalpel in their hand at all times. The tool comes out only when it's needed. Normal mode is "hands empty, observing." Insert mode is "scalpel out, cutting."
+
+### Switching between modes
+
+The most important key in Vim is `Esc`. It takes you back to Normal mode from anywhere. If you're ever lost, press `Esc` (once, or twice for good measure) and you're home.
+
+```
+Normal ──(i / a / o)──→ Insert
+Normal ──(:)──────────→ Command
+Normal ──(v / V)──────→ Visual
+
+Insert ──(Esc)────────→ Normal
+Command ──(Esc / Enter)→ Normal
+Visual ──(Esc)────────→ Normal
+```
+
+Memorize this: **`Esc` always brings you back to Normal mode.**
+
+## Quitting Vim (the eternal meme)
+
+Let's solve the most famous problem in software development first.
+
+In Normal mode, type `:` to enter Command mode. You'll see a `:` appear at the bottom of the screen. Now type:
+
+- `:q` — quit (only works if there are no unsaved changes)
+- `:q!` — quit **without saving** (the `!` forces it)
+- `:w` — save (write) the file
+- `:wq` — save and quit
+- `:x` — save and quit (only writes if there are actually changes)
+- `ZZ` — save and quit (shortcut, no colon needed)
+
+For the "I just want out of here" scenario: **`:q!`**. That's your escape hatch. Always.
+
+```vim
+:q!
+```
+
+```
+(Neovim closes. You're free.)
+```
+
+⚠️ `:q!` discards all unsaved changes. If you've been editing a file for an hour and you type `:q!`, it's gone. Use `:w` first if you want to keep your work.
+
+## Basic navigation: hjkl
+
+In Normal mode, you navigate with the keyboard — no mouse, no arrow keys (well, arrow keys work too, but Vim users frown upon it). The home row navigation keys are:
+
+| Key | Direction |
+| --- | --------- |
+| `h` | Left      |
+| `j` | Down      |
+| `l` | Right     |
+| `k` | Up        |
+
+Why `hjkl`? Because they're on the home row of a QWERTY keyboard, right under your right hand. You never have to move your hand to a separate arrow key cluster. It sounds silly until you've been doing it for a few weeks and your hands never leave the keyboard.
+
+If you can't remember which is which: `j` looks like an arrow pointing down. `h` is left (it's to the left of `j`). From there, `k` must be up and `l` must be right.
+
+```
+     k
+   h   l
+     j
+```
+
+**Don't force yourself to use only `hjkl` from day one.** If you need to use arrow keys for now, go ahead. You'll naturally switch as you practice.
+
+### More navigation commands
+
+Once `hjkl` is in your muscle memory, you'll want faster ways to move:
+
+- `0` — go to the start of the line
+- `$` — go to the end of the line
+- `gg` — go to the first line of the file
+- `G` — go to the last line of the file
+- `Ctrl+d` — scroll half a page down
+- `Ctrl+u` — scroll half a page up
+
+And to jump to a specific line number, type `:<number>` and press Enter. To go to line 42:
+
+```vim
+:42
+```
+
+## Entering Insert mode
+
+Now that you can navigate, let's type some text. There are several ways to enter Insert mode — each one places the cursor differently:
+
+- `i` — insert **before** the cursor
+- `a` — insert **after** the cursor
+- `I` — insert at the **start of the line**
+- `A` — insert at the **end of the line**
+- `o` — open a new line **below** and enter Insert mode
+- `O` — open a new line **above** and enter Insert mode
+
+For now, just remember `i` (before) and `o` (new line below). Those two get you through 80% of daily editing.
+
+Once in Insert mode, you'll see `-- INSERT --` at the bottom of the screen. Now you can type normally. Press `Esc` when you're done to return to Normal mode.
+
+The workflow looks like this:
+
+1. Navigate to where you want to edit (Normal mode)
+2. Press `i` or `o` to enter Insert mode
+3. Type your text
+4. Press `Esc` to return to Normal mode
+5. Navigate to the next thing you want to change
+6. Repeat
+
+This feels slow at first. It's not. Once it's in your hands, it's dramatically faster than keeping your fingers on a mouse — but that comes with practice.
+
+## Basic editing
+
+Still in Normal mode, you can delete and manipulate text without entering Insert mode at all:
+
+- `x` — delete the character under the cursor
+- `dd` — delete the entire current line
+- `u` — undo the last change
+- `Ctrl+r` — redo (undo the undo)
+
+These work instantly, no Insert mode needed. Navigate to a character, press `x`, it's gone.
+
+### Your first real edit
+
+Let's put it all together. Open Neovim with a new file:
+
+```bash
+nvim practice.txt
+```
+
+Now follow these steps:
+
+1. You're in Normal mode. Press `i` to enter Insert mode.
+2. Type: `Hello, Vim!`
+3. Press `Esc` to go back to Normal mode.
+4. Press `o` to open a new line below.
+5. Type: `This is my first edit.`
+6. Press `Esc`.
+7. Type `:w` and press Enter to save.
+8. Now navigate up with `k`, then delete the line with `dd`.
+9. Press `u` to undo the deletion.
+10. Type `:wq` to save and quit.
+
+Congratulations — you just survived Vim.
+
+## Key concepts from this lesson
+
+- Vim has **four modes**: Normal, Insert, Visual, Command. You start in Normal.
+- `Esc` always returns you to Normal mode.
+- **`:q!`** quits without saving. **`:wq`** saves and quits.
+- **`hjkl`** for navigation: h←, j↓, k↑, l→
+- **`i`** inserts before cursor, **`o`** opens a new line below.
+- **`dd`** deletes a line, **`u`** undoes, **`Ctrl+r`** redoes.
+- Normal mode is home. You live there. You visit Insert mode briefly.
+
+---
+
+You can now open Neovim, make edits, save your work, and quit without panicking. That's real progress — most people quit Vim before reaching this point.
+
+But we've only scratched the surface of what Normal mode can do. In the next tutorial, we'll explore **Normal mode's real power**: word movements, the Vim grammar (operator + motion), and how combining just a handful of commands gives you near-infinite editing combinations.
+
+Never stop coding!


### PR DESCRIPTION
## Summary

- Adds lesson 3 of the Vim course in both languages
- Covers modal editing model, the four modes (Normal/Insert/Visual/Command), `hjkl` navigation, entering Insert mode, basic editing commands (`x`, `dd`, `u`, `Ctrl+r`), and quitting Vim
- ES slug: `sobrevivir-en-vim-lo-basico` / EN slug: `surviving-vim-the-basics`
- `i18n` field pairs both files correctly
- `order: 3`, `date: 2026-03-24`, course: `domina-vim-desde-cero` / `mastering-vim-from-scratch`