### PR TITLE
feat(tutorials): add git commit best practices tutorial (es/en)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/src/content/tutorials/buenas-practicas-commits-git.mdx
+++ b/src/content/tutorials/buenas-practicas-commits-git.mdx
@@ -1,0 +1,200 @@
+---
+title: "Buenas prácticas para commits en Git"
+post_slug: "buenas-practicas-commits-git"
+date: "2026-05-08"
+excerpt: "Commits atómicos, mensajes que explican el porqué, y el estándar Conventional Commits: lo que separa un historial que documenta de uno que solo ocupa espacio."
+language: "es"
+categories: ["git"]
+course: "domina-git-desde-cero"
+order: 26
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "git-commit-best-practices"
+---
+
+Hay un tipo de vergüenza que solo conocen los programadores: abrir `git log --oneline` en un proyecto de hace dos años y encontrarse con esto:
+
+```
+a1b2c3d fix
+e4f5g6h wip
+i7j8k9l más cosas
+m0n1o2p ahora sí
+q3r4s5t FINAL
+u6v7w8x FINAL_DE_VERDAD
+```
+
+Y lo peor no es verlo. Lo peor es reconocer la caligrafía. Esos commits los escribiste tú. En un momento de tu vida en el que claramente tenías cosas mejores en las que pensar que en documentar lo que hacías.
+
+El problema no es estético. Es funcional. Cuando en tres meses uses `git bisect` para localizar un bug y Git te señale `q3r4s5t FINAL_DE_VERDAD` como el commit sospechoso, el historial no te va a decir absolutamente nada útil. Tendrás que leer el diff completo línea a línea para entender qué cambió ahí, por qué, y si era intencional. Multiplicado por cada commit del rango. A las dos de la madrugada.
+
+Un historial bien escrito es documentación viva. Esta lección es sobre cómo escribirlo.
+
+## El principio del commit atómico
+
+Antes del formato, la idea más importante: cada commit debe contener **un solo cambio lógico**.
+
+No "trabajo del martes". No "todo lo del sprint". No "varias cosas relacionadas". Un cambio. Con su contexto, bien delimitado.
+
+¿Por qué importa tanto?
+
+- **`git bisect` funciona**: cada commit es verificable de forma independiente. Si un commit mezcla cinco cambios, cuando bisect lo señale como culpable no sabrás cuál de los cinco introdujo el bug.
+- **`git revert` no tiene drama**: deshacer un commit atómico es limpio. Deshacer un commit que mezcla un refactor con un fix con una migración... es otra historia.
+- **`git cherry-pick` es posible**: si necesitas mover ese cambio a otra rama, puedes hacerlo sin arrastrar cosas no relacionadas.
+- **El code review es más rápido**: el revisor entiende exactamente qué está mirando. No tiene que adivinar qué partes forman una unidad lógica.
+
+La tentación es agrupar cosas porque "están relacionadas". Pero "relacionado" es demasiado amplio. Un refactor de una función y los tests que lo cubren — eso puede ir junto. Un refactor, una migración de base de datos y un fix de CSS — eso son tres commits distintos.
+
+## Conventional Commits
+
+Una vez tienes claro qué va en cada commit, hay que decidir cómo describirlo. [Conventional Commits](https://www.conventionalcommits.org) es una especificación que define el formato de los mensajes. Lo usan proyectos como Angular, Vue, Vite y miles de librerías open source, no por estética, sino porque el formato es machine-readable: herramientas como `semantic-release` pueden generar changelogs y calcular la versión siguiente de forma automática basándose en los tipos de tus commits.
+
+El formato:
+
+```
+type(scope): subject
+
+body
+
+footer
+```
+
+Un ejemplo real:
+
+```
+feat(auth): Add Bearer token validation
+
+The authorization header now requires the Bearer prefix.
+Bare tokens sent without it will receive a 401 response.
+
+BREAKING CHANGE: Authorization header format changed
+```
+
+Parece mucha estructura para un mensaje de texto. Pero aguanta un momento — cada parte tiene una razón concreta.
+
+## Los tipos
+
+El tipo describe qué clase de cambio contiene el commit. Los más usados:
+
+| Tipo | Cuándo usarlo |
+|------|---------------|
+| `feat` | Nueva funcionalidad |
+| `fix` | Corrección de un bug |
+| `docs` | Cambios en documentación |
+| `refactor` | Refactor sin cambio de comportamiento observable |
+| `test` | Añadir o corregir tests |
+| `chore` | Mantenimiento: dependencias, configuración, scripts |
+| `perf` | Mejora de rendimiento |
+| `style` | Formato, espacios, comas — sin cambio lógico |
+| `ci` | Configuración de CI/CD |
+| `build` | Sistema de build |
+| `revert` | Revertir un commit anterior |
+
+No te agobies intentando memorizar la tabla completa desde el primer día. `feat`, `fix`, `refactor` y `chore` cubren más del 80% de los commits del día a día. Los demás los vas incorporando cuando los necesitas.
+
+## El scope (opcional)
+
+El scope va entre paréntesis después del tipo e indica el área del código afectada:
+
+```
+feat(auth): Add token refresh endpoint
+fix(api): Return 404 for deleted users
+refactor(database): Extract query builder to its own module
+```
+
+No existe una lista de scopes correcta o incorrecta — cada proyecto define los suyos. Lo importante es que sean **consistentes**: si la capa de autenticación se llama `auth`, úsala siempre así, no `authentication` un día y `auth` otro. El scope sirve para filtrar el historial rápidamente; si cambia de nombre pierde su utilidad.
+
+Si el cambio afecta al proyecto de forma transversal o no encaja en ningún scope concreto, simplemente lo omites.
+
+## El asunto (subject line)
+
+El asunto es la primera línea — lo que ves en `git log --oneline`. Es lo más importante del mensaje y tiene sus reglas:
+
+```
+feat(auth): Add Bearer token validation
+             ↑
+             imperative mood — "Add", not "Added" or "Adding"
+```
+
+**Modo imperativo**: "Add feature", "Fix null check", "Refactor validation". No "Added", no "Adding", no "Fixes". Git usa este mismo estilo en sus propios mensajes (`Merge branch`, `Revert "feat: ..."`); seguirlo es consistencia, no capricho.
+
+**Máximo 70 caracteres**: GitHub y GitLab truncan la primera línea en la interfaz si supera ese límite. Lo que no cabe en el asunto va en el cuerpo.
+
+**Sin punto final**. **Primera letra en mayúscula**.
+
+Y lo más importante: **describe el cambio, no el proceso**. `feat(auth): Add null check before token verification` es útil. `fix: Fix bug` no lo es para nadie.
+
+## El cuerpo (body)
+
+El cuerpo es opcional, pero es donde vive el valor más duradero de un commit: el **porqué**.
+
+Se separa del asunto con una línea en blanco (obligatorio — Git los trata como secciones distintas sin esa línea):
+
+```
+fix(api): Handle null response in user endpoint
+
+Accounts deleted via the legacy migration tool can leave ghost sessions
+in the database. The endpoint was crashing on these instead of
+returning a clean 404.
+
+The migration tool will be deprecated in Q3, but until then this
+null check is necessary.
+```
+
+El diff ya muestra qué cambió. El cuerpo explica el contexto que el diff nunca puede mostrar: por qué existía el bug, qué escenario lo disparaba, qué alternativas se descartaron, qué va a cambiar en el futuro. Esa información desaparece para siempre si no la escribes en el momento — el único que sabe el contexto completo eres tú, ahora mismo, mientras haces el commit.
+
+No todos los commits necesitan cuerpo. `chore: Update dependencies` no necesita explicación adicional. Pero para un fix no obvio, una decisión de diseño, o un cambio que podría sorprender a alguien dentro de seis meses, el cuerpo es inestimable.
+
+## El footer y los breaking changes
+
+El footer es para metadatos estructurados: referencias a issues y, sobre todo, breaking changes.
+
+Un **breaking change** es un cambio que rompe la compatibilidad con versiones anteriores de la API o el comportamiento público. Se declara de dos formas complementarias:
+
+```
+feat(api)!: Remove deprecated v1 endpoints
+
+All v1 endpoints removed. Clients must migrate to the v2 API.
+
+BREAKING CHANGE: v1 endpoints no longer available
+Closes #341
+```
+
+El `!` después del tipo es la señal rápida — visible de un vistazo en el log. El `BREAKING CHANGE:` en el footer es la declaración formal que las herramientas de release usan para saber que toca incrementar la versión mayor en semver. Ambos juntos garantizan que tanto humanos como herramientas entienden la magnitud del cambio.
+
+Las referencias a issues van también en el footer:
+
+```
+fix(auth): Reject expired tokens on silent refresh
+
+Closes #482
+Refs #391
+```
+
+## El workflow práctico: --fixup y --autosquash
+
+El principio del commit atómico colisiona con la realidad de forma predecible: haces un commit, sigues trabajando, y descubres que hay un error en ese commit anterior. La solución instintiva es hacer otro commit con "fix typo" o "oops, esto". La solución correcta es `--fixup`:
+
+```bash
+# You realize commit abc123 needs a correction
+git add -p                    # stage only the fix
+git commit --fixup abc123     # creates: "fixup! feat(auth): Add Bearer..."
+```
+
+Esto crea un commit marcado automáticamente como fixup del original. Cuando limpies el historial antes de hacer merge:
+
+```bash
+git rebase -i --autosquash main
+```
+
+Git reorganiza los commits solo y squashea los fixups en sus commits objetivo. El historial que llega a `main` es limpio: sin "fix", sin "oops", sin "más cosas". La historia del proyecto, contada de forma ordenada.
+
+---
+
+Un historial de commits bien escrito no es documentación extra que alguien decidió mantener — es la documentación que Git te da gratis si la alimentas bien. Dentro de un año, cuando alguien haga `git log -S "función_misteriosa"` para entender por qué existe esa función, los commits que hayas escrito hoy son lo único que va a encontrar.
+
+En el siguiente tutorial vemos las convenciones de nomenclatura de ramas: cómo llamar a las ramas para que el equipo entienda de un vistazo qué contienen, a qué ticket están asociadas, y cuándo borrarlas sin miedo.
+
+---
+
+💡 **Desafío**: Busca en un proyecto tuyo el commit más críptico que encuentres. Escribe cómo lo habrías redactado en formato Conventional Commits con asunto, cuerpo y, si aplica, footer. El ejercicio entrena el ojo para escribir el mensaje en el momento, no reconstruirlo después.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/git-commit-best-practices.mdx
+++ b/src/content/tutorials/git-commit-best-practices.mdx
@@ -1,0 +1,200 @@
+---
+title: "Git commit best practices"
+post_slug: "git-commit-best-practices"
+date: "2026-05-08"
+excerpt: "Atomic commits, messages that explain the why, and the Conventional Commits standard: the difference between a history that documents and one that just takes up space."
+language: "en"
+categories: ["git"]
+course: "mastering-git-from-scratch"
+order: 26
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "buenas-practicas-commits-git"
+---
+
+There's a particular kind of dread that only developers know: running `git log --oneline` on a project you wrote two years ago and finding this:
+
+```
+a1b2c3d fix
+e4f5g6h wip
+i7j8k9l more stuff
+m0n1o2p trying something
+q3r4s5t FINAL
+u6v7w8x FINAL_REAL_THIS_TIME
+```
+
+The bad part isn't seeing it. The bad part is recognizing the handwriting. You wrote those commits. In a period of your life when you apparently had better things to think about.
+
+The problem isn't aesthetic — it's functional. When you run `git bisect` three months from now to track down a regression and Git points at `q3r4s5t FINAL_REAL_THIS_TIME` as the culprit, the history will tell you nothing. You'll have to read the full diff line by line to figure out what changed, why, and whether it was intentional. Repeated for every commit in the range. At 2 AM.
+
+A well-written commit history is living documentation. This lesson is about how to write one.
+
+## The atomic commit principle
+
+Before talking about format, the most important idea: each commit should contain **exactly one logical change**.
+
+Not "Tuesday's work." Not "everything from the sprint." One change, well-scoped, with its context.
+
+Why does this matter so much?
+
+- **`git bisect` works**: each commit is independently verifiable. A commit that mixes five changes tells you nothing when bisect points at it.
+- **`git revert` is painless**: undoing an atomic commit is clean. Undoing one that mixes a refactor, a migration, and a CSS fix is not.
+- **`git cherry-pick` becomes possible**: you can move a specific change to another branch without dragging unrelated things along.
+- **Code review is faster**: the reviewer sees a single, clear unit. They don't have to guess which lines belong together.
+
+The temptation is to group things because they're "related." But "related" is too broad. A function refactor and the tests that cover it — fine, those can go together. A refactor, a database migration, and a CSS fix — those are three separate commits.
+
+## Conventional Commits
+
+Once you're clear on what goes in each commit, you need to decide how to describe it. [Conventional Commits](https://www.conventionalcommits.org) is a lightweight specification for commit message format. Projects like Angular, Vue, Vite, and thousands of open source libraries use it — not for aesthetics, but because the format is machine-readable. Tools like `semantic-release` can generate changelogs and compute the next version automatically based on your commit types.
+
+The format:
+
+```
+type(scope): subject
+
+body
+
+footer
+```
+
+A real example:
+
+```
+feat(auth): Add Bearer token validation
+
+The authorization header now requires the Bearer prefix.
+Bare tokens sent without it will receive a 401 response.
+
+BREAKING CHANGE: Authorization header format changed
+```
+
+That looks like a lot of structure for a text message. Bear with me — each part has a concrete reason.
+
+## Types
+
+The type describes what kind of change the commit contains. The most common ones:
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New functionality |
+| `fix` | Bug fix |
+| `docs` | Documentation changes |
+| `refactor` | Refactoring without observable behavior change |
+| `test` | Adding or fixing tests |
+| `chore` | Maintenance: dependencies, configs, scripts |
+| `perf` | Performance improvement |
+| `style` | Formatting, whitespace, semicolons — no logic change |
+| `ci` | CI/CD configuration |
+| `build` | Build system changes |
+| `revert` | Reverting a previous commit |
+
+Don't stress about memorizing the full list from day one. `feat`, `fix`, `refactor`, and `chore` cover more than 80% of day-to-day commits. The others you pick up when you need them.
+
+## Scope (optional)
+
+The scope goes in parentheses after the type and indicates the area of code affected:
+
+```
+feat(auth): Add token refresh endpoint
+fix(api): Return 404 for deleted users
+refactor(database): Extract query builder to its own module
+```
+
+There's no canonical list of correct scopes — each project defines its own. What matters is **consistency**: if the auth layer is called `auth`, always call it `auth`, not `authentication` one day and `auth` the next. Scopes are useful for filtering history; they lose that value if they're not stable.
+
+If the change is cross-cutting or doesn't fit neatly into any area, just leave it out.
+
+## The subject line
+
+The subject is the first line — what you see in `git log --oneline`. It's the most important part of the message:
+
+```
+feat(auth): Add Bearer token validation
+             ↑
+             imperative mood — "Add", not "Added" or "Adding"
+```
+
+**Imperative mood**: "Add feature", "Fix null check", "Refactor validation". Not "Added", not "Adding", not "Fixes". Git itself uses this style in its own messages (`Merge branch`, `Revert "feat: ..."`). Matching it is consistency, not arbitrary convention.
+
+**70 characters max**: GitHub and GitLab truncate the subject line in their interfaces beyond that. Anything longer belongs in the body.
+
+**No trailing period.** **Capitalize the first letter.**
+
+And most importantly: **describe the change, not the activity**. `feat(auth): Add null check before token verification` is useful. `fix: Fix bug` is useful to no one.
+
+## The body
+
+The body is optional, but it's where the most durable value lives: the **why**.
+
+It's separated from the subject by a blank line (required — Git treats them as distinct sections without it):
+
+```
+fix(api): Handle null response in user endpoint
+
+Accounts deleted via the legacy migration tool can leave ghost sessions
+in the database. The endpoint was crashing on these instead of
+returning a clean 404.
+
+The migration tool will be deprecated in Q3, but until then this
+null check is necessary.
+```
+
+The diff already shows what changed. The body explains the context the diff can never show: why the bug existed, what scenario triggered it, what alternatives were ruled out, what's expected to change later. That information disappears forever if you don't write it down now — you're the only one with the full context, and you have it right now, while making the commit.
+
+Not every commit needs a body. `chore: Update dependencies` doesn't need elaboration. But for a non-obvious fix, a design decision, or a change that might surprise someone six months from now, the body is invaluable. Future you will thank present you. Or at least stop blaming present you.
+
+## The footer and breaking changes
+
+The footer is for structured metadata: issue references and, most importantly, breaking changes.
+
+A **breaking change** is a change that breaks backward compatibility with a previous API or public behavior. It's declared in two complementary ways:
+
+```
+feat(api)!: Remove deprecated v1 endpoints
+
+All v1 endpoints removed. Clients must migrate to the v2 API.
+
+BREAKING CHANGE: v1 endpoints no longer available
+Closes #341
+```
+
+The `!` after the type is the fast signal — visible at a glance in the log. The `BREAKING CHANGE:` in the footer is the formal declaration that release tools use to know a major version bump is needed in semver. Both together ensure both humans and tooling understand the magnitude of the change.
+
+Issue references also go in the footer:
+
+```
+fix(auth): Reject expired tokens on silent refresh
+
+Closes #482
+Refs #391
+```
+
+## The practical workflow: --fixup and --autosquash
+
+The atomic commit principle collides with reality in a predictable way: you make a commit, keep working, and realize there's an error in that previous commit. The instinctive solution is a new commit that says "fix typo" or "oops." The correct solution is `--fixup`:
+
+```bash
+# You realize commit abc123 needs a correction
+git add -p                    # stage only the fix
+git commit --fixup abc123     # creates: "fixup! feat(auth): Add Bearer..."
+```
+
+This creates a commit automatically marked as a fixup for the original. When you clean up history before merging:
+
+```bash
+git rebase -i --autosquash main
+```
+
+Git reorganizes the commits on its own and squashes the fixups into their target commits. What lands in `main` is clean: no "fix typo", no "oops", no "more stuff." The project history, told in order.
+
+---
+
+A well-written commit history isn't extra documentation someone decided to maintain — it's the documentation Git gives you for free if you feed it properly. A year from now, when someone runs `git log -S "mysterious_function"` to understand why that function exists, your commits are the only thing they'll find. Make them worth finding.
+
+In the next tutorial we cover branch naming conventions: how to name branches so your team understands at a glance what they contain, which ticket they're tied to, and when it's safe to delete them.
+
+---
+
+💡 **Challenge**: Find the most cryptic commit in one of your projects. Rewrite it in Conventional Commits format with a proper subject, body, and footer if applicable. The exercise trains the muscle for writing the message in the moment, not reconstructing it after the fact.
+
+Never stop coding!


### PR DESCRIPTION
## Summary

Add bilingual tutorial (ES/EN) on Git commit best practices for the "Mastering Git from Scratch" course:

- **Atomic commits**: why one logical change per commit matters for bisect, revert, cherry-pick, and code review
- **Conventional Commits**: the type(scope): subject format, types table, imperative mood, 70-char subject line
- **The body**: explaining the "why" behind the change
- **Breaking changes**: the `!` notation and `BREAKING CHANGE:` footer
- **Fixup and autosquash**: practical workflow for keeping a clean history before merging

Course order: 26