### PR TITLE
feat(content): add AI for Developers course with first tutorial (ES + EN)

### DIFF
--- a/src/content/categories/ai-en.json
+++ b/src/content/categories/ai-en.json
@@ -1,0 +1,6 @@
+{
+  "name": "AI",
+  "category_slug": "ai",
+  "language": "en",
+  "i18n": "ia"
+}

--- a/src/content/categories/ai-es.json
+++ b/src/content/categories/ai-es.json
@@ -1,0 +1,6 @@
+{
+  "name": "IA",
+  "category_slug": "ia",
+  "language": "es",
+  "i18n": "ai"
+}

--- a/src/content/courses/ai-for-developers.json
+++ b/src/content/courses/ai-for-developers.json
@@ -1,0 +1,7 @@
+{
+  "name": "AI for Developers",
+  "course_slug": "ai-for-developers",
+  "language": "en",
+  "description": "Learn to use AI as a professional development tool: from understanding LLMs to orchestrating multi-agent workflows. With opencode, Claude, and a critical mindset from day one.",
+  "i18n": "ia-para-programadores"
+}

--- a/src/content/courses/ia-para-programadores.json
+++ b/src/content/courses/ia-para-programadores.json
@@ -1,0 +1,7 @@
+{
+  "name": "IA para programadores",
+  "course_slug": "ia-para-programadores",
+  "language": "es",
+  "description": "Aprende a usar la IA como herramienta de desarrollo profesional: desde entender qué son los LLMs hasta orquestar agentes multi-IA. Con opencode, Claude y un enfoque crítico desde el primer día.",
+  "i18n": "ai-for-developers"
+}

