### PR TITLE
feat(tutorials): add 'AI Limitations and Detecting Hallucinations' tutorial (EN + ES)

### DIFF
--- a/src/content/tutorials/ai-limitations-detecting-hallucinations.mdx
+++ b/src/content/tutorials/ai-limitations-detecting-hallucinations.mdx
@@ -1,0 +1,219 @@
+---
+title: "AI Limitations and How to Detect Hallucinations"
+post_slug: "ai-limitations-detecting-hallucinations"
+date: "2026-04-21"
+excerpt: "AI lies with total conviction. Learn to detect hallucinations, understand context blindness, and apply the verification checklist that separates code that works from code that looks like it works."
+language: "en"
+categories: ["ai"]
+course: "ai-for-developers"
+order: 4
+cover: "/images/tutorials/cabecera-ia-para-programadores-curso.jpg"
+i18n: "limitaciones-ia-detectar-alucinaciones"
+---
+
+This has either already happened to you or it's going to. You ask the AI to help with something concrete — parsing a JSON response using a library you've been using for years. It gives you the code. The syntax looks right, the names make sense, the comments are clear. You copy, paste, run.
+
+`AttributeError: module 'requests' has no attribute 'get_json'`.
+
+`requests.get_json` doesn't exist. It never existed. But the AI served it up with the same confidence it would use for `response.json()` — the function that's actually real — with no warning, no footnote, no "hey, I'm not totally sure about this one."
+
+That's a hallucination. And here's where it gets fun.
+
+## Why AI lies with such conviction
+
+In tutorial 2, we established that LLMs predict the next word. Hallucinations flow directly from that mechanic.
+
+The model doesn't have access to a database of verified facts. It doesn't consult the official documentation before answering you. There's no internal module that says "wait, is this actually true?" What it has is a statistical model trained to generate text that sounds coherent and plausible.
+
+When you ask about a function that doesn't exist, it isn't deliberately lying — it generates text that has the _shape_ of a correct answer. It's seen thousands of responses about library functions and it "knows" what a correct answer looks like. The content may be invented. The form is always impeccable. That's the trap.
+
+```python
+# What you asked for:
+# "How do I parse a JSON response body with requests?"
+
+# What the AI might give you (invented with full confidence):
+import requests
+response = requests.get("https://api.example.com/data")
+data = requests.get_json(response)  # ❌ Does not exist
+
+# What's actually correct:
+import requests
+response = requests.get("https://api.example.com/data")
+data = response.json()  # ✅ Method on the Response object
+```
+
+Both versions have the same structure, the same descriptive names, the same "this works" energy. Only one of them actually works. And the one that doesn't — if you're like me when I first started using AI for code — is exactly the one you copy without blinking because it looks so reasonable.
+
+## The three types of AI error
+
+Not all hallucinations are the same. Recognizing the type gives you a clue about where to look.
+
+### Invented information
+
+The model generates something that never existed: a function, a parameter, a class, an endpoint. Like `requests.get_json`. This is the friendliest type — it fails fast and loudly. The code doesn't run, the error is obvious.
+
+The typical pattern: names that sound right but don't appear in the official documentation. If a function name the AI gave you doesn't show up in your editor's autocomplete or in the docs... suspect it.
+
+### Outdated information
+
+This one is more complicated. The model has a **training cutoff date** — the point when they stopped feeding it new data. Anything that happened after that date simply doesn't exist for it. It's not ignoring it — it genuinely doesn't know.
+
+That includes:
+
+- APIs that went through a major version change (Flask 2.x → 3.x, Django 4.x → 5.x)
+- Deprecated methods that were removed in recent versions
+- Security patterns that turned out to be vulnerable
+- New approaches to things that used to be done differently
+
+What makes this dangerous is that the code **works** — just on an older version of the library. On your project, with your current `requirements.txt`, it might fail silently, behave differently, or introduce a known vulnerability. Works on my machine™ taken to its logical extreme.
+
+```python
+# What the AI might recommend (older Flask, perfectly valid in its day):
+from flask import request
+
+@app.route('/login', methods=['POST'])
+def login():
+    data = request.get_json(force=True)
+
+# What you might want to be using today:
+from flask import request
+
+@app.route('/login', methods=['POST'])
+def login():
+    data = request.get_json()  # force is no longer needed in Flask 3.x for JSON content-type
+```
+
+Neither throws an error. But one can produce unexpected behavior depending on your version. The AI doesn't know — it genuinely doesn't know which version you're running unless you tell it.
+
+### Context blindness
+
+This is the subtlest, the most common in real work, and the hardest to catch. The model doesn't know your codebase, your team's conventions, your architecture's constraints. It makes assumptions — the most statistically reasonable ones. Which aren't necessarily yours.
+
+Imagine asking for help adding authentication to an endpoint. The model assumes:
+
+- You're using JWT (reasonable — it's the most common approach)
+- You have a `users` table in your database (reasonable)
+- The token header is called `Authorization` (it's the standard)
+- You have an authentication middleware available (might not be true)
+
+If any of those assumptions doesn't apply to your system, the generated code might compile, pass a quick review, and fail in production in non-obvious ways.
+
+```python
+# What the AI assumes:
+@require_auth          # Do you have this decorator? Is that what it's called in your project?
+@app.route('/api/v1/users/profile')
+def get_profile():
+    user_id = g.current_user.id  # Do you have g.current_user? With that exact name?
+    ...
+
+# What your project might actually have:
+@login_required        # Your decorator has a different name
+@app.route('/api/v1/users/profile')
+def get_profile():
+    user_id = session['user']['id']  # Your project uses sessions, not JWT
+    ...
+```
+
+The error here isn't that the AI is "wrong" in the abstract. It's answering your question while assuming a context that isn't yours.
+
+## The warning signs to learn
+
+Over time, you develop a nose for this. How do I know this output is suspicious? How do I tell what it knows from what it's inventing? In the meantime, here are the most common red flags:
+
+**Names you don't recognize.** If the AI gives you a function, method, or class name that doesn't show up in your autocomplete or the official docs, stop before going further. It's not that you're behind — it might be straight-up invented.
+
+**Maximum confidence on specific or poorly-documented topics.** The more obscure the topic, the higher the risk. The AI has far more training data about Flask than about your internal company library, or about the standard ORM versus the tuned version your team has been running since 2019 (and nobody ever properly documented, let's be honest).
+
+**Specific version numbers without a source.** "This works since version 3.2" — where did that number come from? If it can't cite a source, treat the claim as unverified.
+
+**Code with the right shape that fails at runtime.** `ModuleNotFoundError`, `AttributeError`, `ImportError` after running "looks-correct" code — classic signature of an API hallucination.
+
+**Answers that shift when you rephrase the question.** If you ask the same thing two different ways and get contradictory answers, the AI doesn't have certainty — it's generating plausible versions, not verified facts.
+
+## The verification checklist
+
+This isn't theory. It's what keeps AI-generated code from becoming a production problem. Five steps, in order, before merging any block you didn't write yourself.
+
+```
+1. Does it execute without errors?
+   → Run it. An immediate stack trace = start hunting for the invented name
+
+2. Do the functions it uses exist in the official documentation?
+   → Search for the exact name in the docs for your version, not the latest
+
+3. Is the syntax valid for your version?
+   → Check the changelog if something looks "weird" or suspiciously new
+
+4. Do the edge cases work?
+   → Null, empty string, empty list, negative number — test the ones that matter to you
+
+5. Do the assumptions it makes apply to your context?
+   → Naming conventions, project structure, available libraries
+```
+
+Step 2 is the most commonly skipped — and the one that lets the most hallucinations through. "It works" doesn't mean "it uses real functions." It might work in your environment with your version of the library and break in CI, in production, or on another developer's machine. Don't ask me how I know.
+
+Verification doesn't need to be exhaustive for every line. For a 10-line block doing something familiar, a quick glance is enough. For authentication code, for code that touches the database, for code that handles money or permissions — careful verification, no exceptions.
+
+## The "show me the documentation" tactic
+
+When you suspect a hallucination, there's a move that works surprisingly well: ask the AI to cite its source.
+
+```
+"Which version introduced the strict_mode parameter for json.loads()?
+Can you give me the exact link to that section in the official documentation?"
+```
+
+When it's hallucinating, it usually can't give you a valid URL — or it gives you one that 404s. If it can give you the exact URL and the correct version number, the information is probably real.
+
+Fair warning: it's not foolproof. Newer models can generate URLs that look completely legitimate and aren't (because _inventing a plausible-sounding URL_ is also just predicting coherent text). But it adds a useful friction layer.
+
+```
+You: "Can you cite the section of the requests docs that covers get_json()?"
+AI:  "My information may be outdated. Let me check..."
+     [invented URL that 404s]
+     → Stop. Verify before continuing.
+```
+
+## How to compensate for context blindness
+
+The antidote is giving it context. This sounds obvious, but the practical difference between a context-free prompt and a context-rich one is enormous — not because the model gets smarter, but because it has to make fewer assumptions.
+
+```python
+# ❌ No context:
+"Help me add caching to this database query function"
+
+# ✅ With context:
+"""I have this function in Python 3.12 with SQLAlchemy 2.0:
+
+[function code]
+
+I want to add caching with Redis. In our project we already use redis-py 5.x
+and have a client available as redis_client (injected singleton via DI).
+We follow the repository pattern — caching should be transparent to the business layer.
+"""
+```
+
+With the second prompt, the AI knows you already have Redis, which version, what the client is called, and which architectural pattern to respect. Far fewer assumptions to make — and the ones it does make are far more likely to be correct.
+
+The practical rule: before asking for help with production code, ask yourself what a new colleague would need to know to help you without making mistakes. That's exactly what the AI needs.
+
+## What the AI can never know
+
+There are things that won't be in any LLM's training context, no matter when it was trained:
+
+- Your team's specific conventions
+- Known bugs in your internal services
+- The architectural decisions you made two years ago and why
+- The business context behind why something works "strangely"
+- The implicit dependencies between modules that nobody ever documented
+
+For these things, AI is a starting point, not an endpoint. It can generate the structure, give you the general pattern, save you the boilerplate. The adjustment to your project's context — that part is yours.
+
+This isn't a criticism of AI. It's the nature of the problem. A senior developer joining your team also doesn't know any of this on day one. The difference is that the human can ask proactively and learn over time. The AI only knows what you show it in the current context window.
+
+---
+
+You now have the full map of why AI fails and how to catch it before it reaches production. The next step is putting this into practice — and for that, you need the tools. In the next tutorial, we install and configure **opencode**, the agent we'll use for the rest of the course, and run the first real AI-assisted coding session on an actual project.
+
+Never stop coding!

--- a/src/content/tutorials/limitaciones-ia-detectar-alucinaciones.mdx
+++ b/src/content/tutorials/limitaciones-ia-detectar-alucinaciones.mdx
@@ -1,0 +1,219 @@
+---
+title: "Limitaciones de la IA y cómo detectar alucinaciones"
+post_slug: "limitaciones-ia-detectar-alucinaciones"
+date: "2026-04-21"
+excerpt: "La IA miente con total convicción. Aprende a detectar alucinaciones, qué provoca la ceguera contextual, y el checklist de verificación que separa el código que funciona del que parece que funciona."
+language: "es"
+categories: ["ia"]
+course: "ia-para-programadores"
+order: 4
+cover: "/images/tutorials/cabecera-ia-para-programadores-curso.jpg"
+i18n: "ai-limitations-detecting-hallucinations"
+---
+
+Esto ya te ha pasado, o te va a pasar pronto. Le pides a la IA que te ayude con algo concreto — parsear una respuesta JSON con una librería que llevas años usando. Te da el código. La sintaxis es correcta, los nombres tienen sentido, los comentarios son claros. Copias, pegas, ejecutas.
+
+`AttributeError: module 'requests' has no attribute 'get_json'`.
+
+No existe `requests.get_json`. Nunca existió. Pero la IA te lo sirvió con la misma seguridad con que te habría dado `response.json()`, que es la función real. Sin aviso, sin nota al pie, sin un "oye, no estoy del todo seguro de esto".
+
+Eso es una alucinación. Y aquí es donde se pone interesante.
+
+## Por qué la IA miente con tanta convicción
+
+En el tutorial 2 vimos que los LLMs predicen la siguiente palabra. De esa mecánica sale, directamente, el fenómeno de las alucinaciones.
+
+El modelo no tiene acceso a una base de datos de hechos verificados. No consulta la documentación oficial antes de responderte. No tiene un módulo interno que diga "espera, ¿esto es verdad?". Lo que tiene es un modelo estadístico entrenado para generar texto que suene coherente y plausible.
+
+Cuando le preguntas por una función que no existe, no miente deliberadamente — genera texto que tiene la _forma_ de la respuesta correcta. Ha visto miles de respuestas sobre funciones de librería y "sabe" cómo suena una respuesta correcta. El contenido puede ser inventado. La forma siempre es impecable. Esa es la trampa.
+
+```python
+# Lo que pediste:
+# "Cómo parseo el body de una respuesta JSON con requests?"
+
+# Lo que la IA puede darte (inventado con total confianza):
+import requests
+response = requests.get("https://api.example.com/data")
+data = requests.get_json(response)  # ❌ No existe
+
+# Lo correcto:
+import requests
+response = requests.get("https://api.example.com/data")
+data = response.json()  # ✅ Método del objeto Response
+```
+
+Las dos versiones tienen la misma estructura, los mismos nombres descriptivos, la misma pinta de "esto funciona". Solo una de ellas funciona. Y la que no funciona es, si eres como yo cuando empecé con esto, exactamente la que copias sin pestañear porque tiene muy buena pinta.
+
+## Los tres tipos de error que comete la IA
+
+No todas las alucinaciones son iguales. Reconocer el tipo te da pistas de dónde buscar.
+
+### Información inventada
+
+El modelo genera algo que nunca existió: una función, un parámetro, una clase, un endpoint. Como `requests.get_json`. Es el tipo más amable — falla rápido y ruidosamente. El código no ejecuta, el error es obvio.
+
+El patrón habitual: nombres que suenan bien pero que no aparecen en la documentación oficial. Si el nombre de una función que te dio la IA no sale en la autocomplete de tu editor ni en la docs... sospecha.
+
+### Información desactualizada
+
+Aquí la cosa se complica. El modelo tiene una **fecha de corte de entrenamiento** — el momento en que dejaron de darle nuevos datos. Cualquier cosa que ocurrió después simplemente no existe para él. No es que lo ignore — es que no lo sabe.
+
+Eso incluye:
+
+- APIs que cambiaron de versión principal (Flask 2.x → 3.x, Django 4.x → 5.x)
+- Métodos deprecados que se eliminaron en versiones recientes
+- Patrones de seguridad que resultaron ser vulnerables
+- Nuevas formas de hacer algo que antes se hacía diferente
+
+Lo peligroso de este tipo es que el código **funciona** — pero en una versión anterior de la librería. En tu proyecto, con tu `requirements.txt` actual, puede fallar silenciosamente, comportarse diferente, o introducir una vulnerabilidad conocida. Works on my machine™ llevado a su máxima expresión.
+
+```python
+# Lo que la IA podría recomendarte (Flask antiguo, perfectamente válido en su época):
+from flask import request
+
+@app.route('/login', methods=['POST'])
+def login():
+    data = request.get_json(force=True)
+
+# Lo que quizás deberías estar usando hoy:
+from flask import request
+
+@app.route('/login', methods=['POST'])
+def login():
+    data = request.get_json()  # force ya no es necesario en Flask 3.x para content-type JSON
+```
+
+Ninguno da error. Pero uno puede generar comportamientos inesperados dependiendo de tu versión. La IA no lo sabe — genuinamente no sabe en qué versión estás, a menos que se lo digas.
+
+### Ceguera contextual
+
+Esta es la más sutil, la más frecuente en el trabajo real, y la que más cuesta detectar. El modelo no conoce tu codebase, no conoce las convenciones de tu equipo, no conoce las restricciones de tu arquitectura. Hace suposiciones. ¿Cuáles? Las más razonables estadísticamente. Que no necesariamente son las tuyas.
+
+Imagina que le pides ayuda para añadir autenticación a un endpoint. El modelo asume:
+
+- Que usas JWT (razonable — es lo más común)
+- Que tienes una tabla `users` en tu base de datos (razonable)
+- Que el campo del token se llama `Authorization` (es el estándar)
+- Que tienes un middleware de autenticación disponible (puede que no)
+
+Si alguna de esas suposiciones no aplica a tu sistema, el código que genera puede compilar, pasar una revisión rápida, y fallar en producción de formas nada obvias.
+
+```python
+# Lo que la IA asume:
+@require_auth          # ¿Tienes este decorator? ¿Se llama así en tu proyecto?
+@app.route('/api/v1/users/profile')
+def get_profile():
+    user_id = g.current_user.id  # ¿Tienes g.current_user? ¿Con ese nombre exacto?
+    ...
+
+# Lo que quizás tiene tu proyecto:
+@login_required        # Tu decorator tiene otro nombre
+@app.route('/api/v1/users/profile')
+def get_profile():
+    user_id = session['user']['id']  # Tu proyecto usa sesiones, no JWT
+    ...
+```
+
+El error aquí no es que la IA esté "equivocada" en abstracto. Es que está respondiendo a tu pregunta asumiendo un contexto que no es el tuyo.
+
+## Las señales que deberías aprender a reconocer
+
+Con el tiempo desarrollas un olfato. ¿Cómo sé que este output es sospechoso? ¿Cómo distingo lo que sabe de lo que inventa? Mientras tanto, estas son las banderas rojas más comunes:
+
+**Nombres que no reconoces.** Si la IA te da el nombre de una función, método o clase que no aparece en tu autocomplete ni en la documentación oficial, para antes de continuar. No es que estés desactualizado — puede ser directamente inventado.
+
+**Confianza máxima en temas específicos o poco documentados.** Cuanto más oscuro es el tema, mayor el riesgo. La IA tiene muchos más datos de entrenamiento sobre Flask que sobre tu librería interna de empresa, o sobre el ORM estándar que sobre la versión tuneada que usa tu equipo desde 2019 (y que nadie ha documentado bien, seamos honestos).
+
+**Versiones concretas sin fuente.** "Esto funciona desde la versión 3.2" — ¿de dónde sacó ese número? Si no puede citarte la fuente, trátalo como no verificado.
+
+**Código que tiene la forma correcta pero falla en runtime.** `ModuleNotFoundError`, `AttributeError`, `ImportError` después de ejecutar código que "parecía correcto" — firma clásica de alucinación de API.
+
+**Respuestas que cambian si reformulas la pregunta.** Si preguntas lo mismo de dos formas y obtienes respuestas contradictorias, la IA no tiene certeza — está generando versiones plausibles, no hechos verificados.
+
+## El checklist de verificación
+
+Esto no es teoría. Es lo que evita que el código generado por IA se convierta en un problema en producción. Cinco pasos, en orden, antes de hacer merge de cualquier bloque que no hayas escrito tú.
+
+```
+1. ¿Ejecuta sin errores?
+   → Ejecútalo. Un stack trace inmediato = empieza a buscar el nombre inventado
+
+2. ¿Las funciones que usa existen en la documentación oficial?
+   → Busca el nombre exacto en las docs de la versión que usas tú, no la última
+
+3. ¿La sintaxis es válida en tu versión?
+   → Revisa el changelog si algo parece "raro" o demasiado nuevo
+
+4. ¿Los edge cases funcionan?
+   → Null, string vacío, lista vacía, número negativo — prueba los que te importan
+
+5. ¿Las suposiciones que hace aplican a tu contexto?
+   → Naming conventions, estructura del proyecto, librerías disponibles
+```
+
+El paso 2 es el que más se salta — y el que más alucinaciones deja pasar. "Funciona" no significa "usa funciones reales". Puede funcionar en tu entorno con tu versión de la librería y romperse en CI, en producción, o en el portátil de otro desarrollador. No preguntes cómo lo sé.
+
+La verificación no tiene que ser exhaustiva para cada línea. Para un bloque de 10 líneas que hace algo que conoces bien, un vistazo rápido basta. Para código de autenticación, para código que toca la base de datos, para código que maneja dinero o permisos — verificación cuidadosa, sin excepciones.
+
+## La táctica de "muéstrame la documentación"
+
+Cuando sospechas de una alucinación, hay un movimiento que funciona sorprendentemente bien: pídele a la IA que te cite la fuente.
+
+```
+"¿En qué versión se introdujo el parámetro strict_mode de json.loads()?
+¿Puedes darme el link exacto a la sección de la documentación oficial?"
+```
+
+Si alucina, suele no poder darte una URL válida — o te da una que 404. Si puede darte la URL exacta y el número de versión correcto, la información probablemente es real.
+
+Ojo: no es infalible. Los modelos más nuevos pueden generar URLs que tienen toda la pinta de ser válidas y no lo son (porque también _inventar una URL que suene bien_ es predecir texto coherente). Pero añade una capa de fricción útil.
+
+```
+Tú: "¿Puedes citar la sección de la docs de requests donde aparece get_json()?"
+IA:  "Mi información puede estar desactualizada. Déjame comprobar..."
+     [URL inventada que 404]
+     → Para. Verifica antes de seguir.
+```
+
+## Cómo compensar la ceguera contextual
+
+El antídoto es darle contexto. Suena obvio, pero la diferencia práctica entre un prompt sin contexto y uno con contexto es enorme — no porque el modelo sea más listo, sino porque tiene que hacer menos suposiciones.
+
+```python
+# ❌ Prompt sin contexto:
+"Ayúdame a añadir caching a esta función de consulta a base de datos"
+
+# ✅ Prompt con contexto:
+"""Tengo esta función en Python 3.12 con SQLAlchemy 2.0:
+
+[código de la función]
+
+Quiero añadir caching con Redis. En nuestro proyecto ya usamos redis-py 5.x
+y tenemos un cliente disponible como redis_client (singleton inyectado por DI).
+Seguimos el patrón repository — el caching debe ser transparente para la capa de negocio.
+"""
+```
+
+Con el segundo prompt, la IA sabe que ya tienes Redis, qué versión, cómo se llama el cliente, y qué patrón arquitectónico tiene que respetar. Las suposiciones que tiene que hacer son muchas menos — y las que hace, más probables de ser correctas.
+
+La regla práctica: antes de pedir ayuda con código de producción, pregúntate qué tendría que saber un compañero nuevo para ayudarte sin equivocarse. Eso es exactamente lo que necesita la IA.
+
+## Lo que la IA no puede saber nunca
+
+Hay cosas que no van a estar en el contexto de entrenamiento de ningún LLM, sin importar cuándo fue entrenado:
+
+- Las convenciones específicas de tu equipo
+- Los bugs conocidos de tus servicios internos
+- Las decisiones arquitectónicas que tomásteis hace dos años y por qué
+- El contexto de negocio de por qué algo funciona "raro"
+- Las dependencias implícitas entre módulos que nadie documentó
+
+Para este tipo de cosas, la IA es un punto de partida, no un punto de llegada. Puede generarte la estructura, puede darte el patrón general, puede ahorrarte el boilerplate. El ajuste al contexto de tu proyecto — ese es tuyo.
+
+No es una crítica a la IA. Es la naturaleza del problema. Un senior developer que se incorpora a tu equipo tampoco conoce nada de esto el primer día. La diferencia es que el humano puede preguntar de forma proactiva y aprender con el tiempo. La IA solo sabe lo que le muestras en la ventana de contexto actual.
+
+---
+
+Ya tienes el mapa completo de por qué la IA falla y cómo detectarlo antes de que llegue a producción. El siguiente paso es poner esto en práctica — y para eso necesitas las herramientas. En el siguiente tutorial, instalamos y configuramos **opencode**, el agente que usaremos durante todo el resto del curso, y hacemos la primera sesión real de trabajo con IA en un proyecto de código.
+
+¡Nunca dejes de programar!


### PR DESCRIPTION
Adds a new bilingual tutorial on LLM limitations, hallucinations and verification, available both in English and Spanish.