### PR TITLE
feat(tutorials): add Finding bugs with git bisect tutorial (EN + ES)

### DIFF
--- a/src/content/tutorials/encontrando-bugs-git-bisect.mdx
+++ b/src/content/tutorials/encontrando-bugs-git-bisect.mdx
@@ -1,0 +1,179 @@
+---
+title: "Encontrando bugs con git bisect"
+post_slug: "encontrando-bugs-git-bisect"
+date: "2026-04-24"
+excerpt: "Aprende a usar git bisect para encontrar con búsqueda binaria el commit exacto que introdujo un bug, y a automatizarlo para que Git lo haga solo mientras tú esperas."
+language: "es"
+categories: ["git"]
+course: "domina-git-desde-cero"
+order: 23
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "finding-bugs-git-bisect"
+---
+
+Hay un bug en producción. No estaba ayer. Alguien lo introdujo en algún commit de las últimas dos semanas, pero el historial tiene 200 entradas — "fix", "wip", "refactor auth", "more fixes", los clásicos. Podrías ir uno a uno hacia atrás haciendo checkout y probando si el bug aparece. Podrías. También podrías buscar el bug mirando el código línea a línea, o adivinar quién lo metió basándote en el nombre del commit y la intuición. Todo eso es debugging por fuerza bruta: lento, agotador, y con una tasa de éxito que depende demasiado de la suerte.
+
+`git bisect` hace búsqueda binaria sobre tu historial. En lugar de revisar 200 commits, revisas 8. Git elige cuál probar cada vez, tú le dices si el bug está o no, y en unos pocos pasos te señala el commit culpable con el dedo. Es una de esas herramientas que cuando la descubres te preguntas cómo has podido vivir sin ella.
+
+## Cómo funciona la búsqueda binaria
+
+La idea es la misma que para buscar una palabra en un diccionario: no empiezas por la primera página. Abres por el medio, decides si la palabra está antes o después, y descartas la mitad que no te interesa. Luego repites con la mitad restante. En siete pasos puedes recorrer un diccionario de 128 páginas.
+
+Git aplica exactamente esa lógica al historial de commits. Le dices: "sé que en el commit `v2.0.0` el bug no existía, y sé que ahora mismo sí existe." Git hace checkout del commit del medio, tú pruebas, le dices `good` o `bad`, y descarta la mitad incorrecta. Sigues hasta que solo queda un commit — ese es el que introdujo el problema.
+
+Con 200 commits, bisect necesita como máximo **8 pasos**. Con 1000, unos 10. La matemática no miente.
+
+## Uso básico
+
+Antes de empezar, asegúrate de que tienes el working tree limpio. Bisect va a hacer varios checkouts automáticos y no quiere encontrarse cambios a medias por el camino.
+
+```bash
+git stash          # save any work in progress
+git bisect start
+```
+
+Ahora le dices cuál es el estado actual (malo) y cuál es el último punto en que sabes que todo funcionaba (bueno):
+
+```bash
+git bisect bad          # current commit has the bug
+git bisect good v2.0.0  # this tag/commit was clean
+```
+
+Git calcula cuántos commits hay entre los dos puntos y hace checkout del del medio:
+
+```
+Bisecting: 99 revisions left to test after this (roughly 7 steps)
+[a3f9c12] Refactor authentication middleware
+```
+
+Ahora pruebas. ¿El bug aparece? Si sí:
+
+```bash
+git bisect bad
+```
+
+Si no:
+
+```bash
+git bisect good
+```
+
+Git descarta la mitad incorrecta, hace checkout del siguiente commit candidato, y espera tu veredicto. Repites. En unos pocos pasos verás algo así:
+
+```
+a3f9c12 is the first bad commit
+commit a3f9c12
+Author: Ana García <ana@example.com>
+Date:   Mon Apr 14 11:23:01 2026 +0200
+
+    Refactor authentication middleware
+
+ src/auth/middleware.ts | 47 ++++++++++++++++++++++++++-----------
+ 1 file changed, 33 insertions(+), 14 deletions(-)
+```
+
+Git te entrega el commit exacto: hash, autor, fecha, mensaje y archivos cambiados. Lo que hagas con esa información ya es problema tuyo — bisect ha hecho su trabajo.
+
+Cuando termines, tanto si encontraste el bug como si quieres salir por cualquier otro motivo:
+
+```bash
+git bisect reset
+```
+
+Esto te devuelve al estado en que estabas antes de empezar. Sin rastro.
+
+## Usando referencias en lugar de hashes
+
+No tienes que saber el hash exacto del commit "bueno". Puedes usar cualquier referencia que Git entienda:
+
+```bash
+git bisect good v2.0.0          # a tag
+git bisect good main~30         # 30 commits before main
+git bisect good 2026-04-01      # approximate date (Git interprets this)
+git bisect good origin/release  # a remote branch
+```
+
+La fecha aproximada es especialmente útil cuando sabes "hace una semana funcionaba" pero no recuerdas en qué commit estabas. Git la interpreta y encuentra el commit más cercano.
+
+## Automatizar bisect con un script
+
+Aquí es donde bisect pasa de "útil" a "absurdamente potente". Si tienes un test automatizado que reproduce el bug, puedes decirle a Git que ejecute ese test en cada paso y clasifique los commits solo. Tú te levantas a buscar un café y cuando vuelves Git ya tiene la respuesta.
+
+```bash
+git bisect start
+git bisect bad HEAD
+git bisect good v2.0.0
+git bisect run npm test
+```
+
+Git ejecuta `npm test` en cada commit candidato. Si el comando sale con código 0, el commit es **bueno**. Si sale con código 1–127, es **malo**. Bisect avanza solo hasta encontrar el culpable.
+
+El script puede ser cualquier cosa: un test concreto, un script bash que comprueba un comportamiento específico, incluso un `curl` contra un endpoint local. Lo importante es que el código de salida refleje si el bug está presente o no:
+
+```bash
+#!/bin/bash
+# check-bug.sh
+
+# Start the app in background
+node server.js &
+SERVER_PID=$!
+sleep 1
+
+# Test if the bug is present
+RESULT=$(curl -s http://localhost:3000/api/user/1 | jq '.name')
+
+# Clean up
+kill $SERVER_PID
+
+# Exit 0 = good (no bug), exit 1 = bad (bug present)
+if [ "$RESULT" = "null" ]; then
+  exit 1   # bug present — name should not be null
+else
+  exit 0   # all good
+fi
+```
+
+```bash
+git bisect run ./check-bug.sh
+```
+
+Hay un código de salida especial que vale la pena conocer: el **125**. Si tu script sale con 125, bisect interpreta que ese commit no se puede probar (por ejemplo, no compila, tiene dependencias rotas, o el entorno no está listo) y lo salta sin marcarlo como bueno ni malo. Es la salida de emergencia para commits que no son relevantes para la búsqueda — no contamina el resultado.
+
+```bash
+# Example: skip if the project doesn't compile
+if ! npm run build; then
+  exit 125   # skip this commit, can't test it
+fi
+npm test
+```
+
+## Ver el estado del bisect en curso
+
+Si en algún momento pierdes el hilo de dónde estás en la búsqueda:
+
+```bash
+git bisect log      # full history of good/bad verdicts so far
+git bisect view     # visual representation of the remaining range
+```
+
+`git bisect log` también es útil para reproducir una sesión después. Puedes guardar su salida y usarla con `git bisect replay` si necesitas repetir la búsqueda desde el principio.
+
+## Cuándo bisect no es la herramienta adecuada
+
+Bisect es espectacular para bugs de regresión — algo que antes funcionaba y dejó de funcionar. Para eso es exactamente para lo que fue diseñado.
+
+Pero hay casos en los que no ayuda tanto:
+
+- **El bug siempre estuvo ahí**: si no existe ningún commit "bueno" de referencia, bisect no tiene punto de partida.
+- **El bug es intermitente**: si el comportamiento cambia entre ejecuciones, los veredictos `good`/`bad` no son fiables y bisect te llevará por el camino incorrecto.
+- **Los tests tardan mucho**: si cada paso tarda diez minutos, la automatización pierde parte de su encanto. Bisect sigue siendo útil en modo manual, pero la magia del "voy a por un café y cuando vuelvo está" desaparece.
+
+Para esos casos, `git log -S "string"` (busca commits que añadieron o quitaron una cadena concreta) y `git blame` son alternativas más directas. Los veremos en la siguiente lección.
+
+---
+
+Bisect es uno de esos comandos que parece cosa de magia la primera vez que lo ves funcionar. Tienes 300 commits, cinco minutos de sesión interactiva, y Git te entrega el nombre del commit, el autor y los archivos cambiados. La sensación es bastante satisfactoria — especialmente si el autor del commit resulta ser otra persona (o tú de hace tres semanas, que es casi lo mismo).
+
+En la siguiente lección nos metemos con `git blame` y las herramientas de exploración del historial: cómo saber quién tocó qué línea, cuándo, y por qué — el toolkit completo para entender un codebase que llevas cinco minutos viendo por primera vez.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/finding-bugs-git-bisect.mdx
+++ b/src/content/tutorials/finding-bugs-git-bisect.mdx
@@ -1,0 +1,179 @@
+---
+title: "Finding bugs with git bisect"
+post_slug: "finding-bugs-git-bisect"
+date: "2026-04-24"
+excerpt: "Learn to use git bisect to find the exact commit that introduced a bug using binary search — and how to automate it so Git does all the work while you grab a coffee."
+language: "en"
+categories: ["git"]
+course: "mastering-git-from-scratch"
+order: 23
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "encontrando-bugs-git-bisect"
+---
+
+There's a bug in production. It wasn't there yesterday. Someone introduced it in one of the last two weeks of commits, but the log has 200 entries — "fix", "wip", "refactor auth", "more fixes", the usual suspects. You could check out commits one by one going backwards, testing each time. You could also read every changed line of code looking for the culprit, or try to guess based on commit messages and gut instinct. All of that is brute-force debugging: slow, exhausting, and dependent on luck in a way that should be illegal.
+
+`git bisect` does binary search on your commit history. Instead of reviewing 200 commits, you review 8. Git picks which one to test each time, you tell it whether the bug is there or not, and in a few steps it points a finger at the exact culprit commit. It's one of those tools where you find out it exists and immediately wonder how you've been debugging without it.
+
+## How binary search works here
+
+Same idea as finding a word in a dictionary: you don't start at page one. You open to the middle, decide whether the word comes before or after, and discard the irrelevant half. Repeat with the remaining half. Seven steps covers a 128-page dictionary.
+
+Git applies that exact logic to your commit history. You say: "I know the bug didn't exist at `v2.0.0`, and I know it exists right now." Git checks out the middle commit, you test, you say `good` or `bad`, it discards the wrong half. Keep going until only one commit remains — that's the one that introduced the problem.
+
+With 200 commits, bisect needs at most **8 steps**. With 1,000, around 10. The math doesn't lie.
+
+## Basic usage
+
+Before starting, make sure your working tree is clean. Bisect is going to do several automatic checkouts and doesn't want to find half-finished changes in the way.
+
+```bash
+git stash          # save any work in progress
+git bisect start
+```
+
+Now tell it which state is bad (current) and which was known good:
+
+```bash
+git bisect bad          # current commit has the bug
+git bisect good v2.0.0  # this tag/commit was clean
+```
+
+Git calculates how many commits sit between the two points and checks out the middle one:
+
+```
+Bisecting: 99 revisions left to test after this (roughly 7 steps)
+[a3f9c12] Refactor authentication middleware
+```
+
+Now you test. Does the bug appear? If yes:
+
+```bash
+git bisect bad
+```
+
+If no:
+
+```bash
+git bisect good
+```
+
+Git discards the wrong half, checks out the next candidate, and waits for your verdict. Repeat. After a few steps you'll see something like this:
+
+```
+a3f9c12 is the first bad commit
+commit a3f9c12
+Author: Ana García <ana@example.com>
+Date:   Mon Apr 14 11:23:01 2026 +0200
+
+    Refactor authentication middleware
+
+ src/auth/middleware.ts | 47 ++++++++++++++++++++++++++-----------
+ 1 file changed, 33 insertions(+), 14 deletions(-)
+```
+
+Git hands you the exact commit: hash, author, date, message, and changed files. What you do with that information is up to you — bisect has done its job.
+
+When you're done, whether you found the bug or just want to exit:
+
+```bash
+git bisect reset
+```
+
+This puts you back exactly where you were before starting. Clean slate.
+
+## Using references instead of hashes
+
+You don't need to know the exact hash of the "good" commit. Any reference Git understands works:
+
+```bash
+git bisect good v2.0.0          # a tag
+git bisect good main~30         # 30 commits before main
+git bisect good 2026-04-01      # approximate date
+git bisect good origin/release  # a remote branch
+```
+
+The approximate date is particularly handy when you know "it worked last week" but don't remember which commit you were on. Git interprets it and finds the nearest commit.
+
+## Automating bisect with a script
+
+This is where bisect goes from "useful" to "unreasonably powerful." If you have an automated test that reproduces the bug, you can tell Git to run that test at each step and classify commits on its own. You walk away to get coffee and come back to a solved mystery.
+
+```bash
+git bisect start
+git bisect bad HEAD
+git bisect good v2.0.0
+git bisect run npm test
+```
+
+Git runs `npm test` on each candidate commit. Exit code 0 means the commit is **good**. Exit codes 1–127 mean **bad**. Bisect advances on its own until it finds the culprit.
+
+The script can be anything: a specific test, a bash script that checks a particular behavior, even a `curl` against a local endpoint. The only rule is that the exit code must honestly reflect whether the bug is present:
+
+```bash
+#!/bin/bash
+# check-bug.sh
+
+# Start the app in background
+node server.js &
+SERVER_PID=$!
+sleep 1
+
+# Test if the bug is present
+RESULT=$(curl -s http://localhost:3000/api/user/1 | jq '.name')
+
+# Clean up
+kill $SERVER_PID
+
+# Exit 0 = good (no bug), exit 1 = bad (bug present)
+if [ "$RESULT" = "null" ]; then
+  exit 1   # bug present — name should not be null
+else
+  exit 0   # all good
+fi
+```
+
+```bash
+git bisect run ./check-bug.sh
+```
+
+There's one special exit code worth knowing: **125**. If your script exits with 125, bisect treats that commit as untestable — it skips it without marking it good or bad. Use this when a commit doesn't compile, has broken dependencies, or otherwise can't be tested. It keeps that commit from contaminating the result.
+
+```bash
+# Example: skip if the project doesn't compile
+if ! npm run build; then
+  exit 125   # skip this commit, can't test it
+fi
+npm test
+```
+
+## Checking bisect progress
+
+If you lose track of where you are in the search:
+
+```bash
+git bisect log      # full history of verdicts so far
+git bisect view     # visual representation of the remaining range
+```
+
+`git bisect log` is also useful for reproducing a session later. Save its output and use `git bisect replay` if you need to repeat the same search from scratch.
+
+## When bisect isn't the right tool
+
+Bisect is spectacular for regression bugs — something that worked before and stopped working. That's exactly what it was designed for.
+
+But there are cases where it doesn't help as much:
+
+- **The bug was always there**: if no "good" commit exists, bisect has no starting point.
+- **The bug is intermittent**: if behavior changes between runs, `good`/`bad` verdicts become unreliable and bisect will lead you astray.
+- **Tests take too long**: if each step takes ten minutes, automation loses most of its appeal. Bisect is still useful in manual mode, but the "walk away and come back to an answer" magic evaporates.
+
+For those cases, `git log -S "string"` (finds commits that added or removed a specific string) and `git blame` are more direct alternatives. We'll cover both in the next lesson.
+
+---
+
+Bisect is one of those commands that looks like magic the first time you see it work. You have 300 commits, five minutes of back-and-forth, and Git hands you the commit, the author, and the changed files. It's genuinely satisfying — especially if the commit author turns out to be someone else (or past-you from three weeks ago, which is practically the same thing).
+
+In the next tutorial we cover `git blame` and the history exploration toolkit: how to find out who touched which line, when, and why — everything you need to make sense of a codebase you've been staring at for five minutes.
+
+Never stop coding!


### PR DESCRIPTION
## Summary
- Add bilingual tutorial on git bisect for finding bugs using binary search
- Covers: basic usage, good/bad references, automation with scripts, skip functionality
- Part of the Domina Git desde cero course

## Changes
- src/content/tutorials/encontrando-bugs-git-bisect.mdx (ES)
- src/content/tutorials/finding-bugs-git-bisect.mdx (EN)

## Tutorial Topics
- Binary search explanation
- Basic git bisect start/bad/good workflow
- Using references (tags, branches, dates) instead of hashes
- Automating with git bisect run
- Skip commits with exit code 125
- When NOT to use bisect