### PR TITLE
feat(tutorials): add 'How LLMs work (without the math)' tutorials (EN/ES)

### DIFF
--- a/src/content/tutorials/como-funcionan-los-llms-sin-matematicas.mdx
+++ b/src/content/tutorials/como-funcionan-los-llms-sin-matematicas.mdx
@@ -1,0 +1,155 @@
+---
+title: "Cómo funcionan los LLMs (sin matemáticas)"
+post_slug: "como-funcionan-los-llms-sin-matematicas"
+date: "2026-04-10"
+excerpt: "Entiende cómo funcionan los Large Language Models por dentro — sin ecuaciones, con analogías que explican por qué alucina con tanta seguridad y cómo usar eso a tu favor."
+language: "es"
+categories: ["ia"]
+course: "ia-para-programadores"
+order: 2
+cover: "/images/tutorials/cabecera-ia-para-programadores-curso.jpg"
+i18n: "how-llms-work-without-the-math"
+---
+
+En el tutorial anterior dijimos que los LLMs "predicen texto". Y probablemente pensaste: "vale, pero eso no me dice nada útil". Tienes razón. Necesitamos ir un nivel más abajo — no al nivel de las matemáticas, sino al nivel del _qué está pasando realmente_, porque eso explica directamente por qué la IA a veces se inventa funciones que no existen, por qué el mismo prompt puede dar respuestas distintas, y por qué darle más contexto marca una diferencia enorme.
+
+Este tutorial es quizás el más importante del módulo. No por lo que vas a aprender a hacer, sino por el modelo mental que vas a construir. Y ese modelo mental, te lo garantizo, va a ahorrarte horas de frustración.
+
+## La máquina de predecir la siguiente palabra
+
+Aquí va la verdad incómoda: un LLM no "entiende" nada. No tiene criterio propio, no ha vivido experiencias, no tiene intuición. Lo que tiene es algo más extraño y, en cierta forma, más impresionante: ha leído cantidades absurdas de texto y ha aprendido, estadísticamente, qué palabras suelen ir después de otras.
+
+La tarea durante el entrenamiento era brutal en su simplicidad:
+
+```
+Texto de entrenamiento:  "El gato se sentó en el..."
+Objetivo:                 Predecir "tejado"
+```
+
+Esto, multiplicado por billones de ejemplos, durante semanas, con miles de GPUs. El resultado es un modelo que, dado cualquier fragmento de texto, puede predecir con sorprendente precisión qué viene después.
+
+Y aquí está la magia que nadie esperaba: **predecir bien la siguiente palabra requiere entender muchísimo sobre el mundo**. Para predecir que después de "El presidente firmó el..." viene algo relacionado con legislación o acuerdos, el modelo tiene que haber aprendido qué es un presidente, qué hace, en qué contextos actúa. No como concepto abstracto — como patrón estadístico extraído de millones de textos.
+
+¿Es eso "entender"? Los filósofos llevan años discutiéndolo. Para nosotros como programadores, la respuesta práctica es: da igual. Lo que importa es que el comportamiento emergente es útil, y que conocer su origen nos hace usarlo mejor.
+
+## El becario que ha leído todo Stack Overflow
+
+La analogía más útil que conozco para un LLM es esta:
+
+Imagina un **becario extraordinariamente bien leído**. Ha leído la documentación completa de Python, Node.js, Rust y otros 50 lenguajes. Ha procesado millones de posts de Stack Overflow. Ha visto decenas de miles de repositorios de GitHub. Ha leído artículos técnicos, posts de blog, libros de programación. Todo eso está ahí dentro, comprimido de alguna forma.
+
+Pero hay cosas que ese becario no puede hacer:
+
+```
+Lo que sí puede:
+✅ Sintetizar información de múltiples fuentes rápidamente
+✅ Escribir código coherente y estructurado
+✅ Explicar conceptos con distintos niveles de detalle
+✅ Generar tests, docs y boilerplate a alta velocidad
+✅ Reconocer patrones y sugerir mejoras
+
+Lo que no puede:
+❌ Buscar información nueva (a menos que tenga herramientas para ello)
+❌ Recordar lo que hablasteis ayer
+❌ Saber si algo que dice es correcto con certeza
+❌ Acceder a tu codebase (a menos que se lo muestres)
+❌ Conocer nada posterior a su fecha de entrenamiento
+```
+
+Ese último punto — la fecha de entrenamiento — es importante. El modelo no sabe lo que pasó después de que cerraron el grifo de datos. Si la API de una librería cambió hace seis meses, el LLM puede darte la sintaxis antigua con total confianza. No miente: genuinamente no lo sabe.
+
+## Por qué la IA dice tonterías con seguridad absoluta
+
+Esto es lo que se llama **alucinación**, y entender por qué ocurre es fundamental para no caer en la trampa.
+
+El modelo genera texto prediciendo la siguiente palabra. En ningún momento tiene acceso a un mecanismo que diga "espera, ¿esto es verdad?". No existe una consulta a una base de datos de hechos. No hay un módulo de verificación. Hay predicción estadística, y ya.
+
+Entonces, cuando le preguntas por una función de Python que no existe:
+
+```python
+# Pregunta: "¿Cómo uso python.utils.magic_sort()?"
+# Respuesta de la IA:
+import python.utils
+
+result = python.utils.magic_sort(my_list, reverse=True, stable=True)
+# The stable parameter ensures equal elements maintain their relative order
+```
+
+La IA no ha buscado `magic_sort` en ningún sitio. Ha generado texto que _suena como_ la respuesta correcta a esa pregunta, basándose en cómo suelen ser las respuestas sobre funciones de Python. El nombre, los parámetros, la explicación — todo tiene la forma correcta. Solo le falta existir.
+
+Esto no es un bug que vayan a arreglar. Es una consecuencia directa de cómo funcionan estos modelos. Por eso la verificación no es opcional — es parte del flujo de trabajo.
+
+### Señales de alerta que deberías reconocer
+
+Con el tiempo, desarrollas un olfato para esto. Mientras tanto, aquí van las señales más comunes:
+
+- **Respuesta excesivamente confiada** sobre un tema muy específico o poco documentado
+- **Nombres de funciones que "suenan bien"** pero que no reconoces
+- **Versiones concretas** de librerías o fechas de lanzamiento sin fuente
+- **Código que tiene la forma correcta** pero que al ejecutarlo da `AttributeError` o `ModuleNotFoundError`
+- **Explicaciones que cambian** si repites la pregunta con ligeras variaciones
+
+La regla de oro: trata el output de la IA como código de un compañero que es muy listo pero que trabaja de forma apresurada. Revisar antes de confiar, siempre.
+
+## El contexto es tu superpoder
+
+Aquí está la variable que más controlas y que más diferencia hace: **el contexto que le das al modelo**.
+
+El LLM no tiene memoria entre sesiones (a menos que se la proporciones explícitamente). Cada conversación empieza desde cero. Lo único que sabe de ti, de tu proyecto y de tu problema es lo que hay dentro de la ventana de contexto actual.
+
+La **ventana de contexto** es la cantidad de texto que el modelo puede "ver" a la vez. Claude Sonnet, por ejemplo, tiene una ventana de 200.000 tokens — suficiente para un codebase mediano completo. Esto es enorme y relativamente reciente: hace dos años, las ventanas eran de 8.000 tokens y había que gestionar manualmente qué incluir.
+
+¿Qué significa esto para ti en la práctica?
+
+```
+❌ Prompt pobre:
+"Mi código no funciona, ayúdame"
+
+✅ Prompt con contexto:
+"Tengo esta función de Python que debería parsear fechas en formato ISO 8601,
+pero falla cuando el string incluye timezone offset (e.g., 2026-03-07T10:30:00+01:00).
+Aquí está el código: [código]
+Y aquí el error: [error]
+Estoy usando Python 3.12 con dateutil 2.9.0"
+```
+
+La diferencia en calidad de respuesta es abismal. No porque el modelo sea más listo — sino porque tiene la información que necesita para predecir respuestas relevantes.
+
+## La temperatura: por qué la misma pregunta da respuestas distintas
+
+Si alguna vez has preguntado lo mismo dos veces y te han dado respuestas distintas, no es un fallo. Es por diseño.
+
+Cuando el modelo predice la siguiente palabra, no elige siempre la más probable. Hay un parámetro llamado **temperatura** que controla cuánta aleatoriedad se inyecta en esa elección. Con temperatura alta (más creativa), puede elegir palabras menos probables. Con temperatura baja (más determinista), casi siempre elige la más probable.
+
+```
+Temperatura 0.0  → muy determinista, respuestas consistentes
+Temperatura 0.5  → balance entre creatividad y consistencia
+Temperatura 1.0  → más variación, más creativo, más errático
+```
+
+Para código, generalmente quieres temperatura baja: quieres que el modelo te dé la solución más probable, no que experimente. Para brainstorming o generación de ideas, algo más de temperatura ayuda a salir de los patrones habituales.
+
+OpenCode gestiona esto automáticamente según el tipo de tarea, pero es bueno saber que existe el concepto — especialmente cuando notes que la IA "se vuelve más conservadora" o "más creativa" según el contexto.
+
+## Más nuevo no siempre significa mejor (para ti)
+
+Un último punto que rompe expectativas: que salga un modelo nuevo no significa que debas cambiarte a él inmediatamente para todo.
+
+Los modelos se optimizan para diferentes objetivos. Un modelo muy nuevo puede ser mejor en razonamiento matemático pero peor en seguir instrucciones complejas. O puede tener una ventana de contexto más pequeña. O puede ser significativamente más lento o caro.
+
+La elección del modelo debería ser pragmática:
+
+| Tarea                           | Prioridad                  |
+| ------------------------------- | -------------------------- |
+| Análisis de codebase completo   | Ventana de contexto grande |
+| Generación de código repetitivo | Velocidad y coste          |
+| Diseño de arquitectura          | Capacidad de razonamiento  |
+| Respuestas rápidas y simples    | Cualquier modelo ligero    |
+
+OpenCode te permite especificar el modelo por sesión. En la práctica, Claude Sonnet es un excelente punto de partida para la mayoría de tareas de desarrollo — buen equilibrio entre calidad, velocidad y coste. Profundizaremos en esto cuando veamos el paisaje de modelos en el tutorial 5.
+
+---
+
+Con este modelo mental en la cabeza, ya puedes empezar a trabajar con la IA de forma más inteligente: sabes por qué verifica, sabes por qué el contexto importa, y sabes que las alucinaciones no son magia oscura sino aritmética mal aplicada. En el siguiente tutorial, bajamos al siguiente nivel: **el cambio de paradigma que supone pasar de escribir código a dirigir a una IA** — y por qué eso convierte el saber especificar en la habilidad más valiosa que puedes desarrollar.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/how-llms-work-without-the-math.mdx
+++ b/src/content/tutorials/how-llms-work-without-the-math.mdx
@@ -1,0 +1,155 @@
+---
+title: "How LLMs Work (Without the Math)"
+post_slug: "how-llms-work-without-the-math"
+date: "2026-04-10"
+excerpt: "Understand how Large Language Models work under the hood — no equations, just the mental models that explain why they hallucinate so confidently and how to use that to your advantage."
+language: "en"
+categories: ["ai"]
+course: "ai-for-developers"
+order: 2
+cover: "/images/tutorials/cabecera-ia-para-programadores-curso.jpg"
+i18n: "como-funcionan-los-llms-sin-matematicas"
+---
+
+In the previous tutorial, we said LLMs "predict text." And you probably thought: "okay, but that doesn't actually tell me anything useful." Fair. We need to go one level deeper — not down to the math level, but to the level of _what's actually happening_, because that directly explains why AI sometimes invents functions that don't exist, why the same prompt can give different answers, and why giving it more context makes a massive difference.
+
+This tutorial is arguably the most important one in this module. Not because of what you'll learn to do, but because of the mental model you'll build. And that mental model, I promise, will save you hours of frustration.
+
+## The next-word prediction machine
+
+Here's the uncomfortable truth: an LLM doesn't "understand" anything. It has no opinions of its own, no lived experience, no intuition. What it has is something stranger and, in a way, more impressive: it's read absurd quantities of text and learned, statistically, what words tend to follow other words.
+
+The task during training was brutal in its simplicity:
+
+```
+Training text:  "The cat sat on the..."
+Objective:       Predict "roof"
+```
+
+Multiply that by trillions of examples, over weeks, across thousands of GPUs. The result is a model that, given any fragment of text, can predict with surprising accuracy what comes next.
+
+And here's the magic nobody expected: **predicting the next word well requires understanding an enormous amount about the world**. To predict that after "The president signed the..." comes something related to legislation or agreements, the model has to have learned what a president is, what they do, in what contexts they act. Not as an abstract concept — as a statistical pattern extracted from millions of texts.
+
+Is that "understanding"? Philosophers have been arguing about it for years. For us as developers, the practical answer is: it doesn't matter. What matters is that the emergent behavior is useful, and knowing its origin makes us use it better.
+
+## The intern who has read all of Stack Overflow
+
+The most useful analogy I know for an LLM is this:
+
+Imagine an **extraordinarily well-read intern**. They've read the complete documentation for Python, Node.js, Rust, and 50 other languages. They've processed millions of Stack Overflow posts. They've seen tens of thousands of GitHub repositories. They've read technical articles, blog posts, programming books. All of that is in there, compressed somehow.
+
+But there are things that intern simply cannot do:
+
+```
+What they can do:
+✅ Synthesize information from multiple sources quickly
+✅ Write coherent, structured code
+✅ Explain concepts at different levels of detail
+✅ Generate tests, docs, and boilerplate at high speed
+✅ Recognize patterns and suggest improvements
+
+What they can't do:
+❌ Look up new information (unless given tools to do so)
+❌ Remember what you talked about yesterday
+❌ Know with certainty whether what they're saying is correct
+❌ Access your codebase (unless you show it to them)
+❌ Know anything that happened after their training cutoff
+```
+
+That last point — the training cutoff — matters. The model doesn't know what happened after they closed the data tap. If a library's API changed six months ago, the LLM might give you the old syntax with total confidence. It's not lying: it genuinely doesn't know.
+
+## Why AI says nonsense with absolute confidence
+
+This is what's called **hallucination**, and understanding why it happens is fundamental to not falling into the trap.
+
+The model generates text by predicting the next word. At no point does it have access to a mechanism that says "wait, is this actually true?" There's no query to a facts database. No verification module. There's statistical prediction, and that's it.
+
+So when you ask about a Python function that doesn't exist:
+
+```python
+# Prompt: "How do I use python.utils.magic_sort()?"
+# AI response:
+import python.utils
+
+result = python.utils.magic_sort(my_list, reverse=True, stable=True)
+# The stable parameter ensures equal elements maintain their relative order
+```
+
+The AI didn't look up `magic_sort` anywhere. It generated text that _sounds like_ the correct answer to that question, based on how answers about Python functions tend to look. The name, the parameters, the explanation — all of it has the right shape. It just doesn't exist.
+
+This isn't a bug they're going to fix. It's a direct consequence of how these models work. That's why verification isn't optional — it's part of the workflow.
+
+### Warning signs you should learn to recognize
+
+Over time, you develop a nose for this. In the meantime, here are the most common signals:
+
+- **Overly confident response** about a very specific or poorly-documented topic
+- **Function names that "sound right"** but that you don't recognize
+- **Specific library versions** or release dates with no source
+- **Code that has the right shape** but throws `AttributeError` or `ModuleNotFoundError` when you run it
+- **Explanations that shift** when you repeat the question with slight variations
+
+The golden rule: treat AI output like code from a colleague who's very smart but works in a rush. Review before you trust, always.
+
+## Context is your superpower
+
+Here's the variable you control the most and that makes the biggest difference: **the context you give the model**.
+
+The LLM has no memory between sessions (unless you explicitly provide it). Every conversation starts from zero. The only thing it knows about you, your project, and your problem is what's inside the current context window.
+
+The **context window** is the amount of text the model can "see" at once. Claude Sonnet, for example, has a 200,000-token window — enough for a medium-sized complete codebase. This is enormous and relatively recent: two years ago, windows were 8,000 tokens and you had to manually manage what to include.
+
+What does this mean for you in practice?
+
+```
+❌ Weak prompt:
+"My code doesn't work, help me"
+
+✅ Context-rich prompt:
+"I have this Python function that should parse dates in ISO 8601 format,
+but it fails when the string includes a timezone offset (e.g., 2026-03-07T10:30:00+01:00).
+Here's the code: [code]
+And here's the error: [error]
+I'm using Python 3.12 with dateutil 2.9.0"
+```
+
+The difference in response quality is enormous. Not because the model got smarter — but because it has the information it needs to predict relevant answers.
+
+## Temperature: why the same question gives different answers
+
+If you've ever asked the same thing twice and gotten different answers, that's not a bug. It's by design.
+
+When the model predicts the next word, it doesn't always pick the most probable one. There's a parameter called **temperature** that controls how much randomness gets injected into that choice. With high temperature (more creative), it might pick less probable words. With low temperature (more deterministic), it almost always picks the most probable one.
+
+```
+Temperature 0.0  → very deterministic, consistent responses
+Temperature 0.5  → balance between creativity and consistency
+Temperature 1.0  → more variation, more creative, more erratic
+```
+
+For code, you generally want low temperature: you want the model to give you the most probable solution, not to experiment. For brainstorming or idea generation, a bit more temperature helps break out of familiar patterns.
+
+opencode manages this automatically based on task type, but it's good to know the concept exists — especially when you notice the AI being "more conservative" or "more creative" depending on context.
+
+## Newer doesn't always mean better (for you)
+
+One last expectation-breaker: just because a new model came out doesn't mean you should immediately switch to it for everything.
+
+Models are optimized for different objectives. A very new model might be better at mathematical reasoning but worse at following complex instructions. Or it might have a smaller context window. Or it might be significantly slower or more expensive.
+
+Model choice should be pragmatic:
+
+| Task                       | Priority              |
+| -------------------------- | --------------------- |
+| Full codebase analysis     | Large context window  |
+| Repetitive code generation | Speed and cost        |
+| Architecture design        | Reasoning capability  |
+| Quick, simple answers      | Any lightweight model |
+
+opencode lets you specify the model per session. In practice, Claude Sonnet is an excellent starting point for most development tasks — a good balance of quality, speed, and cost. We'll go deeper on this when we look at the model landscape in tutorial 5.
+
+---
+
+With this mental model in place, you can start working with AI more intelligently: you know why verification matters, you know why context is everything, and you know that hallucinations aren't dark magic — they're statistical prediction applied confidently. In the next tutorial, we go to the next level: **the paradigm shift of going from writing code to directing an AI** — and why the ability to specify clearly becomes the most valuable skill you can develop.
+
+Never stop coding!


### PR DESCRIPTION
## Summary
- Adds Spanish and English versions for 'How LLMs Work (Without the Math)' as part of the AI for Developers series.
- Focuses on mental models and practical use, no mathematical detail.
