### PR TITLE
feat(tutorials): add merge conflict resolution tutorial (es/en)

### DIFF
--- a/src/content/tutorials/resolviendo-conflictos-merge-git.mdx
+++ b/src/content/tutorials/resolviendo-conflictos-merge-git.mdx
@@ -1,0 +1,248 @@
+---
+title: "Cómo resolver conflictos de merge en Git"
+post_slug: "resolviendo-conflictos-merge-git"
+date: "2026-05-07"
+excerpt: "Los markers de conflicto tienen su lógica: una vez que entiendes el merge de tres vías, sabes exactamente qué significa cada sección y cómo resolver conflictos con o sin herramientas visuales."
+language: "es"
+categories: ["git"]
+course: "domina-git-desde-cero"
+order: 25
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "resolving-git-merge-conflicts"
+---
+
+Llevas días en tu rama. Has hecho commits limpios, el código funciona, y decides hacer merge con `main`. Un par de segundos de espera, y entonces:
+
+```
+Auto-merging src/auth/middleware.ts
+CONFLICT (content): Merge conflict in src/auth/middleware.ts
+Automatic merge failed; fix conflicts and then commit the result.
+```
+
+Abres el archivo y ves esto:
+
+```
+<<<<<<< HEAD
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) return res.status(401).json({ error: 'Unauthorized' });
+=======
+  const authHeader = req.headers.authorization;
+  const token = authHeader && authHeader.startsWith('Bearer ')
+    ? authHeader.split(' ')[1]
+    : null;
+  if (!token) return res.status(401).json({ error: 'No token provided' });
+>>>>>>> feature/auth-improvements
+```
+
+Primera reacción natural: ¿qué significa `HEAD`? ¿Cuál es la versión correcta? ¿Tengo que elegir una u otra, o puedo mezclarlas? ¿Borro todos los markers? ¿Qué pasa si me dejo uno?
+
+Tranquilo. Los conflictos tienen su lógica, y una vez que la entiendes, resolverlos deja de ser estresante para convertirse en algo que sigue siendo un poco tedioso, pero al menos sabes exactamente lo que estás haciendo.
+
+## Los markers de conflicto
+
+Cuando Git no puede resolver un merge automáticamente, marca las zonas problemáticas con una sintaxis que lleva décadas siendo igual (sí, esa sintaxis con tres signos de menor que que parece diseñada por alguien que odia profundamente a los programadores — y sin embargo, aquí estamos). La estructura es siempre la misma:
+
+```
+<<<<<<< HEAD                          ← start of your version (current branch)
+tu versión del código
+=======                               ← separator
+la versión de la otra rama
+>>>>>>> feature/auth-improvements     ← end of their version (branch being merged)
+```
+
+`HEAD` es tu rama actual — lo que tienes tú ahora mismo. La otra etiqueta es el nombre de la rama que estás mergeando. El `=======` es el separador.
+
+Para resolver el conflicto tienes tres opciones: quedarte con la versión de arriba (la tuya), con la de abajo (la de ellos), o escribir una nueva que integre lo mejor de ambas. Lo que NO puedes hacer es dejar los markers en el archivo — eso rompe el código y el siguiente que lo abra te va a odiar, o vas a odiarte a ti mismo si lo descubres en producción.
+
+### La variante con diff3
+
+Hay una configuración que te da mucho más contexto y que deberías activar ya:
+
+```bash
+git config --global merge.conflictstyle diff3
+```
+
+Con `diff3`, los markers incluyen una sección extra: el **ancestro común** — la versión del archivo antes de que ninguno de los dos lo tocase:
+
+```
+<<<<<<< HEAD
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) return res.status(401).json({ error: 'Unauthorized' });
+||||||| merged common ancestors
+  const token = req.headers['x-auth-token'];
+  if (!token) return res.status(403).json({ error: 'Forbidden' });
+=======
+  const authHeader = req.headers.authorization;
+  const token = authHeader && authHeader.startsWith('Bearer ')
+    ? authHeader.split(' ')[1]
+    : null;
+  if (!token) return res.status(401).json({ error: 'No token provided' });
+>>>>>>> feature/auth-improvements
+```
+
+Ahora ves de dónde viene cada versión. La sección `|||||||` es lo que había antes de que nadie tocase el archivo. Eso cambia completamente cómo tomas decisiones: ves que tú cambiaste el header de `x-auth-token` a `authorization`, y ellos también cambiaron el header pero además añadieron validación de formato Bearer. La resolución correcta está en esa información — mezclar los dos cambios, no elegir uno y tirar el otro.
+
+## El merge de tres vías
+
+`diff3` tiene más sentido si entiendes cómo funciona un merge por dentro. Cuando mergeas dos ramas, Git no compara solo tu versión contra la de ellos. Compara **ambas versiones contra el ancestro común** — el último commit que las dos ramas comparten. Por eso se llama _three-way merge_: tres versiones, tres vías.
+
+La lógica es elegante: si solo uno de los dos tocó una línea, Git puede resolverlo automáticamente — coge la versión que cambió, porque la otra no hizo nada diferente. El conflicto solo aparece cuando **los dos** tocaron la misma zona de código, de formas distintas. Git no sabe cuál era la intención, así que te pasa el marrón a ti.
+
+Sin el ancestro común, no puedes saber si tu versión "gana" o si debes integrar los dos cambios. Con él, tienes el contexto completo para decidir.
+
+## Resolviendo conflictos a mano
+
+`git status` te dice exactamente qué archivos tienen conflictos:
+
+```bash
+git status
+```
+
+```
+On branch main
+You have unmerged paths.
+  (fix conflicts and run "git commit")
+  (use "git merge --abort" to abort the merge)
+
+Unmerged paths:
+  (use "git add <file>..." to mark resolution)
+        both modified:   src/auth/middleware.ts
+        both modified:   src/config/database.ts
+```
+
+El flujo para cada archivo en conflicto:
+
+1. Abrirlo y buscar los markers `<<<<<<<`
+2. Decidir qué código queda (el tuyo, el de ellos, o una mezcla)
+3. Borrar **todos** los markers (`<<<<<<<`, `|||||||`, `=======`, `>>>>>>>`)
+4. Guardar el archivo
+5. `git add src/auth/middleware.ts`
+
+Cuando hayas resuelto todos los archivos en conflicto:
+
+```bash
+git commit
+```
+
+Git tiene preparado el mensaje de commit del merge. Puedes editarlo o dejarlo tal cual.
+
+### Para archivos enteros: --ours y --theirs
+
+Si hay un archivo donde sabes que una versión gana completamente — sin mezclar nada — no necesitas editar markers a mano:
+
+```bash
+git checkout --ours src/package-lock.json    # take our version entirely
+git checkout --theirs src/yarn.lock          # take their version entirely
+git add src/package-lock.json src/yarn.lock
+```
+
+Esto es especialmente útil para archivos generados automáticamente como lockfiles. El resultado correcto es el que surge de instalar dependencias en tu entorno, no el de intentar fusionar dos lockfiles línea a línea — eso es una batalla que no quieres pelear.
+
+## Herramientas de merge
+
+Resolver conflictos a mano en archivos grandes es viable pero puede ser lento y propenso a errores. Las herramientas de merge te dan una vista visual de las versiones en conflicto — sin tener que desplazarte por el archivo buscando markers a ojo.
+
+### lazygit
+
+Si vives en la terminal — o si la idea de abrir VS Code para resolver cuatro conflictos te parece un poco como llamar a los bomberos porque se ha quemado una tostada —, `lazygit` es la herramienta. Un TUI (terminal UI) completo para Git: sin Electron, sin tres segundos de carga, sin que el ventilador decida que ahora es el momento de imitar un motor de avión.
+
+```bash
+# Install lazygit
+brew install lazygit          # macOS / Linux via Homebrew
+pacman -S lazygit             # Arch (no sorprende a nadie)
+apt install lazygit           # Debian/Ubuntu
+```
+
+Abres `lazygit` en el repositorio y los archivos en conflicto aparecen marcados en el panel de **Files**. Seleccionas uno y el panel derecho muestra los hunks en conflicto: puedes navegar entre ellos, elegir tu versión o la de ellos con una sola tecla, o abrir el archivo directamente en tu `$EDITOR` si el conflicto necesita una solución más quirúrgica. Cuando terminas, el archivo está listo para hacer stage — sin haber abierto ninguna ventana nueva ni cambiado de contexto.
+
+Para quienes resuelven conflictos con frecuencia, la diferencia en velocidad es notable. No porque lazygit sea mágico, sino porque no tienes que esperar a que cargue ninguna aplicación.
+
+### VS Code e IntelliJ
+
+Para los que prefieren una interfaz gráfica con vista de tres paneles (tu versión, el ancestro, la de ellos), VS Code e IntelliJ IDEA tienen soporte de merge integrado. La configuración para usarlos con `git mergetool`:
+
+```bash
+git config --global merge.tool vscode
+git config --global mergetool.vscode.cmd 'code --wait $MERGED'
+```
+
+```bash
+git mergetool
+```
+
+Git abre cada archivo con conflictos en tu herramienta configurada, uno a uno. Funciona bien para conflictos complejos donde quieres ver todo el contexto de un archivo grande en una pantalla amplia.
+
+### vimdiff
+
+`vimdiff` está disponible sin configuración extra. Los usuarios de Arch ya saben de qué va esto; el resto lo descubre por accidente un día que no tiene instalado nada más, aprende más atajos de Vim de los que quería, y sale con una relación ambigua con la herramienta. Funciona. No es exactamente amigable. Pero lleva décadas funcionando, que no es poco.
+
+Y si el accidente te deja con más preguntas que respuestas — o directamente atrapado en el buffer sin recordar cómo salir —, [hay un curso de Vim desde cero](/es/cursos/domina-vim-desde-cero) que empieza exactamente desde ahí.
+
+## git merge --abort
+
+A veces la respuesta correcta es salir.
+
+```bash
+git merge --abort
+```
+
+Esto deshace el merge completamente y te devuelve al estado exacto en que estabas antes de ejecutar `git merge`. Sin rastro, sin commits a medias, sin markers colgando en el código. Como si nunca hubiera pasado.
+
+Cuándo tiene sentido usarlo:
+
+- Los conflictos son tan extensos que necesitas replantear el approach antes de continuar
+- Mergeaste la rama equivocada
+- Necesitas sincronizar con el equipo antes de tomar decisiones sobre el código en conflicto
+- Tu herramienta de merge se colgó a la mitad (esto pasa más de lo que debería)
+
+No es rendirse. Es saber cuándo parar para hacerlo bien en lugar de forzar una resolución que no entiendes del todo.
+
+## Estrategias para conflictos complejos
+
+### Dejar que un lado gane siempre
+
+Si sabes que en caso de conflicto siempre quieres tu versión (o siempre la de ellos), puedes decírselo a Git desde el principio:
+
+```bash
+git merge -X ours feature/rama    # on conflict: take our version
+git merge -X theirs feature/rama  # on conflict: take their version
+```
+
+Esto solo actúa cuando hay un conflicto real — no toca los cambios que Git puede resolver automáticamente. Es útil para merges de ramas de mantenimiento donde el criterio de qué versión prevalece es claro de antemano.
+
+### Rebase primero, merge después
+
+Los conflictos son menos frecuentes — y cuando aparecen, más pequeños y con más contexto — cuando tu rama está al día con `main`. En lugar de mergear directamente después de semanas de divergencia, sincroniza primero:
+
+```bash
+git fetch origin
+git rebase origin/main
+# resolve conflicts one commit at a time if they appear
+git push --force-with-lease origin feature/tu-rama
+```
+
+El rebase aplica tus commits encima de `main` actualizado. Si hay conflictos, los resuelves commit a commit — en pequeñas dosis, con el contexto claro de qué cambió en cada paso. Mucho más manejable que un merge acumulado con semanas de divergencia.
+
+## Prevenir conflictos
+
+La mejor resolución es la que no tienes que hacer.
+
+**Sincroniza con frecuencia.** Una rama que lleva tres semanas sin tocar `main` acumula conflictos. El `git rebase origin/main` diario (o cada vez que haya cambios relevantes en main) mantiene las ramas cortas de diferencia.
+
+**Ramas pequeñas y cortas.** Cuanto más tiempo vive una rama, más diverge. Las features largas se rompen en piezas más pequeñas que se mergean antes de empezar la siguiente.
+
+**Habla con tu equipo antes de tocar archivos críticos.** Las migraciones de base de datos, `package.json`, archivos de configuración compartidos — son tierra de conflictos. No es un problema técnico, es un problema de comunicación. Un "voy a tocar el schema de la tabla users esta tarde, ¿os afecta?" en el canal del equipo evita media hora de resolución de conflictos a posteriori.
+
+**Feature flags en lugar de ramas largas.** Si el código está en producción pero desactivado por flag, puedes mergear sin esperar a que la feature esté completa. La rama vive días en lugar de semanas, y los conflictos no tienen tiempo de acumularse.
+
+---
+
+Los conflictos son la parte del trabajo en equipo que Git delega en los humanos — con razón, porque la máquina no sabe cuál era la intención de cada cambio. Entender el merge de tres vías, activar `diff3`, y saber cuándo usar `--abort` en lugar de forzar una resolución que no entiendes son los tres pilares que convierten algo estresante en algo completamente manejable.
+
+En el próximo tutorial empezamos el módulo de flujos de trabajo: cómo organizan los equipos profesionales su día a día con Git, desde el clásico Gitflow hasta trunk-based development, y por qué cada uno tiene su momento y su contexto.
+
+---
+
+💡 **Desafío**: Crea dos ramas desde un mismo commit, modifica las mismas líneas de un archivo en ambas de formas distintas, y después mergea una en la otra. Activa `diff3` antes si aún no lo tienes, y fíjate en cómo el ancestro común te ayuda a entender exactamente qué pasó.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/resolving-git-merge-conflicts.mdx
+++ b/src/content/tutorials/resolving-git-merge-conflicts.mdx
@@ -1,0 +1,250 @@
+---
+title: "How to resolve merge conflicts in Git"
+post_slug: "resolving-git-merge-conflicts"
+date: "2026-05-07"
+excerpt: "Conflict markers make sense once you understand the three-way merge: what HEAD means, what the separator does, and how to resolve conflicts cleanly with or without visual tools."
+language: "en"
+categories: ["git"]
+course: "mastering-git-from-scratch"
+order: 25
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "resolviendo-conflictos-merge-git"
+---
+
+You run `git merge feature/auth-improvements` and instead of the clean one-liner you were hoping for, your terminal dumps this:
+
+```
+Auto-merging src/auth/middleware.ts
+CONFLICT (content): Merge conflict in src/auth/middleware.ts
+Automatic merge failed; fix conflicts and then commit the result.
+```
+
+You open the file and find:
+
+```
+<<<<<<< HEAD
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) return res.status(401).json({ error: 'Unauthorized' });
+=======
+  const authHeader = req.headers.authorization;
+  const token = authHeader && authHeader.startsWith('Bearer ')
+    ? authHeader.split(' ')[1]
+    : null;
+  if (!token) return res.status(401).json({ error: 'No token provided' });
+>>>>>>> feature/auth-improvements
+```
+
+What is `HEAD` here? Which version is "correct"? Do you pick one and delete the other, or can you combine them? What happens if you accidentally leave a `<<<<<<<` in the file?
+
+Conflict markers have a logic to them. Once you understand it, resolving conflicts stops being stressful and becomes something you can do methodically — still a bit tedious, but never mysterious.
+
+## Conflict markers
+
+When Git can't automatically resolve a merge, it marks the conflicting sections with a syntax that's been unchanged for decades (yes, those three angle brackets — it's genuinely one of the least intuitive choices in software tooling, and yet here we are). The structure is always the same:
+
+```
+<<<<<<< HEAD                          ← start of your version (current branch)
+your version of the code
+=======                               ← separator
+their version of the code
+>>>>>>> feature/auth-improvements     ← end of their version (branch being merged)
+```
+
+`HEAD` is your current branch — what you have right now. The label after `>>>>>>>` is the name of the branch you're merging in. The `=======` is the divider between the two versions.
+
+To resolve the conflict you have three choices: keep your version (top), keep theirs (bottom), or write a new version that integrates both. What you cannot do is leave the markers in the file — that's not valid code, and it will cause problems the moment someone runs it.
+
+### The diff3 variant
+
+There's a setting that gives you significantly more context, and you should enable it now:
+
+```bash
+git config --global merge.conflictstyle diff3
+```
+
+With `diff3`, the markers include an extra section: the **common ancestor** — what the file looked like before either of you touched it:
+
+```
+<<<<<<< HEAD
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) return res.status(401).json({ error: 'Unauthorized' });
+||||||| merged common ancestors
+  const token = req.headers['x-auth-token'];
+  if (!token) return res.status(403).json({ error: 'Forbidden' });
+=======
+  const authHeader = req.headers.authorization;
+  const token = authHeader && authHeader.startsWith('Bearer ')
+    ? authHeader.split(' ')[1]
+    : null;
+  if (!token) return res.status(401).json({ error: 'No token provided' });
+>>>>>>> feature/auth-improvements
+```
+
+Now you can see what each person actually changed. The `|||||||` section is the original. From that, it's clear: you switched from `x-auth-token` to `authorization`, and they also switched the header but added Bearer format validation on top. The right resolution isn't picking a winner — it's combining both changes. That's obvious once you see the base. Without it, you're guessing.
+
+## The three-way merge
+
+The reason `diff3` makes sense becomes clear when you understand how a merge actually works.
+
+When you merge two branches, Git doesn't just compare your version against theirs. It compares **both versions against the common ancestor** — the last commit both branches share. That's why it's called a three-way merge: three versions, three ways.
+
+The logic is clean: if only one side changed a line, Git resolves it automatically — it takes the changed version, because the other side didn't do anything different. A conflict only appears when **both sides** changed the same area of code in different ways. Git doesn't know which change was intentional, so it stops and asks you.
+
+Without the common ancestor, you can't tell whether your version should "win" or whether you need to integrate both changes. With it, you have all the information needed to make the right call.
+
+## Resolving conflicts by hand
+
+`git status` tells you exactly which files have conflicts:
+
+```bash
+git status
+```
+
+```
+On branch main
+You have unmerged paths.
+  (fix conflicts and run "git commit")
+  (use "git merge --abort" to abort the merge)
+
+Unmerged paths:
+  (use "git add <file>..." to mark resolution)
+        both modified:   src/auth/middleware.ts
+        both modified:   src/config/database.ts
+```
+
+The process for each conflicted file:
+
+1. Open it and find the `<<<<<<<` markers
+2. Decide what the code should look like (yours, theirs, or a blend)
+3. Delete **all** the markers (`<<<<<<<`, `|||||||`, `=======`, `>>>>>>>`)
+4. Save the file
+5. `git add src/auth/middleware.ts`
+
+Once every conflicted file is resolved and staged:
+
+```bash
+git commit
+```
+
+Git has a merge commit message already prepared. Edit it or leave it as-is.
+
+### For entire files: --ours and --theirs
+
+If there's a file where you know one version wins completely — no blending needed — you don't have to edit markers manually:
+
+```bash
+git checkout --ours src/package-lock.json    # take our version entirely
+git checkout --theirs src/yarn.lock          # take their version entirely
+git add src/package-lock.json src/yarn.lock
+```
+
+This is especially useful for auto-generated files like lockfiles. Merging two lockfiles line by line is a losing battle — the correct lockfile is the one that results from running your package manager in your environment, not some hybrid of two different install states.
+
+## Merge tools
+
+Resolving conflicts manually in large files is doable but slow. Merge tools give you a visual layout of the conflicting versions — no more scrolling through markers trying to keep track of which block belongs to whom.
+
+### lazygit
+
+If you live in the terminal — or if the idea of opening VS Code to resolve four conflict hunks feels like calling the fire department because your toast burned —, `lazygit` is the tool. A full TUI (terminal UI) for Git: no Electron, no three-second startup, no fan suddenly deciding this is its moment to shine.
+
+```bash
+# Install lazygit
+brew install lazygit          # macOS / Linux via Homebrew
+pacman -S lazygit             # Arch (nobody's surprised)
+apt install lazygit           # Debian/Ubuntu
+```
+
+Open `lazygit` in the repository and conflicted files appear clearly marked in the **Files** panel. Select one and the right panel shows the conflict hunks: you can navigate between them, pick your version or theirs with a single keypress, or drop into your `$EDITOR` for anything that needs a more surgical approach. When you're done, the file is ready to stage — without opening a new window or switching context.
+
+For anyone who resolves conflicts regularly, the speed difference is real. Not because lazygit is magic, but because there's nothing to wait for.
+
+### VS Code and IntelliJ
+
+For those who prefer a full GUI with a three-panel view (your version, the ancestor, theirs), VS Code and IntelliJ IDEA have built-in merge support. To configure them for use with `git mergetool`:
+
+```bash
+git config --global merge.tool vscode
+git config --global mergetool.vscode.cmd 'code --wait $MERGED'
+```
+
+```bash
+git mergetool
+```
+
+Git opens each conflicted file in your configured tool, one at a time. Works well for complex conflicts where you want to see a full file's worth of context on a wide screen.
+
+### vimdiff
+
+`vimdiff` is available without any extra configuration. Arch users already know what comes next; everyone else discovers it by accident on a day when nothing else is installed, learns more Vim shortcuts than they planned, and walks away with an ambiguous relationship with the tool. It works. It's not exactly friendly. But it's been working for decades, which counts for something.
+
+And if the accidental session leaves you with more questions than answers — or just stuck in a buffer with no idea how to exit — [there's a Vim course from scratch](/en/courses/mastering-vim-from-scratch) that starts exactly from there.
+
+## git merge --abort
+
+Sometimes the right move is to back out entirely.
+
+```bash
+git merge --abort
+```
+
+This undoes the merge completely and puts you back exactly where you were before running `git merge`. No trace, no half-committed state, no stray markers in the code. As if it never happened.
+
+When to use it:
+
+- The conflicts are too extensive and you need to rethink your approach before continuing
+- You merged the wrong branch
+- You need to sync with your team before making decisions about conflicting code
+- Your merge tool crashed halfway through (it happens more than it should)
+
+It's not giving up. It's knowing when to stop so you can do it right, rather than forcing a resolution you're not sure about.
+
+## Strategies for complex conflicts
+
+### Let one side always win
+
+If you know that in case of a conflict your version should always take precedence (or always theirs), you can tell Git upfront:
+
+```bash
+git merge -X ours feature/branch    # on conflict: take our version
+git merge -X theirs feature/branch  # on conflict: take their version
+```
+
+This only kicks in when there's a real conflict — it doesn't touch changes Git can resolve automatically. Useful for maintenance branch merges where the precedence rule is clear before you start.
+
+### Rebase first, then merge
+
+Conflicts are less frequent — and when they do appear, smaller and with clearer context — when your branch is up to date with `main`. Instead of merging directly after weeks of divergence, sync first:
+
+```bash
+git fetch origin
+git rebase origin/main
+# resolve conflicts one commit at a time if they appear
+git push --force-with-lease origin feature/your-branch
+```
+
+Rebase replays your commits on top of the updated `main`. If conflicts appear, you deal with them one commit at a time — small doses, each with clear context about what changed in that specific step. Far more manageable than a single merge with weeks of accumulated divergence.
+
+## Preventing conflicts
+
+The best resolution is the one you don't have to do.
+
+**Sync frequently.** A branch that hasn't touched `main` in three weeks will have conflicts. A daily `git rebase origin/main` keeps the gap small and the conflicts manageable.
+
+**Small, short-lived branches.** The longer a branch lives, the more it diverges. Long features get broken into smaller pieces that merge early, before the differences have time to accumulate.
+
+**Talk to your team before touching critical files.** Database migrations, `package.json`, shared configuration files — these are conflict hotspots. It's not a technical problem; it's a communication problem. "I'm going to change the user schema this afternoon — does that affect anyone?" in the team channel prevents half an hour of conflict resolution.
+
+**Feature flags instead of long-lived branches.** If the code is deployed but turned off by a flag, you can merge without waiting for the feature to be finished. The branch lives days instead of weeks, and conflicts don't have time to build up.
+
+---
+
+Conflicts are the part of collaborative work that Git delegates to humans — and rightly so, because the machine doesn't know which change was intentional. Understanding the three-way merge, enabling `diff3`, and knowing when to reach for `--abort` instead of forcing through a resolution you don't fully understand: those three things turn something intimidating into something completely manageable.
+
+In the next tutorial we start the workflows module: how professional teams organize their day-to-day Git usage, from the classic Gitflow model to trunk-based development, and when each one makes sense.
+
+---
+
+💡 **Challenge**: Create two branches from the same commit, modify the same lines of a file in each branch in different ways, then merge one into the other. Enable `diff3` first if you haven't already, and pay attention to how the common ancestor helps you understand exactly what each side changed.
+
+Never stop coding!


### PR DESCRIPTION
Bilingual tutorial pair (ES/EN) covering conflict markers, diff3, three-way merge, manual resolution, merge tools, abort, and prevention strategies. Part of the Git course (lesson 25).