### PR TITLE
feat(tutorials): add docker image/container relationship EN+ES tutorials

### DIFF
--- a/src/content/tutorials/docker-images-containers-relationship.mdx
+++ b/src/content/tutorials/docker-images-containers-relationship.mdx
@@ -1,0 +1,268 @@
+---
+title: "Docker images and containers: understanding the relationship"
+post_slug: "docker-images-containers-relationship"
+date: "2026-04-07"
+excerpt: "What exactly is a Docker image, how are layers stacked, and what happens to a container when it stops? The image-container relationship is the mental model everything else depends on."
+language: "en"
+categories: ["docker"]
+course: "mastering-docker-from-scratch"
+order: 3
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "relacion-imagenes-contenedores-docker"
+---
+
+You pulled `ubuntu`, you pulled `nginx`, you've been running containers and destroying them. But here's the thing — do you actually know what an image _is_? Not the one-liner ("a template"), but what's actually happening on your disk? Why does pulling `node:22` take a while the first time and almost nothing the second? Why can you run ten containers from the same image and none of them affect each other?
+
+If you got through lesson 2 with a vague intuition of how this works, this lesson is about turning that intuition into a mental model you can rely on. Because everything in Docker — Dockerfiles, image caching, volumes, multi-stage builds — makes a lot more sense once you understand what's happening underneath.
+
+## What is a Docker image, really?
+
+Let's start with what an image is _not_. It's not a file. It's not a zip archive. It's not a snapshot of a running system.
+
+A Docker image is a **stack of layers**. Each layer is a set of filesystem changes — files added, files modified, files deleted. When you stack them all together, you get a complete filesystem that a container can run. Think of it like a Git commit history: each commit (layer) describes what changed, and the full history gives you the current state of the project.
+
+This is called a **union filesystem** (OverlayFS is the most common implementation on Linux). Docker merges these read-only layers into a single coherent view, and that's what the container sees as its filesystem.
+
+Let's make it concrete. Imagine an image built like this:
+
+```
+Layer 1 (Base): Ubuntu 22.04 — adds ~80MB of OS files
+Layer 2: apt-get install python3 — adds Python interpreter
+Layer 3: pip install flask — adds Flask and its dependencies
+Layer 4: COPY app.py /app/ — adds your application code
+```
+
+Each layer only stores the diff from the previous one. And here's where it gets efficient: if you have ten different images that all start from `ubuntu:22.04`, they all share that first layer on disk. Docker doesn't download or store it ten times — it references the same layer. Pull a new image that shares base layers with something you already have, and Docker will say "already exists" for those layers.
+
+```bash
+docker pull python:3.12
+```
+
+```
+3.12: Pulling from library/python
+fa9b7e77b6bf: Already exists       ← base layers shared with other images
+48be9699aae1: Already exists
+...
+b0c4ce42c5d0: Pull complete        ← new layers specific to python:3.12
+Digest: sha256:...
+Status: Downloaded newer image for python:3.12
+```
+
+That's the layer cache doing its job.
+
+## Exploring layers
+
+You can inspect exactly what layers an image contains:
+
+```bash
+docker image inspect nginx
+```
+
+This dumps a large JSON object. The relevant section is `RootFS.Layers`, which lists the SHA256 hashes of each layer. You can also see a higher-level view with:
+
+```bash
+docker image history nginx
+```
+
+```
+IMAGE          CREATED        CREATED BY                                      SIZE
+a7be6198544f   2 weeks ago    CMD ["nginx" "-g" "daemon off;"]               0B
+<missing>      2 weeks ago    STOPSIGNAL SIGQUIT                             0B
+<missing>      2 weeks ago    EXPOSE 80                                      0B
+<missing>      2 weeks ago    COPY /etc/nginx /etc/nginx /                   4.61kB
+<missing>      2 weeks ago    RUN /bin/sh -c apt-get update && apt-get ...   91.4MB
+<missing>      2 weeks ago    ENV NGINX_VERSION=1.27.4                       0B
+<missing>      2 weeks ago    FROM debian:bookworm-slim                      0B
+```
+
+Read it bottom to top: start with the base `debian:bookworm-slim`, install packages, copy Nginx config, set the startup command. Each line is a layer (or a metadata instruction that adds 0 bytes).
+
+## Image tags: this is not optional knowledge
+
+When you run `docker pull nginx`, you're actually running `docker pull nginx:latest`. The `:latest` is a **tag**, and `latest` is the default. Tags are mutable pointers — today's `nginx:latest` is not the same image as `nginx:latest` from six months ago. It just points to the newest stable build.
+
+In production, you never use `latest`. You pin to a specific version:
+
+```bash
+docker pull nginx:1.27.4         # Specific patch version — deterministic
+docker pull nginx:1.27           # Minor version — gets patches
+docker pull nginx:1              # Major version — gets minor updates too
+docker pull nginx:latest         # ❌ Fine for local experiments, not for prod
+```
+
+Why? Because `latest` means your deployment changes every time you pull. Upgrading Nginx should be a deliberate decision, not a side effect of running `docker pull`.
+
+There's also a pattern you'll see often: **variant tags**. The same version with different base images:
+
+```bash
+nginx:1.27.4-alpine    # Alpine Linux base (~5MB), minimal, fast to pull
+nginx:1.27.4           # Debian base (~180MB), more compatible
+nginx:1.27.4-slim      # Reduced Debian, middle ground
+```
+
+Alpine is popular for production because of its tiny size. The tradeoff: it uses `musl libc` instead of `glibc`, which can cause subtle compatibility issues with some software. For most things it's fine; for others it's a frustrating debugging session (because C library mismatches).
+
+## The container lifecycle
+
+An image is static. A container is alive — and it has a lifecycle.
+
+When you run `docker run`, the container doesn't just appear in a running state. It goes through a series of states:
+
+```
+Created → Running → (Paused) → Stopped → Removed
+```
+
+**Created**: the container exists but hasn't started yet. You can do this explicitly with `docker create`, or it's an implicit step inside `docker run`.
+
+**Running**: the main process is executing. The container consumes CPU, RAM, and filesystem resources.
+
+**Paused**: the process is suspended (SIGSTOP). The container still exists in memory but isn't doing anything. `docker pause` and `docker unpause`. Rarely used, but useful for debugging — freeze a container in place and inspect its state.
+
+**Stopped**: the main process has exited. The container still exists as a stopped entity — its filesystem is preserved, its logs are still accessible. You can restart it with `docker start`.
+
+**Removed**: the container is gone. Filesystem, logs, everything. You can't bring it back.
+
+```bash
+# Walk through the lifecycle manually
+docker create --name demo nginx          # Created
+docker start demo                        # Running
+docker pause demo                        # Paused
+docker unpause demo                      # Running again
+docker stop demo                         # Stopped (SIGTERM → SIGKILL after 10s)
+docker rm demo                           # Removed
+```
+
+Or skip the ceremony and do everything at once:
+
+```bash
+docker run --rm nginx    # Creates, starts, and removes when done
+```
+
+## The writable layer: why containers don't modify images
+
+Here's a key detail that confuses people. If images are read-only, how can a container write files?
+
+When Docker creates a container from an image, it adds a **thin writable layer** on top of all the read-only image layers. This is where everything the container writes goes — log files, temporary data, any `apt-get install` you do inside the container. The image layers beneath are never touched.
+
+```
+┌─────────────────────────────┐
+│   Container writable layer  │  ← changes here only
+├─────────────────────────────┤
+│   Image layer 4 (app.py)    │  read-only
+├─────────────────────────────┤
+│   Image layer 3 (Flask)     │  read-only
+├─────────────────────────────┤
+│   Image layer 2 (Python)    │  read-only
+├─────────────────────────────┤
+│   Image layer 1 (Ubuntu)    │  read-only
+└─────────────────────────────┘
+```
+
+When the container is removed, the writable layer disappears with it. The image is exactly as it was. Start another container from the same image and you get a fresh writable layer — a clean slate.
+
+This is what makes containers **ephemeral by design**. They're not meant to be permanent homes for data. Anything you want to persist beyond a container's lifetime goes in a volume — but that's a topic for later in the course.
+
+## Ten containers, one image
+
+Let's make this tangible. You can have ten containers running from a single image simultaneously:
+
+```bash
+# Start ten nginx containers, each on a different port
+for i in $(seq 1 10); do
+  docker run -d -p "808${i}:80" --name "nginx-${i}" nginx
+done
+```
+
+```bash
+docker ps
+```
+
+```
+CONTAINER ID   IMAGE   COMMAND                  PORTS                  NAMES
+a1b2c3d4e5f6   nginx   "/docker-entrypoint.…"   0.0.0.0:8081->80/tcp   nginx-1
+b2c3d4e5f6a7   nginx   "/docker-entrypoint.…"   0.0.0.0:8082->80/tcp   nginx-2
+...
+```
+
+Each one is completely isolated. Writing to the filesystem of `nginx-1` doesn't affect `nginx-2`. They all share the read-only Nginx image layers. On disk, the overhead of ten containers is ten tiny writable layers — not ten full copies of Nginx.
+
+Clean up when done:
+
+```bash
+for i in $(seq 1 10); do
+  docker stop "nginx-${i}" && docker rm "nginx-${i}"
+done
+```
+
+Or more directly:
+
+```bash
+docker rm -f $(docker ps -aq --filter name=nginx-)
+```
+
+## Pulling, listing, and removing images
+
+A few commands you'll use constantly:
+
+```bash
+# Download an image without running it
+docker pull node:22-alpine
+
+# List all locally available images
+docker images
+```
+
+```
+REPOSITORY   TAG          IMAGE ID       CREATED        SIZE
+nginx        latest       a7be6198544f   2 weeks ago    192MB
+node         22-alpine    f7d2a4e85d2c   3 weeks ago    141MB
+ubuntu       22.04        3db8720ecbf5   4 weeks ago    77.9MB
+python       3.12         b3a18c9e2f1d   3 weeks ago    1.02GB
+```
+
+```bash
+# Remove an image (only works if no containers — running or stopped — reference it)
+docker rmi nginx
+
+# Force remove (also removes derived containers)
+docker rmi -f nginx
+
+# Remove all unused images
+docker image prune
+docker image prune -a    # Also removes images with no running containers (more aggressive)
+```
+
+⚠️ You can't remove an image while a container (even a stopped one) references it. Remove the container first, then the image.
+
+## Naming containers: don't skip this
+
+If you don't name your containers, Docker assigns random adjective-noun combinations (`ecstatic_hopper`, `confident_kepler`). Endearing, but useless for anything beyond a quick experiment.
+
+```bash
+# Always name your containers
+docker run -d --name web-server nginx
+docker run -d --name api-backend node:22-alpine node app.js
+docker run -d --name db-primary postgres:16
+```
+
+Named containers are easier to reference in every subsequent command:
+
+```bash
+docker logs web-server
+docker exec -it web-server bash
+docker stop web-server
+```
+
+And when you use Docker Compose (coming later), naming becomes even more important because services discover each other by name over Docker's internal network.
+
+---
+
+The image-container relationship is the foundation of everything Docker does. Layers explain the cache behavior, the efficiency of pulling images, and why modifying a container doesn't affect others sharing the same image. The lifecycle explains why containers are designed to be disposable — and why data persistence requires a different mechanism.
+
+In the next lesson we'll go hands-on with **interactive containers and exec**: running shells inside containers, copying files in and out, and understanding when to use `-it` vs `-d` and why the difference matters.
+
+Never stop coding!
+
+---
+
+**💡 Challenge**: Pull three different images (`nginx`, `node:22-alpine`, `python:3.12-slim`). Create two containers from `nginx`, stop one, remove the other. View the logs of the remaining container. Check what layers `nginx` and `python:3.12-slim` have in common using `docker image inspect`. Clean everything up with `docker system prune`.

