### PR TITLE
feat: AI paradigm shift tutorials (EN, ES)

### DIFF
--- a/src/content/tutorials/ai-for-programming-paradigm-shift.mdx
+++ b/src/content/tutorials/ai-for-programming-paradigm-shift.mdx
@@ -1,0 +1,172 @@
+---
+title: "AI for Programming: The Paradigm Shift"
+post_slug: "ai-for-programming-paradigm-shift"
+date: "2026-04-13"
+excerpt: "From writing code to directing AI: understand the new mental model, which tasks are worth delegating and which aren't, and why clarity of thought is now your most valuable skill."
+language: "en"
+categories: ["ai"]
+course: "ai-for-developers"
+order: 3
+cover: "/images/tutorials/cabecera-ia-para-programadores-curso.jpg"
+i18n: "el-cambio-de-paradigma-ia-para-programadores"
+---
+
+Picture this: it's 2019. You're a mid-level developer. You spend your mornings writing boilerplate, your afternoons debugging stack traces, and your evenings on Stack Overflow trying to remember the exact syntax for a thing you've done a dozen times before. That was the job. Nobody thought it was weird — it was just how programming worked.
+
+Now it's 2026. The boilerplate is gone in thirty seconds. Stack traces get explained in plain English. That CRUD endpoint you used to spend a morning on? Twenty minutes with good context and a decent prompt. The job hasn't disappeared — it's been compressed. And that compression creates a gap between people who adapted and people who are still typing like it's 2019.
+
+This tutorial is about that gap. Not the tools — we'll get to those. The mental model. Because without the right mental model, even the best tools become a crutch instead of a multiplier.
+
+## The old way vs the new way
+
+Let's be concrete about what changed, because "AI changes everything" is meaningless without examples.
+
+The 2019 workflow, if you were building a REST endpoint:
+
+```
+1. Recall the framework syntax (or search for it)
+2. Type the boilerplate — route definition, middleware, validation
+3. Write the business logic
+4. Write the error handling
+5. Write the tests (if you wrote tests)
+6. Document it (if you documented)
+7. Realize you missed an edge case, loop back to 3
+```
+
+The 2026 workflow:
+
+```
+1. Describe the intent clearly to the AI
+2. Review what it generates — actually understand it
+3. Test it against your real requirements
+4. Adjust and verify
+```
+
+The bottleneck shifted. Before, it was typing and recall. Now it's **clarity of specification**. If you can't explain what you want precisely enough for another intelligent entity to implement it, the AI won't save you — it'll generate something plausible-looking that solves the wrong problem.
+
+That's not a limitation of the AI. That's the job now.
+
+## You're becoming an engineering director
+
+Here's the analogy that makes this click for most people.
+
+Imagine you've just been promoted. You used to write code all day. Now you have a team of developers — smart, fast, eager to help — and your job is to direct them effectively. You still need to understand the code deeply: you review it, you spot problems, you make architectural decisions. But you're not the one typing every line.
+
+Working with AI is exactly that dynamic. The AI is the developer. You're the director.
+
+```
+Engineering director without AI:
+→ "Why is the auth failing?" → looks through logs → reads code → finds the bug → fixes it
+
+Engineering director with AI:
+→ "Why is the auth failing?" → shows logs + relevant code to AI → AI explains root cause → director evaluates → directs the fix
+```
+
+What doesn't change: you still need to understand what the bug is. You still need to evaluate whether the fix makes sense. You still own the decision. The AI accelerates the mechanical parts — reading through 300 lines to find the one that matters, generating the corrected version, suggesting where to add a test.
+
+What changes: the ratio of time spent thinking versus time spent typing shifts dramatically in favor of thinking. And thinking clearly about problems turns out to be the part nobody automated.
+
+## The new bottleneck: specification
+
+There's a concept in software engineering called **Garbage In, Garbage Out**. It was coined for databases, but it describes AI interaction perfectly.
+
+An AI is not a mind reader. It doesn't know your codebase, your team's conventions, your performance requirements, or that you have a legacy service that uses a slightly non-standard error format. It only knows what you put in the context window.
+
+The quality of the output is bounded by the quality of the input. Always.
+
+Watch how different these prompts are:
+
+```
+❌ Weak specification:
+"Write a function to validate email addresses."
+
+✅ Strong specification:
+"Write a TypeScript function that validates email addresses. It should:
+- Return a boolean
+- Follow RFC 5322 (standard format, no exotic edge cases)
+- Reject addresses over 254 characters (per spec)
+- Reject addresses with consecutive dots in the local part
+- NOT use external libraries — just regex and length check
+
+We're on Node.js 22, TypeScript 5.4 strict mode.
+The function will be called thousands of times per second in a hot path,
+so avoid any allocations we don't need."
+```
+
+The first prompt gets you a function. The second gets you the function you actually need. The difference isn't the AI's capability — it's your ability to say what you want.
+
+This is the skill that compounds. The developer who can write the second prompt consistently will extract ten times more value from AI than someone who writes the first one, regardless of which model they use.
+
+## Delegation without abdication
+
+Here's where a lot of developers stumble: they treat AI as either a magic oracle they trust blindly, or a toy they use for trivial things and never for anything real. Both are wrong.
+
+The right mental model is **delegation with ownership**.
+
+When you delegate to a colleague, you don't stop being responsible for the outcome. You describe what you need, you check the work, you integrate it, you own it. Delegating doesn't mean disappearing from the loop.
+
+Same with AI. The rule that matters:
+
+> Never merge AI code you don't understand.
+
+Not "review it quickly." Not "it looks right." **Understand it.** If you can't explain in plain English what a piece of code does and why it's correct, you haven't reviewed it — you've rubber-stamped it. And when it breaks in production at 3 AM, "the AI wrote it" is not a defense.
+
+This is especially important for developers early in their career. The paradox is brutal: AI helps the most with the mechanical parts of coding, which is exactly the part that builds foundational understanding when you're learning. If you skip the understanding because "the AI already did it," you build speed without foundations. That works until it doesn't, and when it stops working, it stops working hard.
+
+## What's worth delegating (and what isn't)
+
+Not all tasks are equal. Here's the practical breakdown after two years of industry data:
+
+### High-value delegation
+
+**Boilerplate and scaffolding**: This is the clearest win. Setting up a new service, creating data transfer objects, writing CRUD endpoints, configuring test infrastructure — tasks that are repetitive and well-defined. AI does these well because there's a massive amount of training data showing exactly how they should look.
+
+**Explaining unfamiliar code**: You join a new project. There's a 200-line function with no comments, written two years ago, by someone who left the company. Give it to the AI: "explain what this function does, what it assumes about its inputs, and what could go wrong." You'll understand it in two minutes instead of twenty.
+
+**Writing tests**: Counterintuitive for many people, but AI is genuinely good at this. Give it a function, ask for edge cases, ask for tests that cover those cases. The output quality is high because tests have structure — arrange, act, assert — and that structure is exactly the kind of pattern AI learns well. You still verify that the tests make sense, but the mechanical part of writing them is delegated.
+
+**Documentation**: Explaining what code does in prose is exactly what a next-word prediction machine optimized on human writing should be good at. It is.
+
+**Debugging stack traces**: "Here's the error, here's the relevant code, here's the context." This is the exact kind of "given all this information, predict what's wrong" task where large context windows shine.
+
+### Low-value or risky delegation
+
+**Security-critical code**: Authentication logic, authorization checks, cryptographic operations, input sanitization against injection attacks. The AI knows the patterns, but the stakes of getting them wrong are severe enough that you need deep personal understanding of every line. Use AI as a starting point or reviewer, never as the sole author.
+
+**Complex algorithms**: Sorting, graph traversal, optimization problems — AI can produce code that looks correct and has subtle off-by-one errors. Correctness here requires proof, not confidence. Always verify independently.
+
+**Domain-specific business logic**: AI doesn't know that in your company, "active" users are those who logged in within 90 days, or that your pricing model has seven edge cases inherited from a 2017 migration. It will make assumptions. Some will be right. You need to catch the ones that aren't.
+
+**Novel architecture decisions**: Should this be synchronous or async? One service or two? Event-driven or request-response? These decisions require understanding your specific system's constraints — load, latency requirements, team size, operational complexity. AI gives you options and trade-offs, which is valuable input. But it can't make the decision for you, because it doesn't know what you're optimizing for.
+
+## The verification mindset
+
+Let's talk about the daily habit that separates effective AI users from dangerous ones.
+
+Every piece of AI-generated code goes through the same checklist before it enters your codebase:
+
+```
+1. Run it — does it actually execute without errors?
+2. Test it — does it handle the edge cases you care about?
+3. Read it — do you understand every line? Could you rewrite it from scratch?
+4. Question it — are there assumptions that might not hold?
+5. Own it — can you defend this code in a code review?
+```
+
+Step 3 is where most people skip. "It works" and "I understand why it works" are different statements. Both matter. The first gets it past testing. The second gets it past production incidents.
+
+The habit sounds slow. In practice, it takes maybe two minutes for a typical function. And it saves you the debugging session that takes three hours, the production fix that wakes you up at 2 AM, and the six-month accumulation of code you're afraid to touch because nobody knows how it works.
+
+## A note on junior developers
+
+I want to be direct about something the hype glosses over.
+
+If you're early in your career, AI is both your biggest advantage and your biggest risk. The advantage: you can produce at a level above your experience, which opens doors that used to take years to open. The risk: you can ship code you don't understand, build a track record on borrowed foundations, and hit a wall when you need to debug something deep.
+
+The differentiator is the understanding habit. Use AI to go faster — absolutely. But make sure "faster" means "less time on the mechanical parts" and not "less time understanding." Your 10-years-from-now self will have the foundations or won't. The choice happens now, in how you use the tool.
+
+---
+
+You now have the mental model. You know why specification matters, what's worth delegating, and how verification fits into the workflow. In the next tutorial, we get concrete about a specific failure mode: **AI hallucinations — how to detect them, when to trust AI, and the practical toolkit for not getting burned**. Because knowing the theory of verification is one thing. Knowing what hallucinations look like in the wild is another.
+
+Never stop coding!