--- a/src/content/tutorials/que-es-la-ia-generativa-mas-alla-de-chatgpt.mdx
+++ b/src/content/tutorials/que-es-la-ia-generativa-mas-alla-de-chatgpt.mdx
@@ -1,0 +1,111 @@
+---
+title: "¿Qué es la IA generativa? Más allá de ChatGPT"
+post_slug: "que-es-la-ia-generativa-mas-alla-de-chatgpt"
+date: "2026-03-27"
+excerpt: "Entiende qué es la IA generativa, la diferencia entre asistentes e agentes, y por qué los programadores que usan IA están reemplazando a los que no."
+language: "es"
+categories: ["ia"]
+course: "ia-para-programadores"
+order: 1
+cover: "/images/tutorials/cabecera-ia-para-programadores-curso.jpg"
+i18n: "what-is-generative-ai-beyond-chatgpt"
+---
+
+Probablemente hayas oído hablar de ChatGPT. Quizás lo hayas usado para escribir un email o para que te explique algo. Quizás lo usas a diario. Pero hay algo en lo que casi todo el mundo falla al empezar: confundir saber que existe la IA con saber usarla como herramienta de desarrollo.
+
+No es lo mismo. Y esa diferencia, en 2026, vale una diferencia de sueldo.
+
+Este primer tutorial sienta las bases conceptuales que necesitas antes de tocar ninguna herramienta. Sin entender el ecosistema, acabas usando mal lo que tienes. Y usar mal una herramienta poderosa es, en el mejor caso, perder el tiempo.
+
+## ¿Qué es la IA generativa?
+
+La **IA generativa** es un tipo de inteligencia artificial que, en lugar de clasificar o predecir, _genera_ contenido nuevo: texto, código, imágenes, audio. El nombre es descriptivo: genera cosas que no existían.
+
+Lo que hace que sea distinta de la IA "tradicional" es esa capacidad de producción. Un modelo de clasificación te dice "esto es un gato". Un modelo generativo te escribe un cuento sobre ese gato, o te genera el código para detectarlo.
+
+En el contexto de programación, nos interesa principalmente la generación de texto y código. Y los modelos que hacen eso se llaman **LLMs** (_Large Language Models_ — modelos de lenguaje de gran tamaño).
+
+ChatGPT es un producto construido sobre uno de esos modelos. Claude (que probablemente estás usando ahora mismo si tienes opencode) es otro. Gemini es el de Google. Todos hacen, en esencia, lo mismo: predicen texto.
+
+Sí, predicen texto. Ya profundizaremos en eso en el siguiente tutorial. Por ahora, quédate con esto: son máquinas de generar texto muy, muy sofisticadas.
+
+## ChatGPT vs Claude vs Gemini — ¿quién es quién?
+
+Si eres como yo cuando empecé, habrás oído estos nombres en algún podcast, en un hilo de Twitter, en una reunión de trabajo donde alguien los mencionó como si fueran lo mismo. No lo son. Tienen diferencias reales que afectan a cuándo usarlos.
+
+| Modelo                    | Empresa   | Fortalezas                                                |
+| ------------------------- | --------- | --------------------------------------------------------- |
+| **ChatGPT** (GPT-4, GPT-5)| OpenAI    | Uso general, buen ecosistema de plugins, multimodal       |
+| **Claude** (Sonnet, Opus) | Anthropic | Contexto largo, código, razonamiento, menos alucinaciones |
+| **Gemini**                | Google    | Integración con Google Workspace, multimodal              |
+
+¿Cuál es mejor? Depende de la tarea. Para código y análisis de codebases grandes, Claude es actualmente el más sólido. Para uso general en una interfaz de chat, cualquiera funciona. Para integración con Google Drive y Docs (porque así funcionan las cosas en tu empresa), Gemini.
+
+La buena noticia: no tienes que elegir uno para siempre. opencode, la herramienta que vamos a usar en este curso, te permite cambiar de modelo en cualquier momento.
+
+## Asistentes de IA vs agentes de IA
+
+Esta distinción es clave y mucha gente la confunde, así que la explicamos bien antes de continuar.
+
+Un **asistente de IA** (como ChatGPT en su versión básica) responde preguntas. Le preguntas, te responde, fin. Conversación lineal. Tú haces todo el trabajo de leer la respuesta, copiar el código, pegarlo en tu editor, ver si funciona, volver a preguntar...
+
+Un **agente de IA** tiene capacidad de _actuar_. No solo responde: puede leer archivos, escribir código, ejecutar comandos, buscar en la web, tomar decisiones sobre qué hacer después. Tiene un objetivo y va a por él.
+
+```
+Asistente de IA:
+Tú → "Escríbeme una función para calcular el factorial"
+IA  → "Aquí tienes: def factorial(n): ..."
+Tú → [copia, pega, prueba, vuelve si no funciona]
+
+Agente de IA:
+Tú → "Añade tests para la función factorial del módulo math_utils.py"
+IA  → [lee el archivo, identifica la función, escribe los tests,
+        los ejecuta, verifica que pasan, te informa del resultado]
+```
+
+opencode es un agente. Esa diferencia cambia completamente cómo trabajas con él.
+
+## ¿Por qué les importa a los programadores?
+
+Hay una cita que circula por todas partes en 2026 y que, aunque está sobreutilizada, es técnicamente correcta:
+
+> La IA no va a reemplazar a los programadores. Va a reemplazar a los programadores que no usan IA.
+
+¿Qué significa eso en la práctica? Que la IA es un multiplicador de productividad. No piensa por ti, pero sí ejecuta lo que piensas _mucho_ más rápido. El código boilerplate, los tests, la documentación, los refactors repetitivos — todo eso puede delegarse.
+
+Lo que no puede delegarse: entender el problema. Saber si la solución es correcta. Diseñar la arquitectura. Verificar que el código funciona en tu contexto específico. Eso sigue siendo tuyo.
+
+La nueva habilidad crítica no es saber programar más rápido a mano — es **dirigir a la IA con precisión**. Saber qué pedirle, cuándo pedírselo, y cuándo no hacerle caso.
+
+## Para lo que los desarrolladores usan la IA hoy
+
+Esto es lo que pasa en equipos reales:
+
+**Casos de alto valor:**
+
+- Generar código repetitivo (scaffolding, boilerplate, CRUD básico)
+- Explicar código desconocido cuando te incorporas a un proyecto nuevo
+- Depurar errores: "esto falla con este error, aquí está el stack trace"
+- Escribir tests (la IA es especialmente buena en esto)
+- Documentar funciones y módulos
+- Discutir trade-offs de arquitectura
+
+**Casos donde hay que ir con cuidado:**
+
+- Código de seguridad crítico (revisar _siempre_ con detalle)
+- Algoritmos complejos (verificar correctitud de forma independiente)
+- Lógica de negocio específica de tu dominio (la IA no conoce tu empresa)
+
+El patrón es claro: la IA acelera lo que ya sabes hacer. No reemplaza el criterio.
+
+## ¿Qué necesitas para empezar?
+
+Nada todavía. Este módulo es conceptual — las manos en el teclado vienen en el módulo 3, cuando instalemos y configuremos opencode.
+
+Por ahora, el único prerrequisito es entender que lo que estás aprendiendo no es usar una herramienta específica. Estás aprendiendo a pensar con IA. Las herramientas cambiarán en seis meses. El criterio no.
+
+---
+
+Ahora que tienes el mapa general del ecosistema, en el siguiente tutorial bajamos al nivel técnico: vamos a ver **cómo funcionan realmente los LLMs**, sin matemáticas, con analogías que explican por qué a veces la IA dice tonterías con total seguridad y cómo usar ese conocimiento para trabajar mejor con ella.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/what-is-generative-ai-beyond-chatgpt.mdx
+++ b/src/content/tutorials/what-is-generative-ai-beyond-chatgpt.mdx
@@ -1,0 +1,111 @@
+---
+title: "What Is Generative AI? Beyond ChatGPT"
+post_slug: "what-is-generative-ai-beyond-chatgpt"
+date: "2026-03-27"
+excerpt: "Understand what generative AI is, the difference between assistants and agents, and why developers who use AI are replacing those who don't."
+language: "en"
+categories: ["ai"]
+course: "ai-for-developers"
+order: 1
+cover: "/images/tutorials/cabecera-ia-para-programadores-curso.jpg"
+i18n: "que-es-la-ia-generativa-mas-alla-de-chatgpt"
+---
+
+You've probably heard of ChatGPT. Maybe you've used it to write an email or explain something. Maybe you use it daily. But there's something almost everyone gets wrong at the start: confusing knowing that AI exists with knowing how to use it as a development tool.
+
+Those aren't the same thing. And that difference, in 2026, is worth a salary gap.
+
+This first tutorial lays the conceptual foundation you need before touching any tool. Without understanding the ecosystem, you end up misusing what you have. And misusing a powerful tool is, at best, a waste of time.
+
+## What is generative AI?
+
+**Generative AI** is a type of artificial intelligence that, instead of classifying or predicting, _generates_ new content: text, code, images, audio. The name is self-explanatory: it generates things that didn't exist before.
+
+What sets it apart from "traditional" AI is that production capability. A classification model tells you "this is a cat." A generative model writes you a story about that cat, or generates the code to detect it.
+
+For programming purposes, we mainly care about text and code generation. The models that do that are called **LLMs** — Large Language Models.
+
+ChatGPT is a product built on top of one of those models. Claude (which you're probably using right now if you have opencode) is another. Gemini is Google's. They all do essentially the same thing: predict text.
+
+Yes, predict text. We'll go deeper on that in the next tutorial. For now, hold onto this: they're very, very sophisticated text-generating machines.
+
+## ChatGPT vs Claude vs Gemini — who's who?
+
+If you're like me when I started, you've heard these names in podcasts, Twitter threads, or work meetings where someone dropped them as if they were interchangeable. They're not. They have real differences that affect when to use them.
+
+| Model                      | Company   | Strengths                                           |
+| -------------------------- | --------- | --------------------------------------------------- |
+| **ChatGPT** (GPT-4, GPT-5) | OpenAI    | General purpose, good plugin ecosystem, multimodal  |
+| **Claude** (Sonnet, Opus)  | Anthropic | Long context, code, reasoning, fewer hallucinations |
+| **Gemini**                 | Google    | Google Workspace integration, multimodal            |
+
+Which is best? It depends on the task. For code and large codebase analysis, Claude is currently the strongest. For general-purpose chat use, any of them works. For integration with Google Drive and Docs (because that's how things work at your company), Gemini.
+
+The good news: you don't have to pick one forever. opencode, the tool we'll use in this course, lets you switch models at any time.
+
+## AI assistants vs AI agents
+
+This distinction is crucial and most people mix them up, so let's clear it up before moving on.
+
+An **AI assistant** (like basic ChatGPT) answers questions. You ask, it answers, done. Linear conversation. You do all the work of reading the response, copying the code, pasting it into your editor, seeing if it works, going back to ask again...
+
+An **AI agent** can _act_. It doesn't just respond — it can read files, write code, run commands, search the web, make decisions about what to do next. It has a goal and goes after it.
+
+```
+AI assistant:
+You → "Write me a function to calculate factorial"
+AI  → "Here you go: def factorial(n): ..."
+You → [copy, paste, test, come back if it breaks]
+
+AI agent:
+You → "Add tests for the factorial function in math_utils.py"
+AI  → [reads the file, finds the function, writes the tests,
+        runs them, verifies they pass, reports back]
+```
+
+opencode is an agent. That difference completely changes how you work with it.
+
+## Why should developers care?
+
+There's a quote that's everywhere in 2026 and, despite being overused, is technically accurate:
+
+> AI won't replace developers. It will replace developers who don't use AI.
+
+What does that mean in practice? AI is a productivity multiplier. It doesn't think for you, but it executes what you think _much_ faster. Boilerplate code, tests, documentation, repetitive refactors — all of that can be delegated.
+
+What can't be delegated: understanding the problem. Knowing whether the solution is correct. Designing the architecture. Verifying that the code works in your specific context. That's still yours.
+
+The new critical skill isn't writing code faster by hand — it's **directing AI with precision**. Knowing what to ask, when to ask, and when to ignore what it says.
+
+## What developers actually use AI for today
+
+This is what happens in real teams:
+
+**High-value cases:**
+
+- Generating repetitive code (scaffolding, boilerplate, basic CRUD)
+- Explaining unfamiliar code when onboarding to a new project
+- Debugging: "this fails with this error, here's the stack trace"
+- Writing tests (AI is particularly good at this)
+- Documenting functions and modules
+- Discussing architecture trade-offs
+
+**Cases where you need to be careful:**
+
+- Security-critical code (always review in detail)
+- Complex algorithms (verify correctness independently)
+- Domain-specific business logic (AI doesn't know your company)
+
+The pattern is clear: AI accelerates what you already know how to do. It doesn't replace judgment.
+
+## What do you need to get started?
+
+Nothing yet. This module is conceptual — hands on keyboard come in Module 3, when we install and configure opencode.
+
+For now, the only prerequisite is understanding that what you're learning isn't how to use a specific tool. You're learning to think with AI. The tools will change in six months. The judgment won't.
+
+---
+
+Now that you have the ecosystem map, in the next tutorial we go deeper: we'll look at **how LLMs actually work** — no math, just analogies that explain why AI sometimes states nonsense with total confidence, and how to use that knowledge to work with it more effectively.
+
+Never stop coding!


### PR DESCRIPTION
## Summary

- Add bilingual category AI/IA (`ai-en.json`, `ai-es.json`)
- Add bilingual course "AI for Developers / IA para programadores" (`ai-for-developers.json`, `ia-para-programadores.json`)
- Add first tutorial of the course in both languages: what generative AI is, assistant vs agent distinction, and why it matters for developers