--- a/src/content/tutorials/relacion-imagenes-contenedores-docker.mdx
+++ b/src/content/tutorials/relacion-imagenes-contenedores-docker.mdx
@@ -1,0 +1,268 @@
+---
+title: "Imágenes y contenedores en Docker: entendiendo la relación"
+post_slug: "relacion-imagenes-contenedores-docker"
+date: "2026-04-07"
+excerpt: "Qué es exactamente una imagen Docker, cómo se apilan las capas y qué pasa con un contenedor cuando se detiene. La relación imagen-contenedor es el modelo mental del que depende todo lo demás."
+language: "es"
+categories: ["docker"]
+course: "domina-docker-desde-cero"
+order: 3
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "docker-images-containers-relationship"
+---
+
+Llevas dos lecciones descargando imágenes, lanzando contenedores y destruyéndolos. Pero aquí hay una pregunta: ¿sabes realmente lo que _es_ una imagen? No la definición de manual ("una plantilla de solo lectura"), sino lo que está pasando en tu disco. ¿Por qué la primera vez que descargas `node:22` tarda un rato y la segunda es casi instantáneo? ¿Por qué puedes tener diez contenedores corriendo a partir de la misma imagen sin que se interfieran entre sí?
+
+Si saliste de la lección anterior con una intuición vaga de cómo funciona esto, esta lección está pensada para convertir esa intuición en un modelo mental sólido. Porque todo lo que viene después en este curso — Dockerfiles, caché de builds, volúmenes, builds multi-stage — tiene mucho más sentido cuando entiendes lo que hay debajo.
+
+## Qué es realmente una imagen Docker
+
+Empecemos por lo que una imagen _no_ es. No es un archivo. No es un zip. No es una instantánea de un sistema en marcha.
+
+Una imagen Docker es una **pila de capas**. Cada capa es un conjunto de cambios en el sistema de archivos — archivos añadidos, modificados, eliminados. Cuando las apilas todas, obtienes un sistema de archivos completo que un contenedor puede ejecutar. Piénsalo como el historial de commits de Git: cada commit (capa) describe qué cambió, y la historia completa te da el estado actual del proyecto.
+
+A esto se le llama **union filesystem** (en Linux la implementación más común es OverlayFS). Docker fusiona estas capas de solo lectura en una vista coherente única, y eso es lo que el contenedor ve como su sistema de archivos.
+
+Para que sea concreto, imagina una imagen construida así:
+
+```
+Capa 1 (Base): Ubuntu 22.04 — añade ~80MB de archivos del SO
+Capa 2: apt-get install python3 — añade el intérprete de Python
+Capa 3: pip install flask — añade Flask y sus dependencias
+Capa 4: COPY app.py /app/ — añade el código de tu aplicación
+```
+
+Cada capa almacena solo el diff respecto a la anterior. Y aquí viene lo eficiente: si tienes diez imágenes distintas que todas parten de `ubuntu:22.04`, todas comparten esa primera capa en disco. Docker no la descarga ni la almacena diez veces — referencia la misma capa. Descarga una imagen nueva que comparte capas base con algo que ya tienes, y Docker dirá "already exists" para esas capas.
+
+```bash
+docker pull python:3.12
+```
+
+```
+3.12: Pulling from library/python
+fa9b7e77b6bf: Already exists       ← capas base compartidas con otras imágenes
+48be9699aae1: Already exists
+...
+b0c4ce42c5d0: Pull complete        ← capas nuevas específicas de python:3.12
+Digest: sha256:...
+Status: Downloaded newer image for python:3.12
+```
+
+Eso es la caché de capas haciendo su trabajo.
+
+## Explorando las capas
+
+Puedes inspeccionar exactamente qué capas tiene una imagen:
+
+```bash
+docker image inspect nginx
+```
+
+Esto devuelve un JSON enorme. La sección relevante es `RootFS.Layers`, que lista los hashes SHA256 de cada capa. También puedes ver una vista más legible con:
+
+```bash
+docker image history nginx
+```
+
+```
+IMAGE          CREATED        CREATED BY                                      SIZE
+a7be6198544f   2 weeks ago    CMD ["nginx" "-g" "daemon off;"]               0B
+<missing>      2 weeks ago    STOPSIGNAL SIGQUIT                             0B
+<missing>      2 weeks ago    EXPOSE 80                                      0B
+<missing>      2 weeks ago    COPY /etc/nginx /etc/nginx /                   4.61kB
+<missing>      2 weeks ago    RUN /bin/sh -c apt-get update && apt-get ...   91.4MB
+<missing>      2 weeks ago    ENV NGINX_VERSION=1.27.4                       0B
+<missing>      2 weeks ago    FROM debian:bookworm-slim                      0B
+```
+
+Léelo de abajo hacia arriba: empieza con la base `debian:bookworm-slim`, instala paquetes, copia la configuración de Nginx, define el comando de inicio. Cada línea es una capa (o una instrucción de metadatos que no añade bytes).
+
+## Tags de imagen: esto no es conocimiento opcional
+
+Cuando ejecutas `docker pull nginx`, en realidad estás ejecutando `docker pull nginx:latest`. El `:latest` es un **tag**, y `latest` es el valor por defecto. Los tags son punteros mutables — el `nginx:latest` de hoy no es la misma imagen que el `nginx:latest` de hace seis meses. Solo apunta a la build estable más reciente.
+
+En producción, nunca usas `latest`. Fijas una versión concreta:
+
+```bash
+docker pull nginx:1.27.4         # Versión exacta — determinista
+docker pull nginx:1.27           # Versión menor — recibe parches
+docker pull nginx:1              # Versión mayor — recibe actualizaciones menores
+docker pull nginx:latest         # ❌ Bien para experimentos locales, no para prod
+```
+
+¿Por qué? Porque `latest` significa que tu despliegue cambia cada vez que haces `docker pull`. Actualizar Nginx debería ser una decisión deliberada, no un efecto secundario de sincronizar imágenes.
+
+También verás un patrón habitual: **tags de variante**. La misma versión con diferentes imágenes base:
+
+```bash
+nginx:1.27.4-alpine    # Base Alpine Linux (~5MB), mínima, rápida de descargar
+nginx:1.27.4           # Base Debian (~180MB), mayor compatibilidad
+nginx:1.27.4-slim      # Debian reducido, punto intermedio
+```
+
+Alpine es popular en producción por su tamaño diminuto. El trade-off: usa `musl libc` en lugar de `glibc`, lo que puede causar problemas de compatibilidad sutiles con cierto software. Para la mayoría de cosas va perfecto; para otras es una sesión de debugging bastante frustrante (diferencias entre librerías de C, ya sabes cómo va eso).
+
+## El ciclo de vida de un contenedor
+
+Una imagen es estática. Un contenedor está vivo — y tiene un ciclo de vida.
+
+Cuando ejecutas `docker run`, el contenedor no aparece directamente en estado de ejecución. Pasa por una serie de estados:
+
+```
+Created → Running → (Paused) → Stopped → Removed
+```
+
+**Created**: el contenedor existe pero no ha arrancado. Puedes hacerlo explícitamente con `docker create`, o es un paso implícito dentro de `docker run`.
+
+**Running**: el proceso principal está ejecutándose. El contenedor consume CPU, RAM y recursos del sistema de archivos.
+
+**Paused**: el proceso está suspendido (SIGSTOP). El contenedor sigue existiendo en memoria pero no hace nada. `docker pause` y `docker unpause`. Se usa poco, pero es útil para depuración — congelas el contenedor en un punto concreto para inspeccionar su estado.
+
+**Stopped**: el proceso principal ha terminado. El contenedor sigue existiendo como entidad detenida — su sistema de archivos está preservado, sus logs son accesibles. Puedes reiniciarlo con `docker start`.
+
+**Removed**: el contenedor ha desaparecido. Sistema de archivos, logs, todo. No hay vuelta atrás.
+
+```bash
+# Recorre el ciclo de vida paso a paso
+docker create --name demo nginx          # Created
+docker start demo                        # Running
+docker pause demo                        # Paused
+docker unpause demo                      # Running again
+docker stop demo                         # Stopped (SIGTERM → SIGKILL después de 10s)
+docker rm demo                           # Removed
+```
+
+O sáltate la ceremonia y hazlo todo de golpe:
+
+```bash
+docker run --rm nginx    # Crea, arranca y elimina cuando termina
+```
+
+## La capa de escritura: por qué los contenedores no modifican las imágenes
+
+Aquí hay un detalle que genera confusión. Si las imágenes son de solo lectura, ¿cómo puede escribir archivos un contenedor?
+
+Cuando Docker crea un contenedor a partir de una imagen, añade una **capa de escritura fina** encima de todas las capas de solo lectura. Ahí va todo lo que el contenedor escribe — archivos de log, datos temporales, cualquier `apt-get install` que hagas dentro del contenedor. Las capas de la imagen subyacente nunca se tocan.
+
+```
+┌─────────────────────────────┐
+│   Capa de escritura         │  ← los cambios van aquí
+├─────────────────────────────┤
+│   Capa 4 de imagen (app.py) │  solo lectura
+├─────────────────────────────┤
+│   Capa 3 (Flask)            │  solo lectura
+├─────────────────────────────┤
+│   Capa 2 (Python)           │  solo lectura
+├─────────────────────────────┤
+│   Capa 1 (Ubuntu)           │  solo lectura
+└─────────────────────────────┘
+```
+
+Cuando eliminas el contenedor, la capa de escritura desaparece con él. La imagen queda exactamente igual que estaba. Arranca otro contenedor de la misma imagen y obtienes una capa de escritura fresca — pizarra en blanco.
+
+Esto es lo que hace que los contenedores sean **efímeros por diseño**. No están pensados para ser el hogar permanente de datos. Todo lo que quieras conservar más allá del ciclo de vida de un contenedor va en un volumen — pero eso es tema para más adelante en el curso.
+
+## Diez contenedores, una imagen
+
+Vamos a hacer esto tangible. Puedes tener diez contenedores corriendo a partir de una sola imagen simultáneamente:
+
+```bash
+# Lanza diez contenedores nginx, cada uno en un puerto diferente
+for i in $(seq 1 10); do
+  docker run -d -p "808${i}:80" --name "nginx-${i}" nginx
+done
+```
+
+```bash
+docker ps
+```
+
+```
+CONTAINER ID   IMAGE   COMMAND                  PORTS                  NAMES
+a1b2c3d4e5f6   nginx   "/docker-entrypoint.…"   0.0.0.0:8081->80/tcp   nginx-1
+b2c3d4e5f6a7   nginx   "/docker-entrypoint.…"   0.0.0.0:8082->80/tcp   nginx-2
+...
+```
+
+Cada uno está completamente aislado. Escribir en el sistema de archivos de `nginx-1` no afecta a `nginx-2`. Todos comparten las capas de solo lectura de la imagen Nginx. En disco, el overhead de diez contenedores son diez capas de escritura diminutas — no diez copias completas de Nginx.
+
+Para limpiar cuando acabes:
+
+```bash
+for i in $(seq 1 10); do
+  docker stop "nginx-${i}" && docker rm "nginx-${i}"
+done
+```
+
+O más directo:
+
+```bash
+docker rm -f $(docker ps -aq --filter name=nginx-)
+```
+
+## Descargar, listar y eliminar imágenes
+
+Unos comandos que usarás constantemente:
+
+```bash
+# Descargar una imagen sin ejecutarla
+docker pull node:22-alpine
+
+# Listar todas las imágenes disponibles localmente
+docker images
+```
+
+```
+REPOSITORY   TAG          IMAGE ID       CREATED        SIZE
+nginx        latest       a7be6198544f   2 weeks ago    192MB
+node         22-alpine    f7d2a4e85d2c   3 weeks ago    141MB
+ubuntu       22.04        3db8720ecbf5   4 weeks ago    77.9MB
+python       3.12         b3a18c9e2f1d   3 weeks ago    1.02GB
+```
+
+```bash
+# Eliminar una imagen (solo funciona si ningún contenedor — en marcha o detenido — la referencia)
+docker rmi nginx
+
+# Forzar la eliminación (también elimina contenedores derivados)
+docker rmi -f nginx
+
+# Eliminar todas las imágenes sin uso
+docker image prune
+docker image prune -a    # También elimina imágenes sin contenedores en marcha (más agresivo)
+```
+
+⚠️ No puedes eliminar una imagen mientras haya algún contenedor (aunque esté detenido) que la referencie. Elimina primero el contenedor, luego la imagen.
+
+## Nombrar contenedores: no te saltes este paso
+
+Si no nombras tus contenedores, Docker les asigna combinaciones aleatorias de adjetivo-nombre (`ecstatic_hopper`, `confident_kepler`). Tiene su encanto, pero son inútiles para cualquier cosa más allá de un experimento rápido.
+
+```bash
+# Nombra siempre tus contenedores
+docker run -d --name web-server nginx
+docker run -d --name api-backend node:22-alpine node app.js
+docker run -d --name db-primary postgres:16
+```
+
+Los contenedores con nombre son mucho más fáciles de referenciar en cualquier comando posterior:
+
+```bash
+docker logs web-server
+docker exec -it web-server bash
+docker stop web-server
+```
+
+Y cuando empieces a usar Docker Compose (más adelante en el curso), los nombres se vuelven aún más importantes, porque los servicios se descubren entre sí por nombre a través de la red interna de Docker.
+
+---
+
+La relación imagen-contenedor es la base de todo lo que hace Docker. Las capas explican el comportamiento de la caché, la eficiencia al descargar imágenes, y por qué modificar un contenedor no afecta a los demás que comparten la misma imagen. El ciclo de vida explica por qué los contenedores están diseñados para ser desechables — y por qué persistir datos requiere un mecanismo diferente.
+
+En la próxima lección nos pondremos manos a la obra con los **contenedores interactivos y exec**: abrir shells dentro de contenedores, copiar archivos dentro y fuera, y entender cuándo usar `-it` frente a `-d` y por qué la diferencia importa.
+
+¡Nunca dejes de programar!
+
+---
+
+**💡 Reto**: Descarga tres imágenes distintas (`nginx`, `node:22-alpine`, `python:3.12-slim`). Crea dos contenedores a partir de `nginx`, detén uno, elimina el otro. Consulta los logs del contenedor que queda. Comprueba qué capas tienen en común `nginx` y `python:3.12-slim` usando `docker image inspect`. Limpia todo con `docker system prune`.


### PR DESCRIPTION
## Summary

Adds the English (docker-images-containers-relationship.mdx) and Spanish (relacion-imagenes-contenedores-docker.mdx) Docker tutorials, explaining images, layers, and container lifecycle in both languages. These files are i18n-linked and part of the course structure. No other files affected.\n\n---\n\nOnly staged/tracked files included in this PR. All other new tutorials remain untracked (will not be reviewed in this PR).\n\nSee AGENTS.md for commit/PR discipline.