### PR TITLE
feat(tutorials): add Normal mode Vim tutorial (EN+ES)

### DIFF
--- a/src/content/tutorials/modo-normal-el-poder-de-vim.mdx
+++ b/src/content/tutorials/modo-normal-el-poder-de-vim.mdx
@@ -1,0 +1,222 @@
+---
+title: "Modo Normal: el poder de Vim"
+post_slug: "modo-normal-el-poder-de-vim"
+date: "2026-04-09"
+excerpt: "El modo Normal no es el sitio donde esperas entre pulsaciones — es donde Vim vive. Aprende movimientos por palabras, la gramática operador+movimiento y cómo un puñado de teclas te da un poder de edición casi infinito."
+language: "es"
+categories: ["vim"]
+course: "domina-vim-desde-cero"
+order: 4
+cover: "/images/tutorials/cabecera-vim-curso.jpg"
+i18n: "normal-mode-power-of-vim"
+---
+
+Todos los usuarios nuevos de Vim cometen el mismo error: tratan el modo Normal como una incomodidad — ese estado extraño por el que tienes que pasar para llegar al modo Insert, donde ocurre el "trabajo de verdad". Pulsan `i`, escriben una palabra, pulsan `Esc`, vuelven a pulsar `i`, escriben otra palabra. El modo Normal es solo el vestíbulo.
+
+El problema es que el modo Normal no es el vestíbulo. Es el edificio entero.
+
+En VS Code o Sublime, pasas el 80% del tiempo navegando: moviendo el cursor, seleccionando texto, borrando palabras, saltando entre líneas. El teclado gestiona quizás el 20% de eso; el ratón hace el resto. Vim le da la vuelta completamente. El modo Normal te da un vocabulario de movimientos y operaciones precisas y combinable — y cuando eres fluido en él, navegas y editas sin levantar las manos del teclado en ningún momento.
+
+Este tutorial es donde Vim empieza a encajar.
+
+## Moverse más rápido que un carácter cada vez
+
+`hjkl` te metió en el juego. Ahora toca jugarlo de verdad.
+
+### Movimientos por palabras
+
+En lugar de pulsar `l` diecisiete veces para llegar a la palabra que quieres, Vim te permite saltar por palabras:
+
+- `w` — saltar al **inicio** de la siguiente palabra
+- `b` — saltar **atrás** al inicio de la palabra anterior
+- `e` — saltar al **final** de la palabra actual (o de la siguiente)
+
+Estos tres forman un triángulo. `w` y `b` son opuestos; `e` te deja en el último carácter de una palabra. En la práctica usarás `w` y `b` constantemente, y `e` cuando necesitas aterrizar exactamente en el último carácter.
+
+```
+The quick brown fox jumps over the lazy dog
+^   ^     ^     ^   ^     ^    ^   ^    ^
+                              movimientos w (uno por pulsación)
+```
+
+También hay variantes en mayúscula: `W`, `B`, `E`. Hacen lo mismo, pero definen "palabra" de forma diferente — ignoran la puntuación y tratan `user_name`, `foo.bar` y `http://ejemplo.com` como palabras únicas. La `w` minúscula se detiene en cada guión bajo y cada punto.
+
+```vim
+" Cursor en 'u' de user_name
+w    " → se detiene en '_' (entre user y name)
+W    " → salta al siguiente fragmento separado por espacio
+```
+
+Regla general: usa minúsculas cuando te importan los límites de puntuación, mayúsculas cuando quieres saltar sobre el "fragmento" entero.
+
+### Movimientos dentro de la línea
+
+Para moverse dentro de una línea:
+
+- `0` — ir al **inicio absoluto** de la línea (columna 1)
+- `^` — ir al **primer carácter no en blanco** (ignora la indentación)
+- `$` — ir al **final** de la línea
+- `g_` — ir al **último carácter no en blanco** (ignora espacios finales)
+
+Usarás `^` y `$` mucho más que `0` y `g_`. El código tiene indentación; `^` te pone en el primer carácter real del código, no en la columna 1.
+
+### Movimientos por el archivo
+
+- `gg` — saltar a la **primera línea** del archivo
+- `G` — saltar a la **última línea** del archivo
+- `5G` o `:5` — saltar a la **línea 5** (sustituye 5 por cualquier número)
+- `Ctrl+d` — bajar media página (d de down)
+- `Ctrl+u` — subir media página (u de up)
+- `Ctrl+f` — página completa hacia adelante
+- `Ctrl+b` — página completa hacia atrás
+
+El par `Ctrl+d` / `Ctrl+u` merece una mención especial. Cuando estos estén en tu memoria muscular, navegarás por archivos a una velocidad completamente diferente. Abajo, abajo, abajo, arriba — se acabó arrastrar una barra de desplazamiento con el ratón.
+
+## La gramática de Vim: operador + movimiento
+
+Aquí es donde todo encaja. Aguanta un momento.
+
+Cada comando en Vim sigue una gramática simple:
+
+```
+[cuenta] operador movimiento
+```
+
+- **cuenta** (opcional): cuántas veces aplicarlo
+- **operador**: qué hacer (`d` para borrar, `c` para cambiar, `y` para copiar)
+- **movimiento**: dónde hacerlo (`w` para palabra, `$` para final de línea, `j` para abajo)
+
+Ya conoces varios movimientos: `w`, `b`, `e`, `$`, `0`, `G`. En el momento en que aprendes un solo operador, puedes combinarlo con todos los movimientos que conoces.
+
+### Los operadores
+
+| Operador | Qué hace                                                 |
+| -------- | -------------------------------------------------------- |
+| `d`      | **Delete** (y guarda en portapapeles — es un "cortar")   |
+| `c`      | **Change** (borra y entra inmediatamente en modo Insert) |
+| `y`      | **Yank** (copia al portapapeles sin borrar)              |
+| `p`      | **Put** (pega — después del cursor por defecto)          |
+| `P`      | **Put before** — pega antes del cursor                   |
+
+### Combinándolos
+
+```vim
+dw    " borra desde el cursor al inicio de la siguiente palabra
+db    " borra desde el cursor al inicio de la palabra actual
+d$    " borra desde el cursor al final de la línea
+d0    " borra desde el cursor al inicio de la línea
+dG    " borra desde el cursor hasta el final del archivo
+d5j   " borra la línea actual + 5 líneas abajo (6 en total)
+
+cw    " change word (borra la palabra, entra al modo Insert)
+c$    " change hasta el final de la línea
+c^    " change desde el inicio del código hasta el cursor
+
+yw    " yank (copia) una palabra
+y$    " yank hasta el final de la línea
+yy    " yank la línea entera (caso especial — operador doble = línea completa)
+```
+
+Ese último vale la pena destacarlo: **doblar un operador lo aplica a la línea completa**. `dd` borra la línea actual. `yy` la copia. `cc` la cambia. Usarás `dd` e `yy` constantemente.
+
+### Un ejemplo concreto
+
+Imagina que estás editando esta función de Python y quieres renombrar `calcular_total`:
+
+```python
+def calcular_total(items):
+    return sum(item.precio for item in items)
+```
+
+Coloca el cursor en la `c` de `calcular_total`. Ahora:
+
+```vim
+cw    " borra 'calcular_total' y te deja en modo Insert
+```
+
+Escribe `calcular_suma`, pulsa `Esc`. Listo. Dos pulsaciones para borrar la palabra, escribir el reemplazo, salir del modo Insert.
+
+Sin Vim: clic al inicio de la palabra, clic-arrastrar hasta el final, escribir el reemplazo. Cinco gestos, dos de los cuales requieren el ratón.
+
+## El comando punto: la tecla más poderosa de Vim
+
+Una vez que has hecho un cambio, puedes repetirlo al instante: pulsa `.` (punto).
+
+El comando `.` repite el último cambio que hiciste — fuera el que fuera. ¿Añadiste `async` antes de una función? Pulsa `.` para añadirlo a la siguiente. ¿Borraste una línea con `dd`? Pulsa `.` para borrar la siguiente. ¿Cambiaste una palabra con `cw`? Pulsa `.` para cambiar la siguiente de la misma forma.
+
+```vim
+cw    " cambia la palabra actual, escribe 'nuevoNombre', pulsa Esc
+w     " muévete a la siguiente ocurrencia
+.     " repite: cambia esa palabra a 'nuevoNombre' también
+w
+.     " y otra vez
+```
+
+Así es como los usuarios de Vim hacen lo que parece edición con múltiples cursores sin usar múltiples cursores. Encuentra el patrón, haz el cambio una vez, y luego recorre el archivo con `.`.
+
+No subestimes `.`. Los usuarios con experiencia piensan sus ediciones en términos de "¿cómo hago este cambio una vez, de forma repetible?"
+
+## Cuentas: hazlo N veces
+
+Cualquier comando puede ir precedido de un número para repetirlo:
+
+```vim
+3w      " avanza 3 palabras
+5j      " baja 5 líneas
+3dd     " borra 3 líneas
+2p      " pega dos veces
+10G     " va a la línea 10
+```
+
+Cuentas más operadores más movimientos te dan un sistema genuinamente expresivo. `d3w` significa "borra 3 palabras". `y5j` significa "copia la línea actual más las 5 de abajo". No estás memorizando una lista de comandos; estás hablando un idioma.
+
+## Algunos atajos esenciales
+
+Ciertas combinaciones aparecen tan a menudo que se han ganado su propia tecla individual:
+
+| Atajo | Equivalente | Qué hace                                     |
+| ----- | ----------- | -------------------------------------------- |
+| `D`   | `d$`        | Borra hasta el final de la línea             |
+| `C`   | `c$`        | Cambia hasta el final de la línea            |
+| `Y`   | `yy`        | Copia la línea entera                        |
+| `x`   | `dl`        | Borra el carácter bajo el cursor             |
+| `s`   | `cl`        | Sustituye el carácter (borrar + modo Insert) |
+| `S`   | `cc`        | Sustituye la línea entera                    |
+
+Estos no son excepciones a la gramática — son abreviaciones de combinaciones frecuentes. Apréndelos como atajos, no como reglas separadas.
+
+## Ejercicio práctico
+
+Abre cualquier archivo de código en el que hayas estado trabajando y dedica cinco minutos a esto:
+
+1. Navega hasta el nombre de una función o método usando solo `w` y `b` — sin flechas
+2. Usa `cw` para renombrarlo, escribe el nuevo nombre, pulsa `Esc`
+3. Pulsa `gg` para ir al inicio del archivo
+4. Pulsa `G` para ir al final
+5. Usa `10G` (o el número de línea que tenga sentido) para saltar a algún punto en medio
+6. Borra tres líneas con `3dd`
+7. Pégalas de nuevo con `p`
+8. Encuentra otra palabra que quieras borrar y usa `dw`
+9. Pulsa `u` para deshacer
+10. Pulsa `.` — fíjate en qué pasa
+
+Si en este punto te sientes un poco abrumado, es completamente normal. Por ahora, no te agobies con memorizar cada combinación — céntrate en la gramática: **operador + movimiento**. Cuando eso esté en tu cabeza, lo demás llega solo.
+
+## Conceptos clave de esta lección
+
+- **Movimientos por palabras**: `w` / `b` / `e` saltan por palabra; `W` / `B` / `E` saltan por WORD (ignoran puntuación)
+- **Movimientos en línea**: `^` → primer no-blanco, `$` → final de línea
+- **Movimientos por archivo**: `gg` → inicio, `G` → final, `Ctrl+d` / `Ctrl+u` → scroll
+- **La gramática**: `[cuenta] operador movimiento` — `d3w`, `c$`, `y5j`
+- **Operadores**: `d` (delete/cut), `c` (change), `y` (yank/copy), `p` (put/paste)
+- **Operadores dobles** = línea completa: `dd`, `yy`, `cc`
+- **`.`** repite el último cambio — úsalo constantemente
+- **Cuentas** multiplican cualquier comando: `3dd`, `5j`, `2p`
+
+---
+
+Ahora entiendes qué hace a Vim fundamentalmente diferente de cualquier editor que hayas usado antes. No es la cantidad de atajos — es la gramática. Los operadores se combinan con movimientos, las cuentas los escalan, y `.` los repite. No estás memorizando; estás componiendo.
+
+El siguiente paso es entender el otro lado de la gramática: **el modo Insert en profundidad**. Hay más ahí de lo que parece — Vim tiene formas poderosas de entrar y salir del modo Insert que harán tus ediciones más precisas y tus repeticiones con `.` más efectivas.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/normal-mode-power-of-vim.mdx
+++ b/src/content/tutorials/normal-mode-power-of-vim.mdx
@@ -1,0 +1,222 @@
+---
+title: "Normal Mode: The Power of Vim"
+post_slug: "normal-mode-power-of-vim"
+date: "2026-04-09"
+excerpt: "Normal mode isn't just where you land between keystrokes — it's where Vim lives. Learn word movements, the operator+motion grammar, and how a handful of keys gives you near-infinite editing power."
+language: "en"
+categories: ["vim"]
+course: "mastering-vim-from-scratch"
+order: 4
+cover: "/images/tutorials/cabecera-vim-curso.jpg"
+i18n: "modo-normal-el-poder-de-vim"
+---
+
+Every new Vim user makes the same mistake: they treat Normal mode as an inconvenience — that awkward state you have to pass through to get to Insert mode, where the "real work" happens. They tap `i`, type a word, tap `Esc`, tap `i` again, type another word. Normal mode is just the lobby.
+
+Here's the thing: Normal mode is not the lobby. It's the whole building.
+
+In VS Code or Sublime, you spend 80% of your time navigating: moving the cursor, selecting text, deleting words, jumping between lines. The keyboard handles maybe 20% of that; the mouse handles the rest. Vim flips this completely. Normal mode gives you a vocabulary of precise, composable movements and operations — and once you're fluent, you'll navigate and edit without ever lifting your hands from the keyboard.
+
+This tutorial is where Vim starts to click.
+
+## Moving faster than one character at a time
+
+`hjkl` got you into the game. Now it's time to actually play.
+
+### Word movements
+
+Instead of pressing `l` seventeen times to get to the word you want, Vim lets you jump by word:
+
+- `w` — jump to the **start** of the next word
+- `b` — jump **back** to the start of the previous word
+- `e` — jump to the **end** of the current (or next) word
+
+These three form a triangle. `w` and `b` are opposites; `e` gets you to the last character of a word. In practice you'll use `w` and `b` constantly, and `e` when you need to land precisely on the final character.
+
+```
+The quick brown fox jumps over the lazy dog
+^   ^     ^     ^   ^     ^    ^   ^    ^
+                              w movements (one per press)
+```
+
+There's also the uppercase variants: `W`, `B`, `E`. These do the same thing, but they define "word" differently — they skip over punctuation and treat `user_name`, `foo.bar`, and `http://example.com` as single words. The lowercase `w` would stop at every underscore and dot.
+
+```vim
+" Cursor on 'u' in user_name
+w    " → stops at '_' (between user and name)
+W    " → skips to next whitespace-separated chunk
+```
+
+Rule of thumb: use lowercase when you care about punctuation boundaries, uppercase when you want to jump over the whole "thing."
+
+### Line movements
+
+Getting around within a line:
+
+- `0` — go to the **absolute start** of the line (column 1)
+- `^` — go to the **first non-blank character** (ignores indentation)
+- `$` — go to the **end** of the line
+- `g_` — go to the **last non-blank character** (ignores trailing spaces)
+
+You'll use `^` and `$` far more than `0` and `g_`. Code has indentation; `^` puts you at the actual first character of the code, not at column 1.
+
+### File movements
+
+- `gg` — jump to the **first line** of the file
+- `G` — jump to the **last line** of the file
+- `5G` or `:5` — jump to **line 5** (replace 5 with any number)
+- `Ctrl+d` — scroll half a page **down** (d for down)
+- `Ctrl+u` — scroll half a page **up** (u for up)
+- `Ctrl+f` — full page **forward**
+- `Ctrl+b` — full page **back**
+
+The `Ctrl+d` / `Ctrl+u` pair deserves a special mention. Once these are in your muscle memory, you'll browse through files at a completely different speed. Down, down, down, up — no more dragging a scrollbar with the mouse.
+
+## The Vim grammar: operator + motion
+
+This is the part where it all clicks. Stay with me.
+
+Every command in Vim follows a simple grammar:
+
+```
+[count] operator motion
+```
+
+- **count** (optional): how many times to apply
+- **operator**: what to do (`d` for delete, `c` for change, `y` for yank/copy)
+- **motion**: where to do it (`w` for word, `$` for end of line, `j` for down)
+
+You already know several motions: `w`, `b`, `e`, `$`, `0`, `G`. The moment you learn even one operator, you can combine it with every motion you know.
+
+### The operators
+
+| Operator | What it does                                            |
+| -------- | ------------------------------------------------------- |
+| `d`      | **Delete** (and put in clipboard — it's actually "cut") |
+| `c`      | **Change** (delete and immediately enter Insert mode)   |
+| `y`      | **Yank** (copy to clipboard without deleting)           |
+| `p`      | **Put** (paste — after cursor by default)               |
+| `P`      | **Put before** the cursor                               |
+
+### Combining them
+
+```vim
+dw    " delete from cursor to start of next word
+db    " delete from cursor back to start of current word
+d$    " delete from cursor to end of line
+d0    " delete from cursor to start of line
+dG    " delete from cursor to end of file
+d5j   " delete current line + 5 lines below (6 total)
+
+cw    " change word (delete word, enter Insert mode)
+c$    " change to end of line
+c^    " change from start of code to cursor
+
+yw    " yank (copy) one word
+y$    " yank to end of line
+yy    " yank entire line (special case — doubled operator = full line)
+```
+
+That last one is worth dwelling on: **doubling an operator applies it to the whole line**. `dd` deletes the current line. `yy` yanks it. `cc` changes it. You'll use `dd` and `yy` constantly.
+
+### A concrete example
+
+Say you're editing this Python function and want to rename `calculate_total`:
+
+```python
+def calculate_total(items):
+    return sum(item.price for item in items)
+```
+
+Position your cursor on the `c` of `calculate_total`. Now:
+
+```vim
+cw    " deletes 'calculate_total' and drops you into Insert mode
+```
+
+Type `compute_sum`, press `Esc`. Done. Two keystrokes to delete the word, type the replacement, exit Insert mode.
+
+Without Vim: click at the start of the word, click-drag to the end, type the replacement. Five gestures, two of which require the mouse.
+
+## The dot command: the most powerful key in Vim
+
+Once you've made a change, you can repeat it instantly: press `.` (dot).
+
+The `.` command replays the last change you made — whatever it was. Added `async` before a function? Press `.` to add it to the next one. Deleted a line with `dd`? Press `.` to delete the next line. Changed a word with `cw`? Press `.` to change the next word the same way.
+
+```vim
+cw    " change current word, type 'newName', press Esc
+w     " move to next occurrence
+.     " repeat: change that word to 'newName' too
+w
+.     " and again
+```
+
+This is how Vim users do what looks like multiple-cursor editing without actually using multiple cursors. Find the pattern, make the change once, then `.` your way through the file.
+
+Don't underestimate `.`. Experienced Vim users think about their edits in terms of "how do I make this change once, repeatably?"
+
+## Counts: do it N times
+
+Any command can be prefixed with a number to repeat it:
+
+```vim
+3w      " move forward 3 words
+5j      " move down 5 lines
+3dd     " delete 3 lines
+2p      " paste twice
+10G     " go to line 10
+```
+
+Counts plus operators plus motions give you a genuinely expressive system. `d3w` means "delete 3 words." `y5j` means "yank current line plus 5 below." You're not memorizing a list of commands; you're speaking a language.
+
+## A few essential shortcuts
+
+Some combinations appear so often they've earned their own single keys:
+
+| Shortcut | Equivalent | What it does                                |
+| -------- | ---------- | ------------------------------------------- |
+| `D`      | `d$`       | Delete to end of line                       |
+| `C`      | `c$`       | Change to end of line                       |
+| `Y`      | `yy`       | Yank entire line                            |
+| `x`      | `dl`       | Delete character under cursor               |
+| `s`      | `cl`       | Substitute character (delete + Insert mode) |
+| `S`      | `cc`       | Substitute entire line                      |
+
+These aren't exceptions to the grammar — they're just common abbreviations. Learn them as shortcuts, not as separate rules.
+
+## Practical exercise
+
+Open any code file you've been working on and spend five minutes on this:
+
+1. Navigate to a function or method name using `w` and `b` only — no arrow keys
+2. Use `cw` to rename it, type the new name, press `Esc`
+3. Press `gg` to go to the top of the file
+4. Press `G` to go to the bottom
+5. Use `10G` (or whatever line number makes sense) to jump somewhere in the middle
+6. Delete three lines with `3dd`
+7. Paste them back with `p`
+8. Find another word you want to delete and use `dw`
+9. Press `u` to undo
+10. Press `.` — notice what happens
+
+If you feel slightly overwhelmed at this point, that's completely normal. For now, don't stress about memorizing every combination — focus on the grammar: **operator + motion**. Once that's in your head, the rest follows naturally.
+
+## Key concepts from this lesson
+
+- **Word movements**: `w` / `b` / `e` jump by word; `W` / `B` / `E` jump by WORD (ignoring punctuation)
+- **Line movements**: `^` → first non-blank, `$` → end of line
+- **File movements**: `gg` → top, `G` → bottom, `Ctrl+d` / `Ctrl+u` → scroll
+- **The grammar**: `[count] operator motion` — `d3w`, `c$`, `y5j`
+- **Operators**: `d` (delete/cut), `c` (change), `y` (yank/copy), `p` (put/paste)
+- **Doubled operators** = whole line: `dd`, `yy`, `cc`
+- **`.`** repeats the last change — use it constantly
+- **Counts** multiply any command: `3dd`, `5j`, `2p`
+
+---
+
+You now understand what makes Vim fundamentally different from every editor you've used before. It's not the number of shortcuts — it's the grammar. Operators combine with motions, counts scale them, and `.` repeats them. You're not memorizing; you're composing.
+
+The next step is understanding the other side of the grammar: **Insert mode in depth**. There's more there than just "press `i` and type" — Vim has a set of powerful ways to enter and exit Insert mode that will make your edits more precise and your `.` repetitions more effective.
+
+Never stop coding!


### PR DESCRIPTION
Adds both Spanish and English versions of the Normal mode Vim tutorial. Includes word motions, operator+motion grammar, and practical exercises. Part of 'mastering-vim-from-scratch' and 'domina-vim-desde-cero' courses.