--- a/src/content/tutorials/el-cambio-de-paradigma-ia-para-programadores.mdx
+++ b/src/content/tutorials/el-cambio-de-paradigma-ia-para-programadores.mdx
@@ -1,0 +1,173 @@
+---
+title: "IA para programadores: el cambio de paradigma"
+post_slug: "el-cambio-de-paradigma-ia-para-programadores"
+date: "2026-04-13"
+excerpt: "De escribir código a dirigir una IA: el nuevo modelo mental, qué tareas merece la pena delegar y cuáles no, y por qué la claridad de pensamiento es tu habilidad más valiosa ahora mismo."
+language: "es"
+categories: ["ia"]
+course: "ia-para-programadores"
+order: 3
+cover: "/images/tutorials/cabecera-ia-para-programadores-curso.jpg"
+i18n: "ai-for-programming-paradigm-shift"
+---
+
+Imagínate: es 2019. Eres un desarrollador de nivel medio. Pasas las mañanas escribiendo boilerplate, las tardes depurando stack traces, y las noches en Stack Overflow intentando recordar la sintaxis exacta de algo que has hecho docenas de veces. Ese era el trabajo. Nadie lo cuestionaba — era simplemente así como funciona la programación.
+
+Ahora es 2026. El boilerplate desaparece en treinta segundos. Los stack traces se explican en español sin rodeos. Ese endpoint CRUD que te llevaba una mañana entera: veinte minutos con buen contexto y un prompt decente. El trabajo no ha desaparecido — se ha comprimido. Y esa compresión crea una brecha entre la gente que se adaptó y la gente que sigue tecleando como si fuera 2019.
+
+Este tutorial trata sobre esa brecha. No las herramientas — ya llegaremos. El modelo mental. Porque sin el modelo mental correcto, acabas apoyándote en las herramientas para tapar lo que no sabes, en lugar de usarlas para ir más lejos.
+
+## La vieja forma vs la nueva forma
+
+Seamos concretos, porque "la IA lo cambia todo" no significa nada sin ejemplos.
+
+El flujo de trabajo de 2019, si estabas construyendo un endpoint REST:
+
+```
+1. Recordar la sintaxis del framework (o buscarlo)
+2. Escribir el boilerplate — definición de ruta, middleware, validación
+3. Escribir la lógica de negocio
+4. Escribir el manejo de errores
+5. Escribir los tests (si es que los escribías)
+6. Documentarlo (si es que documentabas)
+7. Darte cuenta de que te faltó un edge case, volver al 3
+```
+
+El flujo de trabajo de 2026:
+
+```
+1. Describir la intención con claridad a la IA
+2. Revisar lo que genera — entenderlo de verdad
+3. Probarlo contra tus requisitos reales
+4. Ajustar y verificar
+```
+
+El cuello de botella cambió. Antes era teclear y recordar. Ahora es **claridad de especificación**. Si no puedes explicar lo que quieres con suficiente precisión para que otra entidad inteligente lo implemente, la IA no te va a salvar — va a generar algo que parece correcto pero resuelve el problema equivocado.
+
+Eso no es una limitación de la IA. Eso es el trabajo ahora.
+
+## Te estás convirtiendo en director de ingeniería
+
+Esta es la analogía que hace que todo encaje para la mayoría de la gente.
+
+Imagina que acaban de ascenderte. Antes escribías código todo el día. Ahora tienes un equipo de desarrolladores — listos, rápidos, con ganas de ayudar — y tu trabajo es dirigirlos eficazmente. Sigues necesitando entender el código a fondo: lo revisas, detectas problemas, tomas decisiones arquitectónicas. Pero no eres tú quien escribe cada línea.
+
+Trabajar con IA es exactamente esa dinámica. La IA es el desarrollador. Tú eres el director.
+
+```
+Director de ingeniería sin IA:
+→ "¿Por qué falla la autenticación?" → busca en logs → lee código → encuentra el bug → lo corrige
+
+Director de ingeniería con IA:
+→ "¿Por qué falla la autenticación?" → muestra logs + código relevante a la IA
+→ la IA explica la causa raíz → el director evalúa → dirige el fix
+```
+
+Lo que no cambia: sigues necesitando entender cuál es el bug. Sigues necesitando evaluar si el fix tiene sentido. La decisión sigue siendo tuya. La IA acelera las partes mecánicas — leer 300 líneas para encontrar la que importa, generar la versión corregida, sugerir dónde añadir un test.
+
+Lo que cambia: el ratio de tiempo pensando versus tiempo tecleando se desplaza drásticamente hacia el pensamiento. Y pensar con claridad sobre problemas resulta ser la parte que nadie ha automatizado.
+
+## El nuevo cuello de botella: la especificación
+
+Hay un concepto en ingeniería de software llamado **Basura dentro, basura fuera** (_Garbage In, Garbage Out_). Se acuñó para bases de datos, pero describe la interacción con la IA a la perfección.
+
+Una IA no lee mentes. No conoce tu codebase, las convenciones de tu equipo, tus requisitos de rendimiento, ni que tienes un servicio legacy que usa un formato de error ligeramente no estándar. Solo sabe lo que metes en la ventana de contexto.
+
+La calidad del output está acotada por la calidad del input. Siempre.
+
+Observa la diferencia entre estos dos prompts:
+
+```
+❌ Especificación pobre:
+"Escribe una función para validar emails."
+
+✅ Especificación sólida:
+"Escribe una función en TypeScript que valide direcciones de email. Debe:
+- Devolver un boolean
+- Seguir RFC 5322 (formato estándar, sin casos exóticos)
+- Rechazar direcciones de más de 254 caracteres (según spec)
+- Rechazar direcciones con puntos consecutivos en la parte local
+- NO usar librerías externas — solo regex y comprobación de longitud
+
+Estamos en Node.js 22, TypeScript 5.4 strict mode.
+La función se llamará miles de veces por segundo en un hot path,
+así que evita allocations innecesarias."
+```
+
+El primero te da una función. El segundo te da la función que realmente necesitas. La diferencia no es la capacidad de la IA — es tu habilidad para decir lo que quieres.
+
+Esta es la habilidad que escala exponencialmente. El desarrollador que puede escribir el segundo prompt de forma consistente va a extraer diez veces más valor de la IA que alguien que escribe el primero, independientemente del modelo que use.
+
+## Delegar sin abdicar
+
+Aquí es donde muchos desarrolladores tropiezan: tratan la IA como un oráculo mágico en el que confían ciegamente, o como un juguete para cosas triviales que nunca usan para nada real. Ambas posturas son incorrectas.
+
+El modelo mental correcto es **delegación con propiedad**.
+
+Cuando delegas a un compañero, no dejas de ser responsable del resultado. Describes lo que necesitas, revisas el trabajo, lo integras, lo posees. Delegar no significa desaparecer del bucle.
+
+Con la IA, igual. La regla que importa:
+
+> Nunca hagas merge de código generado por IA que no entiendas.
+
+No "revisarlo rápido". No "tiene buena pinta". **Entenderlo.** Si no puedes explicar en español llano qué hace un fragmento de código y por qué es correcto, no lo has revisado — lo has sellado sin mirar. Y cuando falle en producción a las 3 de la mañana, "lo escribió la IA" no es una defensa.
+
+Esto es especialmente importante para los desarrolladores al principio de su carrera. La paradoja es brutal: la IA ayuda más con las partes mecánicas de la programación, que es exactamente la parte que construye comprensión fundamental cuando estás aprendiendo. Si te saltas la comprensión porque "ya lo hizo la IA", construyes velocidad sin cimientos. Eso funciona hasta que deja de funcionar, y cuando deja de funcionar, duele mucho.
+
+## Qué merece la pena delegar (y qué no)
+
+No todas las tareas son iguales. Aquí está el desglose práctico después de dos años de datos en la industria:
+
+### Delegación de alto valor
+
+**Boilerplate y scaffolding**: Este es el win más claro. Configurar un nuevo servicio, crear data transfer objects, escribir endpoints CRUD, configurar infraestructura de tests — tareas repetitivas y bien definidas. La IA hace esto bien porque hay una cantidad masiva de datos de entrenamiento que muestra exactamente cómo deben quedar.
+
+**Explicar código desconocido**: Te incorporas a un proyecto nuevo. Hay una función de 200 líneas sin comentarios, escrita hace dos años, por alguien que ya no está en la empresa. Dásela a la IA: "explica qué hace esta función, qué asume sobre sus inputs, y qué podría fallar". La vas a entender en dos minutos en lugar de veinte.
+
+**Escribir tests**: Contraintuitivo para mucha gente, pero la IA es genuinamente buena en esto. Dale una función, pídele edge cases, pídele tests que los cubran. La calidad del output es alta porque los tests tienen estructura — arrange, act, assert — y esa estructura es exactamente el tipo de patrón que la IA aprende bien. Tú sigues verificando que los tests tienen sentido, pero la parte mecánica de escribirlos está delegada.
+
+**Documentación**: Explicar qué hace un código en prosa es exactamente lo que debería hacer bien una máquina de predicción de siguiente palabra optimizada sobre escritura humana. Y lo hace.
+
+**Depuración de stack traces**: "Aquí está el error, aquí está el código relevante, aquí está el contexto." Esta es exactamente la tarea de "dado todo esto, predice qué está mal" donde las ventanas de contexto grandes brillan.
+
+### Delegación de bajo valor o con riesgo
+
+**Código crítico de seguridad**: Lógica de autenticación, comprobaciones de autorización, operaciones criptográficas, sanitización de inputs contra ataques de inyección. La IA conoce los patrones, pero las consecuencias de equivocarse son graves: necesitas comprensión personal profunda de cada línea. Usa la IA como punto de partida o como revisor, nunca como autor único.
+
+**Algoritmos complejos**: Ordenación, recorrido de grafos, problemas de optimización — la IA puede producir código que parece correcto y tiene errores sutiles de off-by-one. La corrección aquí requiere prueba, no confianza. Verifica siempre de forma independiente.
+
+**Lógica de negocio específica del dominio**: La IA no sabe que en tu empresa los usuarios "activos" son los que han hecho login en los últimos 90 días, o que tu modelo de precios tiene siete casos especiales heredados de una migración de 2017. Va a hacer suposiciones. Algunas serán correctas. Tú necesitas atrapar las que no lo son.
+
+**Decisiones arquitectónicas nuevas**: ¿Esto debería ser síncrono o asíncrono? ¿Un servicio o dos? ¿Event-driven o request-response? Estas decisiones requieren entender las restricciones de tu sistema específico — carga, requisitos de latencia, tamaño del equipo, complejidad operacional. La IA te da opciones y trade-offs, lo cual es input valioso. Pero no puede tomar la decisión por ti, porque no sabe qué estás optimizando.
+
+## El mindset de verificación
+
+Hablemos del hábito diario que separa a los usuarios efectivos de IA de los peligrosos.
+
+Todo código generado por IA pasa por el mismo checklist antes de entrar en tu codebase:
+
+```
+1. Ejecútalo — ¿funciona sin errores?
+2. Pruébalo — ¿maneja los edge cases que te importan?
+3. Léelo — ¿entiendes cada línea? ¿Podrías reescribirla desde cero?
+4. Cuestionalo — ¿hay suposiciones que podrían no cumplirse?
+5. Hazlo tuyo — ¿puedes defender este código en una code review?
+```
+
+El paso 3 es donde la mayoría lo esquiva. "Funciona" y "entiendo por qué funciona" son afirmaciones distintas. Ambas importan. La primera supera los tests. La segunda supera los incidentes de producción.
+
+El hábito parece lento. En la práctica, lleva dos minutos para una función típica. Y te ahorra la sesión de debugging de tres horas, el fix de producción que te despierta a las 2 de la mañana, y los seis meses de acumulación de código que da miedo tocar porque nadie sabe cómo funciona.
+
+## Una nota para los que están empezando
+
+Quiero ser directo en algo que el hype suele ignorar.
+
+Si estás al principio de tu carrera, la IA es a la vez tu mayor ventaja y tu mayor riesgo. La ventaja: puedes producir a un nivel por encima de tu experiencia, lo que abre puertas que antes llevaban años abrir. El riesgo: puedes entregar código que no entiendes, construir un track record sobre cimientos prestados, y chocar con una pared cuando necesitas depurar algo profundo.
+
+El diferenciador es el hábito de comprensión. Usa la IA para ir más rápido — absolutamente. Pero asegúrate de que "más rápido" significa "menos tiempo en las partes mecánicas" y no "menos tiempo entendiendo". Tu yo de dentro de diez años tendrá los cimientos o no los tendrá. La elección ocurre ahora, en cómo usas la herramienta.
+
+---
+
+Ya tienes el modelo mental. Sabes por qué importa la especificación, qué merece delegar, y cómo encaja la verificación en el flujo. En el siguiente tutorial, veremos y comprenderemos un modo de fallo específico: **las alucinaciones de la IA — cómo detectarlas, cuándo confiar en la IA, y el toolkit práctico para no quemarte**. Porque conocer la teoría de la verificación es una cosa. Reconocer cómo se ven las alucinaciones en la práctica es otra.
+
+¡Nunca dejes de programar!

