### PR TITLE
feat(tutorials): add Docker L1 — installing Docker and first container (ES + EN)

### DIFF
--- a/src/content/tutorials/instalando-docker-primer-contenedor.mdx
+++ b/src/content/tutorials/instalando-docker-primer-contenedor.mdx
@@ -1,0 +1,233 @@
+---
+title: "Instalando Docker y lanzando tu primer contenedor"
+post_slug: "instalando-docker-primer-contenedor"
+date: "2026-04-01"
+excerpt: "Instala Docker en Linux, macOS o Windows y ejecuta tu primer contenedor. Arquitectura del sistema, comandos básicos y el ritual de iniciación que es docker run hello-world."
+language: "es"
+categories: ["docker"]
+course: "domina-docker-desde-cero"
+order: 2
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "installing-docker-first-container"
+---
+
+Toda herramienta tiene su momento de iniciación. Con Git es `git init`. Con Node es `npm install` y esperar a que `node_modules` se trague la mitad del disco. Con Docker es un comando que lleva años siendo la primera línea de cualquier tutorial que se precie:
+
+```bash
+docker run hello-world
+```
+
+Es ridículamente simple para lo que hace por debajo. Cuando ejecutas ese comando por primera vez, Docker descarga una imagen desde internet, crea un contenedor, lo ejecuta, imprime un mensaje y lo destruye. Todo en cuestión de segundos. No has configurado nada. No has escrito ningún Dockerfile. Y sin embargo, acabas de recorrer el ciclo completo de vida de un contenedor.
+
+Pero antes de llegar ahí, hay que instalar la herramienta.
+
+## Docker Desktop vs Docker Engine: ¿cuál instalo?
+
+Esta es la primera bifurcación con la que te vas a encontrar, y conviene tenerla clara desde el principio.
+
+**Docker Engine** es el motor puro: el demonio que gestiona contenedores, sin interfaz gráfica, pensado para servidores Linux y para gente que prefiere vivir en la terminal. Es el que usarás en producción.
+
+**Docker Desktop** es una aplicación de escritorio que incluye Docker Engine, una interfaz gráfica, y una capa de compatibilidad para que Docker funcione en macOS y Windows (donde no hay kernel Linux nativo). Incluye también Docker Compose y algunas herramientas extra.
+
+La regla práctica:
+
+- **Linux**: instala Docker Engine directamente. Docker Desktop existe para Linux pero añade una capa de virtualización innecesaria.
+- **macOS**: Docker Desktop es la opción estándar y la más sencilla.
+- **Windows**: Docker Desktop con WSL2. Sin WSL, el dolor es considerable (porque Windows, ya sabes).
+
+## Instalación en Linux
+
+Linux es el entorno nativo de Docker, así que aquí la instalación es más directa. Los usuarios de Arch ya saben el drill — un `pacman -S docker` y listo. Para el resto, el método más fiable y que funciona en Ubuntu, Debian, Fedora y la mayoría de distros derivadas es el script oficial:
+
+```bash
+# Download and run the official install script
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+```
+
+El script detecta tu distribución y configura los repositorios correctos automáticamente. Una vez instalado, hay un paso que la mayoría olvida y que causa el primer "¿por qué me dice permission denied?":
+
+```bash
+# Add your user to the docker group
+sudo usermod -aG docker $USER
+
+# Apply group change immediately (or log out and back in)
+newgrp docker
+```
+
+Sin este paso, necesitarás `sudo` para cada comando Docker. Técnicamente funciona, pero es incómodo y va en contra de cómo está pensado el flujo de trabajo.
+
+Verifica que todo está en orden:
+
+```bash
+docker --version
+```
+
+```
+Docker version 27.4.1, build f31f73a
+```
+
+```bash
+docker info
+```
+
+`docker info` te devuelve el estado del demonio: cuántos contenedores hay corriendo, cuántas imágenes tienes descargadas, la versión del kernel, el driver de almacenamiento. Si ves todo eso sin errores, el motor está funcionando.
+
+## Instalación en macOS
+
+Aquí tienes dos caminos. El más cómodo para la mayoría es Docker Desktop:
+
+```bash
+# Via Homebrew (recommended)
+brew install --cask docker
+```
+
+O descarga directamente desde [docker.com](https://docker.com). Una vez instalado, abre Docker Desktop desde Applications. Verás el icono de la ballena en la barra de menú — cuando deja de moverse significa que el motor está listo.
+
+La alternativa minimalista, si prefieres no tener la interfaz gráfica, es [OrbStack](https://orbstack.dev): más ligero, más rápido en arrancar, y perfectamente compatible con todos los comandos Docker estándar. Cada vez más gente en macOS lo usa en lugar de Docker Desktop.
+
+## Instalación en Windows (WSL2)
+
+Windows necesita WSL2 (Windows Subsystem for Linux) como base. Si aún no lo tienes:
+
+```powershell
+# Run in PowerShell as Administrator
+wsl --install
+```
+
+Reinicia, y después instala Docker Desktop desde [docker.com](https://docker.com). Durante la instalación, asegúrate de que la opción "Use WSL 2 based engine" está marcada.
+
+⚠️ **Importante**: si tienes WSL1 instalado de antes, actualiza a WSL2 primero. Docker funciona con WSL1, pero el rendimiento es notablemente peor y te encontrarás con comportamientos extraños.
+
+## La arquitectura de Docker (lo que pasa cuando escribes un comando)
+
+Antes de ejecutar ese primer contenedor, vale la pena entender lo que hay detrás. Cuando escribes `docker run nginx`, no estás simplemente lanzando un proceso. Hay tres piezas hablando entre sí:
+
+**Docker Client** (el CLI): la herramienta que usas en la terminal. Convierte tus comandos en llamadas a la API REST del demonio. Es solo un cliente — no hace el trabajo pesado.
+
+**Docker Daemon** (`dockerd`): el proceso que realmente gestiona contenedores, imágenes, redes y volúmenes. Corre en segundo plano. Cuando ejecutas `docker run`, el cliente le dice al demonio "lanza este contenedor", y el demonio lo hace.
+
+**Docker Registry**: el repositorio de imágenes. [Docker Hub](https://hub.docker.com) es el registro público por defecto. Cuando pides una imagen que no tienes localmente, el demonio la descarga de ahí.
+
+```
+[docker CLI] → API REST → [dockerd] → descarga de [Docker Hub]
+                                    → crea el contenedor
+                                    → gestiona su ciclo de vida
+```
+
+Este modelo cliente-servidor tiene una implicación práctica: puedes conectar el cliente Docker de tu máquina a un demonio que corre en otro servidor remoto. Útil para gestionar producción desde tu terminal.
+
+## Imágenes vs contenedores: el molde y las piezas
+
+Esta distinción es fundamental y vale la pena fijarla bien desde el principio, porque genera confusión si se mezclan los dos conceptos.
+
+Una **imagen** es una plantilla de solo lectura. Define qué sistema operativo base usar, qué software instalar, qué archivos copiar, qué comandos ejecutar al arrancar. Es inmutable — no cambia. Puedes pensar en ella como una clase en programación orientada a objetos, o como un molde de galletas.
+
+Un **contenedor** es una instancia en ejecución de una imagen. Es lo que realmente corre, lo que consume CPU y RAM, lo que tiene su propio sistema de archivos y su propia red. Puedes crear diez contenedores a partir de la misma imagen — diez galletas del mismo molde, cada una independiente de las demás.
+
+Cuando un contenedor termina, desaparece (salvo que le hayas dicho explícitamente que persista datos). La imagen sigue ahí, lista para crear más contenedores.
+
+## Tu primer contenedor
+
+Con Docker instalado, el momento de verdad:
+
+```bash
+docker run hello-world
+```
+
+```
+Hello from Docker!
+This message shows that your installation appears to be working correctly.
+
+To generate this message, Docker took the following steps:
+ 1. The Docker client contacted the Docker daemon.
+ 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
+ 3. The Docker daemon created a new container from that image which runs the
+    executable that produces the output you are currently reading.
+ 4. The Docker daemon streamed that output to the Docker client, which sent it
+    to your terminal.
+```
+
+El propio mensaje te explica lo que acaba de pasar. La primera vez tarda un momento porque descarga la imagen. La segunda vez es instantáneo — la imagen ya está en caché local.
+
+Ahora algo un poco más interesante: un contenedor interactivo.
+
+```bash
+docker run -it ubuntu bash
+```
+
+```
+root@a3f8c2b1d9e7:/#
+```
+
+¿Sensación extraña? Normal. Acabas de abrir una shell dentro de un contenedor Ubuntu completamente aislado de tu sistema. Puedes instalar cosas, borrar archivos, romper todo lo que quieras — cuando salgas, el contenedor desaparece y tu máquina queda intacta.
+
+```bash
+# Inside the container
+cat /etc/os-release
+ls /
+whoami  # root (containers run as root by default — we'll fix this later)
+exit
+```
+
+Y el clásico servidor web:
+
+```bash
+# Run Nginx in the background, mapping port 8080 on your machine to port 80 in the container
+docker run -d -p 8080:80 --name my-nginx nginx
+```
+
+Abre el navegador en `http://localhost:8080`. Tienes un servidor Nginx corriendo en un contenedor, sin haber instalado nada en tu sistema. Cuando acabes:
+
+```bash
+docker stop my-nginx
+docker rm my-nginx
+```
+
+## Los comandos básicos
+
+No hace falta memorizar todo esto ahora — lo irás interiorizando con el uso. Pero tenerlo de referencia viene bien:
+
+```bash
+docker pull <image>        # Download image from registry
+docker images              # List locally available images
+docker run <image>         # Create and start a container
+docker ps                  # List running containers
+docker ps -a               # List all containers (including stopped)
+docker stop <container>    # Stop a container (SIGTERM)
+docker start <container>   # Start a stopped container
+docker rm <container>      # Remove a stopped container
+docker rmi <image>         # Remove an image
+docker logs <container>    # View container output
+docker exec -it <container> bash  # Open shell in running container
+```
+
+Un truco útil: `docker run --rm` elimina el contenedor automáticamente cuando termina. Perfecto para pruebas rápidas donde no te importa persistir nada.
+
+```bash
+# Container disappears automatically when you exit
+docker run --rm -it ubuntu bash
+```
+
+## Limpiar lo que has descargado
+
+Después de experimentar, es normal que hayas acumulado imágenes y contenedores parados. Para hacer limpieza:
+
+```bash
+# Remove all stopped containers
+docker container prune
+
+# Remove unused images
+docker image prune
+
+# Remove everything unused (containers, images, networks, build cache)
+docker system prune
+```
+
+⚠️ `docker system prune` es agresivo — te preguntará confirmación, pero elimina todo lo que no esté en uso activo. Úsalo con cabeza.
+
+---
+
+Tienes Docker instalado y has ejecutado tus primeros contenedores. En la próxima lección profundizaremos en la relación entre imágenes y contenedores: qué son las capas de una imagen, cómo funciona el ciclo de vida completo de un contenedor, y cómo inspeccionar y gestionar todo lo que tienes corriendo.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/installing-docker-first-container.mdx
+++ b/src/content/tutorials/installing-docker-first-container.mdx
@@ -1,0 +1,233 @@
+---
+title: "Installing Docker and running your first container"
+post_slug: "installing-docker-first-container"
+date: "2026-04-01"
+excerpt: "Install Docker on Linux, macOS, or Windows and run your first container. Docker's architecture, the image vs container distinction, and the essential commands to get started."
+language: "en"
+categories: ["docker"]
+course: "mastering-docker-from-scratch"
+order: 2
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "instalando-docker-primer-contenedor"
+---
+
+Every tool has its initiation ritual. With Git it's `git init`. With Node it's `npm install` and watching `node_modules` devour half your disk. With Docker, it's a command that's been the opening line of every tutorial for years:
+
+```bash
+docker run hello-world
+```
+
+It looks trivially simple. But what it does under the hood is anything but: Docker downloads an image from the internet, creates a container, runs it, prints a message, and destroys it — all in seconds. No Dockerfile. No configuration. And yet you've just completed the full container lifecycle.
+
+Before you get there, though, you need to install the thing.
+
+## Docker Desktop vs Docker Engine: which one?
+
+The first fork in the road, and worth understanding upfront.
+
+**Docker Engine** is the raw engine: the daemon that manages containers, no GUI, built for Linux servers and people who live in the terminal. This is what you'll run in production.
+
+**Docker Desktop** is a desktop application that bundles Docker Engine, a graphical interface, and a compatibility layer that makes Docker work on macOS and Windows (which don't have a native Linux kernel). It also includes Docker Compose and a few extra tools.
+
+The practical rule:
+
+- **Linux**: install Docker Engine directly. Docker Desktop exists for Linux but adds an unnecessary virtualization layer.
+- **macOS**: Docker Desktop is the standard choice and the simplest path.
+- **Windows**: Docker Desktop with WSL2. Without WSL, the pain is real (because Windows).
+
+## Installation on Linux
+
+Linux is Docker's native environment, so installation is the most straightforward here. Arch users already know the drill — `pacman -S docker` and done. For everyone else, the most reliable method that works across Ubuntu, Debian, Fedora, and most derivatives is the official script:
+
+```bash
+# Download and run the official install script
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+```
+
+The script detects your distribution and configures the right repositories automatically. Once installed, there's one step most people miss, and it causes the classic "why am I getting permission denied?" moment:
+
+```bash
+# Add your user to the docker group
+sudo usermod -aG docker $USER
+
+# Apply the group change immediately (or log out and back in)
+newgrp docker
+```
+
+Without this, you'll need `sudo` for every Docker command. Technically it works, but it's annoying and goes against how the workflow is meant to feel.
+
+Verify everything is working:
+
+```bash
+docker --version
+```
+
+```
+Docker version 27.4.1, build f31f73a
+```
+
+```bash
+docker info
+```
+
+`docker info` shows you the daemon's state: how many containers are running, how many images you have locally, the kernel version, the storage driver. If you see all that without errors, the engine is running.
+
+## Installation on macOS
+
+Two options. The most comfortable for most people is Docker Desktop:
+
+```bash
+# Via Homebrew (recommended)
+brew install --cask docker
+```
+
+Or download directly from [docker.com](https://docker.com). Once installed, open Docker Desktop from Applications. You'll see the whale icon in the menu bar — when it stops animating, the engine is ready.
+
+The minimalist alternative, if you'd rather skip the GUI, is [OrbStack](https://orbstack.dev): lighter, faster to start, and fully compatible with all standard Docker commands. More and more people on macOS are using it instead of Docker Desktop.
+
+## Installation on Windows (WSL2)
+
+Windows needs WSL2 (Windows Subsystem for Linux) as its foundation. If you don't have it yet:
+
+```powershell
+# Run in PowerShell as Administrator
+wsl --install
+```
+
+Restart, then install Docker Desktop from [docker.com](https://docker.com). During installation, make sure "Use WSL 2 based engine" is checked.
+
+⚠️ **Important**: if you have WSL1 installed from before, upgrade to WSL2 first. Docker works with WSL1, but the performance is noticeably worse and you'll hit weird edge cases.
+
+## Docker's architecture (what actually happens when you type a command)
+
+Before running that first container, it's worth understanding what's happening behind the scenes. When you type `docker run nginx`, you're not just launching a process. There are three pieces talking to each other:
+
+**Docker Client** (the CLI): the tool you use in the terminal. It converts your commands into REST API calls to the daemon. It's just a client — it doesn't do the heavy lifting.
+
+**Docker Daemon** (`dockerd`): the process that actually manages containers, images, networks, and volumes. It runs in the background. When you run `docker run`, the client tells the daemon "start this container", and the daemon does it.
+
+**Docker Registry**: the image repository. [Docker Hub](https://hub.docker.com) is the default public registry. When you request an image you don't have locally, the daemon downloads it from there.
+
+```
+[docker CLI] → REST API → [dockerd] → pulls from [Docker Hub]
+                                     → creates the container
+                                     → manages its lifecycle
+```
+
+This client-server model has a practical implication: you can point your local Docker client at a daemon running on a remote server. Useful for managing production from your terminal.
+
+## Images vs containers: the mold and the pieces
+
+This distinction is fundamental. Get it wrong and Docker will feel confusing forever. Get it right and everything clicks.
+
+An **image** is a read-only template. It defines which base OS to use, what software to install, what files to copy in, what command to run at startup. It's immutable — it doesn't change. Think of it like a class in object-oriented programming, or a cookie cutter.
+
+A **container** is a running instance of an image. It's what actually executes, what consumes CPU and RAM, what has its own isolated filesystem and its own network. You can create ten containers from the same image — ten cookies from the same cutter, each independent of the others.
+
+When a container stops, it's gone (unless you explicitly told it to persist data). The image stays, ready to create more containers.
+
+## Your first container
+
+With Docker installed, the moment of truth:
+
+```bash
+docker run hello-world
+```
+
+```
+Hello from Docker!
+This message shows that your installation appears to be working correctly.
+
+To generate this message, Docker took the following steps:
+ 1. The Docker client contacted the Docker daemon.
+ 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
+ 3. The Docker daemon created a new container from that image which runs the
+    executable that produces the output you are currently reading.
+ 4. The Docker daemon streamed that output to the Docker client, which sent it
+    to your terminal.
+```
+
+The message walks you through exactly what just happened. The first time it takes a moment because it's downloading the image. The second time it's instant — the image is cached locally.
+
+Now something a bit more interesting: an interactive container.
+
+```bash
+docker run -it ubuntu bash
+```
+
+```
+root@a3f8c2b1d9e7:/#
+```
+
+Feeling disoriented? That's expected. You just opened a shell inside a completely isolated Ubuntu container. You can install things, delete files, break whatever you want — when you exit, the container disappears and your machine is untouched.
+
+```bash
+# Inside the container
+cat /etc/os-release
+ls /
+whoami  # root (containers run as root by default — we'll address this later)
+exit
+```
+
+And the classic web server:
+
+```bash
+# Run Nginx in the background, mapping port 8080 on your machine to port 80 in the container
+docker run -d -p 8080:80 --name my-nginx nginx
+```
+
+Open your browser at `http://localhost:8080`. You have an Nginx server running in a container, without having installed anything on your system. When you're done:
+
+```bash
+docker stop my-nginx
+docker rm my-nginx
+```
+
+## The essential commands
+
+You don't need to memorize all of this now — it'll sink in through use. But having it as a reference helps:
+
+```bash
+docker pull <image>        # Download image from registry
+docker images              # List locally available images
+docker run <image>         # Create and start a container
+docker ps                  # List running containers
+docker ps -a               # List all containers (including stopped)
+docker stop <container>    # Stop a container (SIGTERM)
+docker start <container>   # Start a stopped container
+docker rm <container>      # Remove a stopped container
+docker rmi <image>         # Remove an image
+docker logs <container>    # View container output
+docker exec -it <container> bash  # Open shell in running container
+```
+
+One handy trick: `docker run --rm` removes the container automatically when it stops. Perfect for quick experiments where you don't care about persistence.
+
+```bash
+# Container disappears automatically when you exit
+docker run --rm -it ubuntu bash
+```
+
+## Cleaning up
+
+After experimenting, you'll have accumulated images and stopped containers. To clean house:
+
+```bash
+# Remove all stopped containers
+docker container prune
+
+# Remove unused images
+docker image prune
+
+# Remove everything unused (containers, images, networks, build cache)
+docker system prune
+```
+
+⚠️ `docker system prune` is aggressive — it will ask for confirmation, but it removes everything not actively in use. Use it deliberately.
+
+---
+
+Docker is installed, and you've run your first containers. In the next lesson, we'll go deeper into the image-container relationship: what image layers are, how the full container lifecycle works, and how to inspect and manage everything you have running.
+
+Never stop coding!


### PR DESCRIPTION
## Summary

- Adds Docker Lesson 1 tutorial in Spanish and English
- Covers Docker Desktop vs Docker Engine, installation on Linux/macOS/Windows, and running the first container with `docker run hello-world`
- Part of the *Domina Docker desde cero* course (order: 2, publish date: 2026-04-01)