### PR TITLE
fix(ci): add Node.js setup to Cloudflare deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary

Astro 6 requires Node.js >=22.12.0, but the Cloudflare Pages deploy workflow was missing `actions/setup-node`.

The runner's default Node.js v20.20.2 caused the build to fail with:

> Node.js v20.20.2 is not supported by Astro!
> Please upgrade Node.js to a supported version: ">=22.12.0"

The CI workflow already had `actions/setup-node@v4` with `node-version: "22"` — deploy.yml was the only workflow missing it.

## Changes

- `.github/workflows/deploy.yml` — Added `actions/setup-node@v4` step with Node 22 before the Bun setup