--- a/src/pages-templates/authors/AuthorsDetailPage.astro
+++ b/src/pages-templates/authors/AuthorsDetailPage.astro
@@ -108,11 +108,11 @@ const itemListSchema = generateItemListSchema(
   <!-- Short indexable description for Pagefind -->
   <p class="sr-only" aria-hidden="true">{description}</p>
 
-  <div class="author-detail-page__author-section" data-pagefind-ignore>
+  <div class="author-detail-page__author-section" data-pagefind-ignore="all">
     <AuthorInfo author={author} border={true} />
   </div>
 
-  <div data-pagefind-ignore>
+  <div data-pagefind-ignore="all">
     <PostList posts={content} lang={lang} />
   </div>
 

--- a/src/pages-templates/authors/AuthorsListPage.astro
+++ b/src/pages-templates/authors/AuthorsListPage.astro
@@ -42,7 +42,7 @@ const pageDescription = t(lang, "allAuthors");
   <h1 class="sr-only">{pageTitle}</h1>
   <Title title={pageTitle} icon="pen-line" />
 
-  <div data-pagefind-ignore>
+  <div data-pagefind-ignore="all">
     {
       itemsWithContent.length > 0 ? (
         <TaxonomyListGrouped

--- a/src/pages-templates/categories/CategoriesDetailPage.astro
+++ b/src/pages-templates/categories/CategoriesDetailPage.astro
@@ -103,7 +103,7 @@ const itemListSchema = generateItemListSchema(
   <!-- Short indexable description for Pagefind -->
   <p class="sr-only" aria-hidden="true">{description}</p>
 
-  <div data-pagefind-ignore>
+  <div data-pagefind-ignore="all">
     <PostList posts={content} lang={lang} />
   </div>
 

--- a/src/pages-templates/categories/CategoriesListPage.astro
+++ b/src/pages-templates/categories/CategoriesListPage.astro
@@ -42,7 +42,7 @@ const pageDescription = t(lang, "allCategories");
   <h1 class="sr-only">{pageTitle}</h1>
   <Title title={pageTitle} icon="tag" />
 
-  <div data-pagefind-ignore>
+  <div data-pagefind-ignore="all">
     {
       itemsWithContent.length > 0 ? (
         <TaxonomyListGrouped

--- a/src/pages-templates/genres/GenresDetailPage.astro
+++ b/src/pages-templates/genres/GenresDetailPage.astro
@@ -104,7 +104,7 @@ const itemListSchema = generateItemListSchema(
   <!-- Short indexable description for Pagefind -->
   <p class="sr-only" aria-hidden="true">{description}</p>
 
-  <div data-pagefind-ignore>
+  <div data-pagefind-ignore="all">
     <PostList posts={content} lang={lang} />
   </div>
 

--- a/src/pages-templates/genres/GenresListPage.astro
+++ b/src/pages-templates/genres/GenresListPage.astro
@@ -42,7 +42,7 @@ const pageDescription = t(lang, "allGenres");
   <h1 class="sr-only">{pageTitle}</h1>
   <Title title={pageTitle} icon="bookmark" />
 
-  <div data-pagefind-ignore>
+  <div data-pagefind-ignore="all">
     {
       itemsWithContent.length > 0 ? (
         <TaxonomyListGrouped

--- a/src/pages-templates/publishers/PublishersDetailPage.astro
+++ b/src/pages-templates/publishers/PublishersDetailPage.astro
@@ -96,7 +96,7 @@ const itemListSchema = generateItemListSchema(
   <!-- Short indexable description for Pagefind -->
   <p class="sr-only" aria-hidden="true">{description}</p>
 
-  <div data-pagefind-ignore>
+  <div data-pagefind-ignore="all">
     <PostList posts={content} lang={lang} />
   </div>
 

--- a/src/pages-templates/publishers/PublishersListPage.astro
+++ b/src/pages-templates/publishers/PublishersListPage.astro
@@ -42,7 +42,7 @@ const pageDescription = t(lang, "allPublishers");
   <h1 class="sr-only">{pageTitle}</h1>
   <Title title={pageTitle} icon="book" />
 
-  <div data-pagefind-ignore>
+  <div data-pagefind-ignore="all">
     {
       itemsWithContent.length > 0 ? (
         <TaxonomyListGrouped

--- a/src/pages-templates/series/SeriesDetailPage.astro
+++ b/src/pages-templates/series/SeriesDetailPage.astro
@@ -98,7 +98,7 @@ const itemListSchema = generateItemListSchema(
   <!-- Short indexable description for Pagefind -->
   <p class="sr-only" aria-hidden="true">{description}</p>
 
-  <div data-pagefind-ignore>
+  <div data-pagefind-ignore="all">
     <PostList posts={content} lang={lang} showOrderBadges={true} />
   </div>
 

--- a/src/pages-templates/series/SeriesListPage.astro
+++ b/src/pages-templates/series/SeriesListPage.astro
@@ -42,7 +42,7 @@ const pageDescription = t(lang, "allSeries");
   <h1 class="sr-only">{pageTitle}</h1>
   <Title title={pageTitle} icon="book-open" />
 
-  <div data-pagefind-ignore>
+  <div data-pagefind-ignore="all">
     {
       itemsWithContent.length > 0 ? (
         <TaxonomyListGrouped


### PR DESCRIPTION
Adds EN and ES tutorial for the programming paradigm shift caused by AI. Both files are paired for i18n. See commit details for more context.