### PR TITLE
feat(posts): add AI for Developers course presentation posts (ES + EN)

### DIFF
--- a/src/content/posts/presentacion-curso-ia-para-programadores.mdx
+++ b/src/content/posts/presentacion-curso-ia-para-programadores.mdx
@@ -1,0 +1,85 @@
+---
+title: "Presentación del curso IA para Programadores"
+post_slug: "presentacion-curso-ia-para-programadores"
+date: "2026-03-26"
+excerpt: "¿Usas la IA para escribir emails pero no para escribir código? Este curso te enseña a usar la IA como herramienta de desarrollo profesional: desde entender los LLMs hasta orquestar agentes multi-IA. ¡Completamente gratis!"
+language: "es"
+categories: ["programacion"]
+cover: "/images/posts/cabecera-ia-para-programadores-post.jpg"
+i18n: "presentation-ai-for-developers-course"
+---
+
+Probablemente ya uses la IA para algo. Un email, una búsqueda, una explicación rápida. Pero hay una diferencia abismal entre _usar_ la IA y _trabajar_ con ella como desarrollador. Entre pedirle que te explique un error y tener un agente que lea tu codebase, proponga la solución, escriba los tests, los ejecute y te informe del resultado.
+
+La mayoría de los desarrolladores están en el primer grupo. Este curso te lleva al segundo.
+
+Bienvenido a **IA para Programadores**: un curso completo y gratuito que te llevará desde entender qué son los LLMs hasta orquestar workflows de agentes multi-IA para el desarrollo de software. Con opencode, Claude, y un enfoque crítico desde el primer día.
+
+### ¿Por qué la IA es la habilidad más importante de 2026?
+
+No lo digo como hype. Lo digo como observación técnica.
+
+En 2023, la IA era una herramienta de productividad marginal: autocompletado glorificado. En 2025, los agentes de IA podían escribir features completas, debuggear, hacer code reviews y proponer refactors. En 2026, los equipos que no usan agentes de IA tienen desventajas mensurables en velocidad de entrega.
+
+La cita que circula por todos lados (y que, aunque está sobreutilizada, es técnicamente exacta):
+
+> La IA no va a reemplazar a los programadores. Va a reemplazar a los programadores que no usan IA.
+
+Lo que eso significa en la práctica: la IA es un multiplicador. No piensa por ti, pero ejecuta lo que piensas mucho más rápido. El código boilerplate, los tests, la documentación, los refactors repetitivos — todo eso puede delegarse. Lo que no puede delegarse es el criterio: entender el problema, diseñar la arquitectura, verificar que la solución es correcta. Eso sigue siendo tuyo.
+
+La nueva habilidad crítica no es programar más rápido a mano. Es **dirigir a la IA con precisión**.
+
+### ¿Qué hace diferente a este curso?
+
+La mayoría de recursos de IA para programadores fallan por las mismas razones: asumen que ya eres un developer con experiencia, muestran demos mágicas sin enseñar evaluación crítica, tratan el output de la IA como siempre correcto, se enfocan en herramientas específicas (que cambian cada seis meses), y no abordan el cambio de mentalidad que requiere trabajar con agentes.
+
+**Este curso es diferente:**
+
+- **Cero prerequisitos técnicos**: Empezamos desde lo más básico. Si sabes que existe ChatGPT pero poco más, estás en el sitio correcto.
+- **Pensamiento crítico primero**: Aprenderás a detectar alucinaciones, verificar código antes de usarlo, y cuándo _no_ usar la IA.
+- **Principios sobre herramientas**: Las herramientas de IA cambian cada seis meses. Los principios no. Aprenderás a adaptarte, no a memorizar menús.
+- **opencode como herramienta principal**: No una interfaz de chat. Un agente real que opera en tu codebase, ejecuta comandos y toma decisiones. Así es como trabajan los desarrolladores avanzados.
+- **El "por qué" antes del "cómo"**: Entender cómo funcionan los LLMs (sin matemáticas) te hace usarlos mejor. No es teoría por teoría: es contexto que cambia cómo trabajas.
+
+### ¿Qué voy a aprender?
+
+El curso tiene 72 lecciones en 12 módulos, diseñadas para llevarte de cero a profesional de forma progresiva:
+
+- **Módulo 1**: Qué es la IA generativa, cómo funcionan los LLMs, el mapa del ecosistema en 2026
+- **Módulo 2**: Prompting efectivo para desarrolladores — cómo pedir lo que quieres y obtenerlo
+- **Módulo 3**: Herramientas de desarrollo con IA — instalación y configuración de opencode
+- **Módulo 4**: Desarrollo asistido por IA — el ciclo completo de una feature con agente
+- **Módulo 5**: Debugging con IA — de error a solución con contexto
+- **Módulo 6**: Code review y calidad con IA — refactoring, análisis estático, mejora continua
+- **Módulo 7**: Arquitectura de software con IA — decisiones de diseño, trade-offs, ADRs
+- **Módulo 8**: Workflows avanzados con opencode — el agente en tu flujo de trabajo real
+- **Módulo 9**: Tools — cómo opencode interactúa con tu mundo (shell, APIs, archivos)
+- **Módulo 10**: Skills — cómo enseñarle conocimiento especializado a tu agente
+- **Módulo 11**: MCP — extender las capacidades de la IA con integraciones
+- **Módulo 12**: Orquestación multi-agente — IA a escala
+
+### ¿Necesito conocimientos previos?
+
+El curso empieza desde cero absoluto. No necesitas experiencia con IA ni conocimientos avanzados de programación.
+
+Lo que sí ayuda tener:
+
+- Curiosidad genuina sobre cómo funcionan las cosas
+- Disposición a cuestionar el output de la IA (esto es más importante que la experiencia técnica)
+- Un ordenador donde puedas instalar software (Linux, macOS, o Windows con WSL)
+
+Si ya programas con cierta experiencia, aprovecharás más el curso. Si estás empezando, los módulos 1 y 2 te darán la base conceptual que necesitas antes de tocar herramientas.
+
+### Una advertencia honesta
+
+La IA no es magia. No va a escribir software complejo por ti sin supervisión. No va a reemplazar entender lo que estás haciendo. Y si la usas sin criterio, vas a introducir bugs sutiles, vulnerabilidades de seguridad y código que no entiendes.
+
+Este curso no te enseña a confiar en la IA. Te enseña a **colaborar** con ella: saber cuándo usarla, cómo dirigirla, cómo verificar su output, y cuándo ignorarla.
+
+Esa distinción es lo que separa a quien usa IA de quien trabaja con IA.
+
+---
+
+**Primera lección disponible el 27 de marzo**: "¿Qué es la IA generativa? Más allá de ChatGPT"
+
+¡Nunca dejes de programar! ¡Permanece atento a las próximas lecciones!

