### PR TITLE
feat(tutorials): add cherry-pick tutorial in EN and ES

### DIFF
--- a/src/content/tutorials/cherry-pick-git.mdx
+++ b/src/content/tutorials/cherry-pick-git.mdx
@@ -1,0 +1,236 @@
+---
+title: "Cherry-pick en Git: aplica commits quirúrgicamente"
+post_slug: "cherry-pick-git"
+date: "2026-04-15"
+excerpt: "Aprende a usar git cherry-pick para trasladar commits concretos entre ramas sin hacer un merge completo: ideal para backports, hotfixes y rescatar trabajo enterrado."
+language: "es"
+categories: ["git"]
+course: "domina-git-desde-cero"
+order: 21
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "cherry-picking-commits-git"
+---
+
+Producción está caída. Hay un bug crítico. La solución está en tu rama de feature —ese commit de hace tres días, el que se llama "Fix null pointer in payment service". El problema es que esa rama también tiene otros quince commits de cosas a medias: un refactor sin terminar, una API nueva que rompe la mitad del código existente, y dos commits que dicen "wip" (siempre hay dos commits que dicen "wip"). Hacer merge de esa rama sería un desastre. Pero necesitas ese commit. Solo ese.
+
+Para eso existe `git cherry-pick`.
+
+## ¿Qué es el cherry-pick?
+
+Imagina que tienes un árbol con ramas llenas de cerezas. Puedes coger todo el árbol, o puedes extender la mano y coger exactamente la cereza que quieres sin tocar las demás. El cherry-pick es eso: tomar un commit específico de cualquier rama y aplicarlo en la rama donde estás, como si lo hubieras hecho allí desde el principio.
+
+A diferencia del merge —que fusiona toda una rama— o del rebase —que reasienta tu trabajo sobre otra base—, el cherry-pick es quirúrgico. Un commit, un destino, sin ruido.
+
+Git coge los cambios que introdujo ese commit (el diff entre el commit y su padre) y los aplica en tu rama actual como un commit nuevo. El hash será diferente; el contenido, el mismo.
+
+## Uso básico
+
+Necesitas el hash del commit que quieres. Lo consigues con `git log` sobre la rama de origen:
+
+```bash
+git log feature/payments --oneline
+```
+
+```
+a3f9c12 Fix null pointer in payment service
+b7e4d89 WIP: new payment gateway integration
+c2a8f01 Refactor billing module (incomplete)
+d6c3b47 Add payment model
+```
+
+Ese primer commit, `a3f9c12`, es el que necesitas. Cambias a tu rama de destino y lo aplicas:
+
+```bash
+git switch main
+git cherry-pick a3f9c12
+```
+
+```
+[main 9b1d4e3] Fix null pointer in payment service
+ Date: Mon Apr 14 18:32:01 2026 +0200
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+```
+
+Listo. El fix está en `main`. Los otros catorce commits siguen en su rama, esperando a estar listos. La producción respira.
+
+## Cherry-pick de múltiples commits
+
+A veces necesitas más de uno. Tienes dos opciones.
+
+### Commits individuales
+
+Puedes pasar varios hashes de golpe, en el orden en que quieres aplicarlos:
+
+```bash
+git cherry-pick a3f9c12 d6c3b47 e1f2a03
+```
+
+Git los aplica en ese orden, uno por uno. Si alguno genera conflicto, se detiene —ya veremos cómo gestionar eso.
+
+### Rango de commits
+
+Si los commits que necesitas son consecutivos, puedes usar la sintaxis de rango:
+
+```bash
+git cherry-pick a3f9c12..e1f2a03
+```
+
+⚠️ Ojo con esta sintaxis: el rango es **exclusivo por la izquierda**. `a3f9c12..e1f2a03` aplica todos los commits _después_ de `a3f9c12` hasta `e1f2a03` incluido. Si también quieres `a3f9c12`, usa `^`:
+
+```bash
+git cherry-pick a3f9c12^..e1f2a03
+```
+
+Es uno de esos detalles de Git que a todo el mundo le pilla exactamente una vez, sin excepción. Ya puedes tachar ese rito de iniciación.
+
+## Flags útiles
+
+### `-n` / `--no-commit`: solo hacer stage, sin commitear
+
+```bash
+git cherry-pick -n a3f9c12
+```
+
+Git aplica los cambios al área de stage pero no crea el commit. Útil cuando quieres combinar los cambios de varios commits en uno solo, o revisar lo que va a entrar antes de commitear:
+
+```bash
+git cherry-pick -n a3f9c12 d6c3b47
+git status              # review staged changes
+git commit -m "Apply payment fixes from feature branch"
+```
+
+### `-e` / `--edit`: editar el mensaje antes de commitear
+
+```bash
+git cherry-pick -e a3f9c12
+```
+
+Abre el editor con el mensaje original del commit para que lo modifiques. Útil cuando el mensaje original era "fix" y quieres algo más descriptivo en la rama destino.
+
+### `-x`: referenciar el commit original en el mensaje
+
+```bash
+git cherry-pick -x a3f9c12
+```
+
+Añade automáticamente una línea al mensaje del commit indicando de dónde vino:
+
+```
+Fix null pointer in payment service
+
+(cherry picked from commit a3f9c12b3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8)
+```
+
+Es trazabilidad gratuita. Si alguien se pregunta por qué ese commit está en `main` cuando claramente nació en otra rama, el mensaje se lo explica. En proyectos con varios mantenedores o múltiples ramas de release, `-x` es casi obligatorio.
+
+## Gestión de conflictos
+
+El cherry-pick no siempre es indoloro. Si los cambios que quieres traer tocan las mismas líneas que han cambiado en la rama destino desde que esos commits fueron creados, habrá conflicto. Aquí es donde se pone interesante (y por "interesante" quiero decir ligeramente frustrante, pero manejable).
+
+Cuando Git encuentra un conflicto durante el cherry-pick, se detiene y te lo avisa:
+
+```
+error: could not apply a3f9c12... Fix null pointer in payment service
+hint: After resolving the conflicts, mark them with
+hint: "git add/rm <pathspec>", then run
+hint: "git cherry-pick --continue".
+hint: You can instead skip this commit with "git cherry-pick --skip".
+hint: To abort and get back to the state before "git cherry-pick",
+hint: run "git cherry-pick --abort".
+```
+
+El flujo de resolución es igual que en un merge o rebase:
+
+```bash
+# 1. Abre los archivos con conflictos, resolverlos manualmente
+# (busca los marcadores <<<<<<< / ======= / >>>>>>> y elige qué queda)
+
+# 2. Marca el conflicto como resuelto
+git add src/services/payment.ts
+
+# 3. Continúa con el cherry-pick
+git cherry-pick --continue
+```
+
+Si el commit que estás intentando aplicar ya existe en la rama destino (por ejemplo, ya se mergeó antes), puede que Git intente aplicar un diff vacío. En ese caso:
+
+```bash
+git cherry-pick --skip   # skip this commit and continue with the rest
+```
+
+Y si te arrepientes de todo y quieres dejarlo como estaba:
+
+```bash
+git cherry-pick --abort  # back to square one, no harm done
+```
+
+No te agobies con los conflictos: son inevitables cuando llevas código entre ramas con historiales divergentes. La clave es resolverlos con calma, verificar que el resultado es correcto, y seguir.
+
+## Casos reales
+
+### Backport de un hotfix a ramas de release
+
+Tienes versiones `1.x` y `2.x` en producción. Encuentras un bug de seguridad y lo corriges en `main`. Ambas versiones necesitan el fix, pero no quieres subir los cambios de `main` a ninguna de las dos:
+
+```bash
+# Fix is on main as commit f4e3d2c
+git switch release/1.x
+git cherry-pick -x f4e3d2c
+
+git switch release/2.x
+git cherry-pick -x f4e3d2c
+```
+
+El flag `-x` deja trazabilidad en ambas ramas. Si alguien audita el historial de `release/1.x` dentro de seis meses, sabe exactamente de dónde vino ese commit. Esto es backporting: llevar arreglos hacia atrás sin fusionar versiones completas. Cherry-pick es la herramienta estándar para hacerlo.
+
+### Rescatar trabajo de una rama muerta
+
+Llevas semanas en una rama de refactor que al final no va a salir adelante: demasiado scope, el cliente cambió de opinión, o simplemente no fue aprobado. Pero hay dos commits en esa rama con utilidades genéricas que sí quieres conservar:
+
+```bash
+git log feature/big-refactor --oneline | head -20
+```
+
+```
+7a9b1c2 Add generic retry helper
+8b0c2d3 Extract HTTP client abstraction
+c1d3e4f Refactor entire codebase (never mind)
+...
+```
+
+```bash
+git switch main
+git cherry-pick 7a9b1c2 8b0c2d3
+```
+
+La rama se cierra. El trabajo útil vive. El resto desaparece sin drama. Si eres como yo cuando empecé, probablemente pensabas que perder una rama significaba perder todo lo que había en ella — pero con cherry-pick puedes rescatar exactamente lo que vale la pena.
+
+## Cuándo NO usar cherry-pick
+
+Cherry-pick es una herramienta poderosa que se presta al abuso. Usarlo mal puede dejarte con un historial duplicado, conflictos perpetuos y compañeros de equipo que te miran raro en el standup.
+
+**No uses cherry-pick cuando lo que necesitas es un merge o rebase completo.**
+
+Si una rama de feature está lista y quieres integrarla en `main`, usa `git merge` o `git rebase`. Cherry-pick commit a commit es lento, propenso a errores, y rompe la trazabilidad natural de la historia:
+
+```bash
+# ❌ Traer una feature entera con cherry-pick
+git cherry-pick a1b2c3d e2f3a4b f3a4b5c g4b5c6d h5c6d7e
+
+# ✅ Integrar la feature correctamente
+git merge feature/my-feature
+# or
+git rebase feature/my-feature
+```
+
+**No uses cherry-pick como sustituto de un flujo de integración.** Si te encuentras haciendo cherry-pick de los mismos commits en tres ramas distintas de forma rutinaria, tienes un problema de arquitectura de ramas, no de Git.
+
+**El peligro del historial duplicado.** Cuando cherry-pickeas un commit, Git crea un commit _nuevo_ con el mismo contenido pero un hash diferente. Si más adelante haces merge de la rama original, Git intentará aplicar esos cambios de nuevo y probablemente generará conflictos o duplicados. En ramas de larga duración, esto se acumula. La regla: cherry-pick para casos puntuales (hotfixes, rescates), no como estrategia habitual de sincronización entre ramas.
+
+---
+
+El cherry-pick es el bisturí de Git: preciso, útil, y peligroso si lo usas donde necesitabas una llave inglesa. Para hotfixes, backports, y rescatar trabajo enterrado en ramas olvidadas, no tiene rival. Para integrar features completas, merge y rebase hacen un trabajo mucho mejor con mucho menos drama.
+
+En la siguiente lección veremos `git reflog` y cómo recuperar trabajo que parece perdido para siempre: commits huérfanos, ramas borradas por accidente, resets que fueron demasiado lejos. Si alguna vez has sentido el pánico de "acabo de borrar algo importante", la siguiente lección es para ti.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/cherry-picking-commits-git.mdx
+++ b/src/content/tutorials/cherry-picking-commits-git.mdx
@@ -1,0 +1,238 @@
+---
+title: "Cherry-picking commits in Git"
+post_slug: "cherry-picking-commits-git"
+date: "2026-04-15"
+excerpt: "Learn how to use git cherry-pick to apply specific commits from one branch to another—perfect for backporting hotfixes, rescuing buried work, and surgical history management."
+language: "en"
+categories: ["git"]
+course: "mastering-git-from-scratch"
+order: 21
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "cherry-pick-git"
+---
+
+Production is down. There's a null pointer exception in the payment service and your on-call rotation landed on a Tuesday. You know exactly where the fix is: that commit from three days ago on `feature/payments`, the one called "Fix null pointer in payment service." The problem? That branch is a warzone — an unfinished refactor, a half-baked API that breaks half the existing code, and at least two commits named "wip" (there are always at least two commits named "wip"). Merging that branch into `main` would be like performing surgery by dropping a bowling ball on the patient.
+
+You don't need the whole branch. You need that one commit.
+
+That's exactly what `git cherry-pick` is for.
+
+## What is cherry-pick?
+
+Think of your Git history as a playlist. Branches are playlists, commits are individual tracks. A merge is like saying "add this entire album to my playlist." A rebase is like moving your songs so they come after a different album. `git cherry-pick` is you pulling a single track from someone else's playlist and adding it to yours — without subscribing to their whole discography.
+
+The mechanics: Git takes the diff introduced by that specific commit (what changed between it and its parent), and replays that diff on top of your current branch as a brand-new commit. Same content, different hash. The original commit stays exactly where it was. You just get a copy of the change.
+
+That's worth repeating: **the new commit gets a new hash**. We'll come back to why that matters.
+
+## Basic usage
+
+First, find the hash of the commit you need. Run `git log` on the source branch:
+
+```bash
+git log feature/payments --oneline
+```
+
+```
+a3f9c12 Fix null pointer in payment service
+b7e4d89 WIP: new payment gateway integration
+c2a8f01 Refactor billing module (incomplete)
+d6c3b47 Add payment model
+```
+
+There it is — `a3f9c12`. Switch to your target branch and apply it:
+
+```bash
+git switch main
+git cherry-pick a3f9c12
+```
+
+```
+[main 9b1d4e3] Fix null pointer in payment service
+ Date: Mon Apr 14 18:32:01 2026 +0200
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+```
+
+That's it. The fix is in `main`. The other fourteen commits are still sitting on `feature/payments`, waiting to be ready. Production breathes again.
+
+## Cherry-picking multiple commits
+
+Sometimes one commit isn't enough. You have two options.
+
+### Individual commits
+
+Pass multiple hashes in the order you want them applied:
+
+```bash
+git cherry-pick a3f9c12 d6c3b47 e1f2a03
+```
+
+Git applies them one by one, in that order. If any of them causes a conflict, it stops and waits for you to sort it out before continuing.
+
+### A range of commits
+
+If the commits you need are consecutive, use range syntax:
+
+```bash
+git cherry-pick a3f9c12..e1f2a03
+```
+
+⚠️ Watch out: this syntax is **exclusive on the left**. `a3f9c12..e1f2a03` applies every commit _after_ `a3f9c12` up to and including `e1f2a03`. If you also want `a3f9c12` itself, use the `^` suffix:
+
+```bash
+git cherry-pick a3f9c12^..e1f2a03
+```
+
+This catches everyone exactly once. File it under "Git syntax that looks like line noise but actually makes sense once you've been burned by it."
+
+## Useful flags
+
+### `-n` / `--no-commit`: stage without committing
+
+```bash
+git cherry-pick -n a3f9c12
+```
+
+Git applies the changes to the staging area but doesn't create a commit. Useful when you want to combine changes from multiple commits into a single one, or when you want to inspect what's about to happen before pulling the trigger:
+
+```bash
+git cherry-pick -n a3f9c12 d6c3b47
+git status              # review staged changes
+git commit -m "Apply payment fixes from feature branch"
+```
+
+### `-e` / `--edit`: edit the message before committing
+
+```bash
+git cherry-pick -e a3f9c12
+```
+
+Opens your editor with the original commit message so you can modify it. Handy when the original said "fix" and you want something that actually describes what was fixed.
+
+### `-x`: record where the commit came from
+
+```bash
+git cherry-pick -x a3f9c12
+```
+
+Appends a line to the commit message pointing back to the original:
+
+```
+Fix null pointer in payment service
+
+(cherry picked from commit a3f9c12b3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8)
+```
+
+Free traceability. Six months from now, when someone's auditing `release/1.x` and wondering why a commit clearly born on a feature branch is sitting there, the message explains itself. In projects with multiple maintainers or multiple active release branches, `-x` is effectively mandatory. Use it.
+
+## Handling conflicts
+
+Cherry-pick isn't always painless. If the changes you're bringing in touch the same lines that have changed in the target branch since the original commit was made, you'll get a conflict. Here's where things get fun (and by "fun" I mean mildly annoying, but entirely manageable).
+
+When Git hits a conflict mid-cherry-pick, it stops and tells you:
+
+```
+error: could not apply a3f9c12... Fix null pointer in payment service
+hint: After resolving the conflicts, mark them with
+hint: "git add/rm <pathspec>", then run
+hint: "git cherry-pick --continue".
+hint: You can instead skip this commit with "git cherry-pick --skip".
+hint: To abort and get back to the state before "git cherry-pick",
+hint: run "git cherry-pick --abort".
+```
+
+The resolution flow is the same as merge or rebase conflicts:
+
+```bash
+# 1. Open the conflicting files, resolve manually
+# (look for <<<<<<< / ======= / >>>>>>> markers and choose what stays)
+
+# 2. Mark the conflict as resolved
+git add src/services/payment.ts
+
+# 3. Continue
+git cherry-pick --continue
+```
+
+If the commit you're trying to apply already exists in the target branch (maybe it was merged in earlier), Git might try to apply an empty diff. In that case:
+
+```bash
+git cherry-pick --skip   # skip this commit and continue with the rest
+```
+
+And if you want to back out entirely and pretend this never happened:
+
+```bash
+git cherry-pick --abort  # back to square one, no harm done
+```
+
+Don't stress about conflicts — they're unavoidable when you're moving code between branches with diverged histories. Resolve them carefully, verify the result compiles and passes tests, then carry on.
+
+## Real-world scenarios
+
+### Backporting a hotfix to release branches
+
+You maintain `v1.x` and `v2.x` in production. A security vulnerability surfaces and you fix it on `main`. Both versions need the patch, but you absolutely don't want to push all of `main` into either release branch:
+
+```bash
+# Fix is on main as commit f4e3d2c
+git switch release/1.x
+git cherry-pick -x f4e3d2c
+
+git switch release/2.x
+git cherry-pick -x f4e3d2c
+```
+
+The `-x` flag leaves a paper trail in both branches. This is **backporting** — carrying fixes backward in time without merging entire version lines. Cherry-pick is the standard tool for it, and it handles this use case extremely well.
+
+### Rescuing commits from a dead branch
+
+You've been on a refactoring branch for weeks. The scope ballooned, priorities shifted, and the branch isn't going anywhere. But it has two commits — utility functions, an HTTP client abstraction — that you genuinely want to keep. Those commits deserve better than dying with the branch.
+
+```bash
+git log feature/big-refactor --oneline | head -20
+```
+
+```
+7a9b1c2 Add generic retry helper
+8b0c2d3 Extract HTTP client abstraction
+c1d3e4f Refactor entire codebase (never mind)
+...
+```
+
+```bash
+git switch main
+git cherry-pick 7a9b1c2 8b0c2d3
+```
+
+The branch closes. The useful work survives. Everything else disappears without drama. If you're like me when I started, you probably assumed losing a branch meant losing everything in it — cherry-pick makes it easy to be selective about what's worth saving.
+
+## When NOT to use cherry-pick
+
+Cherry-pick is sharp, precise, and genuinely useful — which makes it tempting to reach for it in situations where it's the wrong tool. Using it wrong leaves you with a duplicate-commit-infested history, perpetual conflicts, and teammates giving you looks in standup.
+
+**Don't use cherry-pick when you need a full merge or rebase.**
+
+If a feature branch is done and ready to integrate, use `git merge` or `git rebase`. Cherry-picking commit by commit is slow, error-prone, and destroys the natural traceability of your history:
+
+```bash
+# ❌ Pulling in an entire feature one commit at a time
+git cherry-pick a1b2c3d e2f3a4b f3a4b5c g4b5c6d h5c6d7e
+
+# ✅ Integrating the feature properly
+git merge feature/my-feature
+# or
+git rebase feature/my-feature
+```
+
+**Don't use cherry-pick as a branch synchronization strategy.** If you find yourself cherry-picking the same commits across three different branches on a regular basis, you don't have a Git problem — you have a branching strategy problem. That's a different conversation.
+
+**The duplicate hash problem.** When you cherry-pick a commit, Git creates a _new_ commit with the same content but a different hash. If you later merge the original branch, Git sees those changes as new and tries to apply them again — leading to conflicts or outright duplicates. The longer those branches coexist, the worse this gets. The rule is simple: use cherry-pick for specific, one-off situations (hotfixes, rescues, backports). Don't make it your routine synchronization mechanism.
+
+---
+
+Cherry-pick is the scalpel of Git: precise, effective, and the wrong choice when what you actually need is a shovel. For hotfixes, backports, and rescuing useful work from abandoned branches, nothing beats it. For integrating complete features, merge and rebase do the job with far less collateral damage.
+
+In the next tutorial we'll look at `git reflog` — Git's internal diary that records every movement of every reference, including ones you've deleted. If you've ever `reset --hard` to the wrong commit, deleted a branch by accident, or stared at an empty working tree wondering what you just did, reflog is your safety net. We'll cover how to read it, how to navigate it, and how to recover work that feels permanently gone.
+
+Never stop coding!


### PR DESCRIPTION
## Summary

Add Spanish and English tutorials for git cherry-pick:
- src/content/tutorials/cherry-pick-git.mdx: ES
- src/content/tutorials/cherry-picking-commits-git.mdx: EN

Bilingual, linked for i18n in frontmatter. No other files changed.