### PR TITLE
feat(tutorials): add Git rebase rewriting history tutorial (ES + EN)

### DIFF
--- a/src/content/tutorials/reescribiendo-historial-git-rebase.mdx
+++ b/src/content/tutorials/reescribiendo-historial-git-rebase.mdx
@@ -1,0 +1,171 @@
+---
+title: "Reescribiendo el historial con git rebase"
+post_slug: "reescribiendo-historial-git-rebase"
+date: "2026-03-30"
+excerpt: "Aprende qué es el rebase en Git, cuándo usarlo en lugar de merge, cómo resolver conflictos durante el proceso y la regla de oro que nunca debes romper."
+language: "es"
+categories: ["git"]
+course: "domina-git-desde-cero"
+order: 19
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "rewriting-history-git-rebase"
+---
+
+Imagina que llevas tres días trabajando en una nueva feature en tu rama `feature/login`. Mientras tanto, alguien ha hecho cuatro commits en `master` que afectan a partes del código con las que necesitas trabajar. Cuando llegue el momento de integrar tu trabajo, el historial va a parecer un espagueti de merges que nadie va a querer leer.
+
+Existe una alternativa más limpia: `git rebase`. Una herramienta que reescribe la historia para que todo parezca haber ocurrido en orden, sin los nudos que deja el merge. Pero con un poder así vienen responsabilidades, y hay una regla que si rompes vas a hacer sufrir mucho a tus compañeros de equipo.
+
+## Qué es el rebase
+
+Para entender el rebase hay que tener claro qué hace el merge. Cuando haces `git merge master` desde tu rama `feature`, Git crea un nuevo **commit de merge** que une los dos historiales. El resultado es funcional pero el historial queda ramificado, con dos líneas que convergen en un punto.
+
+El rebase hace algo diferente. Literalmente **recoloca tus commits** encima de la rama destino. Es como si hubieras empezado tu trabajo hoy, después de los últimos cambios de `master`, aunque en realidad lo empezaste hace tres días.
+
+Una analogía: imagina que escribes un informe mientras tu jefe va modificando el borrador base. Con merge, tu versión y la de tu jefe se fusionan en un documento final con marcas de combinación. Con rebase, es como si hubieras leído el borrador actualizado de tu jefe antes de empezar a escribir tu parte. El resultado es más limpio, la autoría más clara.
+
+## Cómo funciona git rebase
+
+La mecánica es la siguiente. Tienes esta situación:
+
+```
+      A---B---C  feature
+     /
+D---E---F---G    master
+```
+
+Los commits `A`, `B` y `C` son los tuyos en `feature`. Los commits `F` y `G` llegaron a `master` mientras trabajabas.
+
+Cuando haces:
+
+```bash
+git switch feature
+git rebase master
+```
+
+Git hace tres cosas en orden:
+
+1. Encuentra el punto común entre `feature` y `master` (el commit `E`)
+2. Guarda temporalmente tus commits (`A`, `B`, `C`) como parches
+3. Los reaplicar uno a uno encima de `G`, el último commit de `master`
+
+El resultado:
+
+```
+              A'--B'--C'  feature
+             /
+D---E---F---G             master
+```
+
+Los commits `A'`, `B'` y `C'` son nuevos commits (con nuevos hashes) que contienen los mismos cambios que `A`, `B` y `C`, pero aplicados sobre `G`. El historial queda **lineal**.
+
+## La regla de oro del rebase
+
+⚠️ **Nunca hagas rebase de commits que ya están en una rama pública.**
+
+Esta es la regla más importante y la que más gente rompe cuando está aprendiendo. El motivo es técnico pero la consecuencia es muy concreta.
+
+El rebase crea commits nuevos. Aunque el contenido es el mismo, los hashes cambian. Si otras personas tienen clonados esos commits en sus máquinas y tú los reescribes con rebase, cuando intenten hacer pull van a encontrarse con un historial incompatible. Vas a crear un caos de commits duplicados y conflictos que son muy difíciles de deshacer.
+
+La regla práctica es sencilla: **solo haz rebase en ramas que son únicamente tuyas**. Tu `feature` branch local que nadie más ha tocado: sí. `master`, `develop`, o cualquier rama que hayan clonado tus compañeros: nunca.
+
+## Rebase básico: actualizar tu rama con los cambios de master
+
+El caso más habitual es querer poner tu rama al día con los últimos cambios de `master` antes de abrir un pull request. El workflow es:
+
+```bash
+# First, make sure master is up to date
+git switch master
+git pull
+
+# Then rebase your feature branch on top of master
+git switch feature/login
+git rebase master
+```
+
+Si no hay conflictos, Git reaplica tus commits automáticamente y listo:
+
+```
+Successfully rebased and updated refs/heads/feature/login.
+```
+
+Tu rama `feature/login` ahora parte desde el último commit de `master`. Cuando hagas el merge o el pull request, será un **fast-forward limpio** sin commit de merge.
+
+## Resolviendo conflictos durante el rebase
+
+A veces Git no puede reaplicar un commit automáticamente porque hay conflictos. En ese caso se detiene y te avisa:
+
+```
+Auto-merging src/auth/login.ts
+CONFLICT (content): Merge conflict in src/auth/login.ts
+error: could not apply a1b2c3d... Add login validation
+hint: Resolve all conflicts manually, mark them as resolved with
+hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
+hint: You can instead skip this commit: run "git rebase --skip".
+hint: To abort and get back to the original state, run "git rebase --abort".
+```
+
+El proceso para resolver es:
+
+1. **Edita el archivo** con el conflicto y elige qué código conservar
+2. **Marca el conflicto como resuelto**:
+
+```bash
+git add src/auth/login.ts
+```
+
+3. **Continúa el rebase**:
+
+```bash
+git rebase --continue
+```
+
+Git aplicará el siguiente commit y así sucesivamente hasta terminar. Si en algún momento te pierdes o decides que no merece la pena seguir, tienes la salida de emergencia:
+
+```bash
+git rebase --abort
+```
+
+Esto devuelve tu rama exactamente al estado en que estaba antes de empezar el rebase. Como si no hubiera pasado nada.
+
+## Rebase vs merge: cuándo usar cada uno
+
+No existe una respuesta absoluta. Depende del contexto y de las convenciones de tu equipo. Pero hay una heurística útil:
+
+| Situación                                | Recomendación                                |
+| ---------------------------------------- | -------------------------------------------- |
+| Actualizar tu rama local con `master`    | **Rebase** — historial más limpio            |
+| Integrar una feature terminada en `main` | **Merge** — preserva el contexto del trabajo |
+| Ramas compartidas con el equipo          | **Merge** — nunca rebase                     |
+| Preparar commits para un PR limpio       | **Rebase** — ideal                           |
+| Rama con muchos commits pequeños "WIP"   | Rebase interactivo (siguiente lección)       |
+
+La filosofía detrás del rebase es: _el historial debería contar la historia del proyecto, no la historia de cómo lo desarrollaste_. Hay equipos que prefieren ver exactamente cómo evolucionó el trabajo, y para ellos el merge es más honesto. Otros prefieren un historial lineal y limpio que sea fácil de leer. Ninguna postura es incorrecta.
+
+## Comprobando el resultado
+
+Después de un rebase exitoso, puedes verificar que tu historial es lineal con:
+
+```bash
+git log --oneline --graph
+```
+
+Algo así:
+
+```
+* c3d4e5f (HEAD -> feature/login) Add remember me option
+* b2c3d4e Add password validation
+* a1b2c3d Add login form
+* 9f8e7d6 (master) Fix user session timeout
+* 8e7d6c5 Add user profile page
+* 7d6c5b4 Initial commit
+```
+
+Lineal, limpio, fácil de leer. Cada commit de tu feature aplicado sobre el último estado de `master`.
+
+---
+
+El rebase es una de esas herramientas que al principio da un poco de vértigo porque "reescribe la historia", pero cuando la dominas y la usas en el contexto correcto se convierte en parte natural del workflow. La clave es interiorizar la regla de oro: ramas propias y locales, sí; ramas públicas y compartidas, nunca.
+
+En la siguiente lección veremos el **rebase interactivo** (`git rebase -i`), una variante que te permite reorganizar, combinar y editar commits individuales de tu rama antes de integrarlos. Es la herramienta perfecta para limpiar esos commits "fix typo" y "wip wip" antes de que queden en el historial para siempre.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/rewriting-history-git-rebase.mdx
+++ b/src/content/tutorials/rewriting-history-git-rebase.mdx
@@ -1,0 +1,171 @@
+---
+title: "Rewriting History with git rebase"
+post_slug: "rewriting-history-git-rebase"
+date: "2026-03-30"
+excerpt: "Learn what rebase is in Git, when to use it instead of merge, how to resolve conflicts during the process, and the golden rule you must never break."
+language: "en"
+categories: ["git"]
+course: "mastering-git-from-scratch"
+order: 19
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "reescribiendo-historial-git-rebase"
+---
+
+Imagine you've spent three days working on a new feature in your `feature/login` branch. Meanwhile, someone has pushed four commits to `master` that touch parts of the code you're working with. When the time comes to integrate your work, the history is going to look like a plate of spaghetti that nobody wants to untangle.
+
+There's a cleaner alternative: `git rebase`. A tool that rewrites history so everything appears to have happened in a straight line, without the knots that merge leaves behind. But with great power comes responsibility, and there's one rule that, if broken, will make your teammates' lives miserable.
+
+## What is rebase?
+
+To understand rebase, you first need to be clear on what merge does. When you run `git merge master` from your `feature` branch, Git creates a new **merge commit** that joins the two histories. The result works, but the history is branched — two lines converging at a point.
+
+Rebase does something different. It literally **replays your commits** on top of the target branch. It's as if you started your work today, after all the latest changes to `master`, even though you actually started three days ago.
+
+An analogy: imagine you're writing a report while your manager keeps updating the base draft. With merge, your version and your manager's version are combined into a final document with merge markers. With rebase, it's as if you had read your manager's updated draft before you started writing your section. The result is cleaner, the authorship clearer.
+
+## How git rebase works
+
+Here's the mechanics. You have this situation:
+
+```
+      A---B---C  feature
+     /
+D---E---F---G    master
+```
+
+Commits `A`, `B`, and `C` are yours on `feature`. Commits `F` and `G` arrived on `master` while you were working.
+
+When you run:
+
+```bash
+git switch feature
+git rebase master
+```
+
+Git does three things in order:
+
+1. Finds the common ancestor between `feature` and `master` (commit `E`)
+2. Temporarily saves your commits (`A`, `B`, `C`) as patches
+3. Replays them one by one on top of `G`, the latest commit on `master`
+
+The result:
+
+```
+              A'--B'--C'  feature
+             /
+D---E---F---G             master
+```
+
+Commits `A'`, `B'`, and `C'` are new commits (with new hashes) that contain the same changes as `A`, `B`, and `C`, but applied on top of `G`. The history is **linear**.
+
+## The golden rule of rebase
+
+⚠️ **Never rebase commits that have already been pushed to a public branch.**
+
+This is the most important rule and the one most people break when they're learning. The reason is technical, but the consequence is very concrete.
+
+Rebase creates new commits. Even though the content is the same, the hashes change. If other people have cloned those commits and you rewrite them with rebase, when they try to pull they'll find an incompatible history. You'll create a mess of duplicate commits and conflicts that are very hard to undo.
+
+The practical rule is simple: **only rebase branches that are exclusively yours**. Your local `feature` branch that nobody else has touched: yes. `master`, `develop`, or any branch your teammates have cloned: never.
+
+## Basic rebase: updating your branch with master's changes
+
+The most common case is wanting to bring your branch up to date with the latest changes from `master` before opening a pull request. The workflow:
+
+```bash
+# First, make sure master is up to date
+git switch master
+git pull
+
+# Then rebase your feature branch on top of master
+git switch feature/login
+git rebase master
+```
+
+If there are no conflicts, Git replays your commits automatically and you're done:
+
+```
+Successfully rebased and updated refs/heads/feature/login.
+```
+
+Your `feature/login` branch now starts from the latest commit on `master`. When you merge or open a pull request, it will be a clean **fast-forward** with no merge commit.
+
+## Resolving conflicts during rebase
+
+Sometimes Git can't replay a commit automatically because there are conflicts. In that case it stops and tells you:
+
+```
+Auto-merging src/auth/login.ts
+CONFLICT (content): Merge conflict in src/auth/login.ts
+error: could not apply a1b2c3d... Add login validation
+hint: Resolve all conflicts manually, mark them as resolved with
+hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
+hint: You can instead skip this commit: run "git rebase --skip".
+hint: To abort and get back to the original state, run "git rebase --abort".
+```
+
+The process to resolve:
+
+1. **Edit the file** with the conflict and choose which code to keep
+2. **Mark the conflict as resolved**:
+
+```bash
+git add src/auth/login.ts
+```
+
+3. **Continue the rebase**:
+
+```bash
+git rebase --continue
+```
+
+Git will apply the next commit and so on until it's done. If you get lost at any point or decide it's not worth continuing, you have an escape hatch:
+
+```bash
+git rebase --abort
+```
+
+This returns your branch exactly to the state it was in before you started the rebase. As if nothing happened.
+
+## Rebase vs merge: when to use each
+
+There's no absolute answer. It depends on context and your team's conventions. But there's a useful heuristic:
+
+| Situation                                  | Recommendation                                |
+| ------------------------------------------ | --------------------------------------------- |
+| Updating your local branch with `master`   | **Rebase** — cleaner history                  |
+| Integrating a finished feature into `main` | **Merge** — preserves the context of the work |
+| Shared branches with the team              | **Merge** — never rebase                      |
+| Preparing commits for a clean PR           | **Rebase** — ideal                            |
+| Branch with many small "WIP" commits       | Interactive rebase (next lesson)              |
+
+The philosophy behind rebase is: _history should tell the story of the project, not the story of how you developed it_. Some teams prefer to see exactly how the work evolved, and for them merge is more honest. Others prefer a linear, clean history that's easy to read. Neither stance is wrong.
+
+## Checking the result
+
+After a successful rebase, you can verify that your history is linear with:
+
+```bash
+git log --oneline --graph
+```
+
+Something like:
+
+```
+* c3d4e5f (HEAD -> feature/login) Add remember me option
+* b2c3d4e Add password validation
+* a1b2c3d Add login form
+* 9f8e7d6 (master) Fix user session timeout
+* 8e7d6c5 Add user profile page
+* 7d6c5b4 Initial commit
+```
+
+Linear, clean, easy to read. Each of your feature commits applied on top of the latest state of `master`.
+
+---
+
+Rebase is one of those tools that feels a little dizzying at first because it "rewrites history," but once you master it and use it in the right context, it becomes a natural part of your workflow. The key is to internalize the golden rule: your own local branches, yes; public and shared branches, never.
+
+In the next lesson we'll look at **interactive rebase** (`git rebase -i`), a variant that lets you reorganize, combine, and edit individual commits in your branch before integrating them. It's the perfect tool for cleaning up those "fix typo" and "wip wip" commits before they end up in the history forever.
+
+Never stop coding!


### PR DESCRIPTION
## Summary

- Adds ES tutorial: `reescribiendo-historial-git-rebase.mdx` (Lesson 22, PublishOrder 19, course `domina-git-desde-cero`)
- Adds EN tutorial: `rewriting-history-git-rebase.mdx` — i18n pair
- Covers `git rebase`, the golden rule, conflict resolution, and rebase vs merge comparison