--- a/src/content/posts/presentation-ai-for-developers-course.mdx
+++ b/src/content/posts/presentation-ai-for-developers-course.mdx
@@ -1,0 +1,85 @@
+---
+title: "Introducing the AI for Developers Course"
+post_slug: "presentation-ai-for-developers-course"
+date: "2026-03-26"
+excerpt: "Using AI for emails but not for code? This course teaches you to use AI as a professional development tool: from understanding LLMs to orchestrating multi-agent workflows. Completely free!"
+language: "en"
+categories: ["programming"]
+cover: "/images/posts/cabecera-ia-para-programadores-post.jpg"
+i18n: "presentacion-curso-ia-para-programadores"
+---
+
+You probably already use AI for something. An email, a search, a quick explanation. But there's a vast difference between _using_ AI and _working_ with it as a developer. Between asking it to explain an error and having an agent that reads your codebase, proposes the fix, writes the tests, runs them, and reports back.
+
+Most developers are in the first group. This course takes you to the second.
+
+Welcome to **AI for Developers**: a complete, free course that will take you from understanding what LLMs are to orchestrating multi-agent AI workflows for software development. With opencode, Claude, and a critical mindset from day one.
+
+### Why AI is the most important skill of 2026
+
+Not hype. A technical observation.
+
+In 2023, AI was a marginal productivity tool: glorified autocomplete. By 2025, AI agents could write complete features, debug, do code reviews, and propose refactors. In 2026, teams not using AI agents have measurable disadvantages in delivery speed.
+
+The quote that's everywhere right now (and despite being overused, is technically accurate):
+
+> AI won't replace developers. It will replace developers who don't use AI.
+
+What that means in practice: AI is a multiplier. It doesn't think for you, but it executes what you think much faster. Boilerplate code, tests, documentation, repetitive refactors — all of that can be delegated. What can't be delegated is judgment: understanding the problem, designing the architecture, verifying the solution is correct. That's still yours.
+
+The new critical skill isn't writing code faster by hand. It's **directing AI with precision**.
+
+### What makes this course different?
+
+Most AI-for-developers resources fail for the same reasons: they assume you're already an experienced developer, show magic demos without teaching critical evaluation, treat AI output as always correct, focus on specific tools (which change every six months), and don't address the mental model shift that working with agents requires.
+
+**This course is different:**
+
+- **Zero technical prerequisites**: We start from absolute basics. If you know ChatGPT exists but little else, you're in the right place.
+- **Critical thinking first**: You'll learn to detect hallucinations, verify code before using it, and when _not_ to use AI.
+- **Principles over tools**: AI tools change every six months. Principles don't. You'll learn to adapt, not to memorize menus.
+- **opencode as the main tool**: Not a chat interface. A real agent that operates in your codebase, runs commands, and makes decisions. That's how advanced developers actually work.
+- **Why before How**: Understanding how LLMs work (without the math) makes you use them better. It's not theory for theory's sake — it's context that changes how you work.
+
+### What will I learn?
+
+The course has 72 lessons across 12 modules, designed to take you from zero to professional progressively:
+
+- **Module 1**: What is generative AI, how LLMs work, the 2026 ecosystem map
+- **Module 2**: Effective prompting for developers — how to ask for what you want and get it
+- **Module 3**: AI development tools — installing and configuring opencode
+- **Module 4**: AI-assisted development — the complete cycle of a feature with an agent
+- **Module 5**: Debugging with AI — from error to fix with context
+- **Module 6**: Code review and quality with AI — refactoring, static analysis, continuous improvement
+- **Module 7**: Software architecture with AI — design decisions, trade-offs, ADRs
+- **Module 8**: Advanced workflows with opencode — the agent in your real workflow
+- **Module 9**: Tools — how opencode interacts with your world (shell, APIs, files)
+- **Module 10**: Skills — how to teach your agent specialized knowledge
+- **Module 11**: MCP — extending AI capabilities with integrations
+- **Module 12**: Multi-agent orchestration — AI at scale
+
+### Do I need prior knowledge?
+
+The course starts from absolute zero. You don't need AI experience or advanced programming knowledge.
+
+What does help:
+
+- Genuine curiosity about how things work
+- Willingness to question AI output (this matters more than technical experience)
+- A computer where you can install software (Linux, macOS, or Windows with WSL)
+
+If you already have some programming experience, you'll get more out of the course. If you're just starting out, Modules 1 and 2 give you the conceptual foundation you need before touching any tools.
+
+### An honest warning
+
+AI isn't magic. It's not going to write complex software for you without supervision. It's not going to replace understanding what you're doing. And if you use it without judgment, you'll introduce subtle bugs, security vulnerabilities, and code you don't understand.
+
+This course doesn't teach you to trust AI. It teaches you to **collaborate** with it: knowing when to use it, how to direct it, how to verify its output, and when to ignore it.
+
+That distinction is what separates someone who uses AI from someone who works with AI.
+
+---
+
+**First lesson available March 27th**: "What Is Generative AI? Beyond ChatGPT"
+
+Never stop coding! Stay tuned for upcoming lessons!


### PR DESCRIPTION
## Summary

- Adds bilingual presentation posts for the new "AI for Developers" course (`ia-para-programadores` / `ai-for-developers`)
- ES post: `presentacion-curso-ia-para-programadores.mdx` (date: 2026-03-26, category: programacion)
- EN post: `presentation-ai-for-developers-course.mdx` (date: 2026-03-26, category: programming)
- Both posts are i18n-linked and share the same cover image