### PR TITLE
feat(tutorials): add vim visual mode tutorial (ES/EN)

### DIFF
--- a/src/content/tutorials/modo-visual-vim.mdx
+++ b/src/content/tutorials/modo-visual-vim.mdx
@@ -1,0 +1,119 @@
+---
+title: "Modo Visual en Vim: selecciona, opera, domina"
+post_slug: "modo-visual-vim"
+date: "2026-05-13"
+excerpt: "El modo Visual no es 'seleccionar con el teclado como con el ratón'. Es una herramienta de tres variantes con operaciones directas y un modo de bloques que simula múltiples cursores sin un solo plugin."
+language: "es"
+categories: ["vim"]
+course: "domina-vim-desde-cero"
+order: 6
+cover: "/images/tutorials/cabecera-vim-curso.jpg"
+i18n: "visual-mode-vim"
+---
+
+La primera reacción de casi todo el mundo cuando llega al modo Visual es un suspiro de alivio: "por fin, algo con lo que ya sé cómo lidiar". Puedes seleccionar texto antes de borrarlo, copiarlo o indentarlo. Como siempre has hecho. Como en cualquier editor.
+
+Y está bien. Ese es exactamente el punto de entrada. Pero si usas el modo Visual solo como "seleccionar texto con el teclado antes de hacer algo", te estás perdiendo las dos partes que lo hacen realmente potente: los operadores que funcionan de forma diferente aquí, y el modo de bloques que simula múltiples cursores sin un solo plugin.
+
+## Los tres modos dentro del modo Visual
+
+El modo Visual no es uno solo — son tres, cada uno con un comportamiento diferente:
+
+| Comando  | Modo                | Qué selecciona                                      |
+| -------- | ------------------- | --------------------------------------------------- |
+| `v`      | Visual por carácter | Selección carácter a carácter                       |
+| `V`      | Visual por línea    | Líneas completas, sin importar dónde esté el cursor |
+| `Ctrl+v` | Visual de bloques   | Un rectángulo de texto (columnas)                   |
+
+El `v` es el más intuitivo. Pulsas `v`, mueves el cursor y la selección crece. Funciona con cualquier movimiento del modo Normal: `w`, `e`, `$`, `gg`, `G`, incluso búsquedas. Si sabes moverte en modo Normal, ya sabes seleccionar en modo Visual por caracteres.
+
+`V` selecciona siempre líneas completas. No importa dónde esté el cursor al entrar — la selección arranca desde la línea actual completa y se expande línea a línea. Práctico cuando trabajas con bloques de código donde la granularidad de carácter no aporta nada.
+
+`Ctrl+v` es la joya. Lo dejamos para su sección porque merece espacio.
+
+### `gv`: volver a la última selección
+
+Un comando pequeño que merece estar aquí: después de hacer una operación sobre una selección y volver al modo Normal, `gv` restaura exactamente la última selección visual. Útil cuando indentaste con `>` pero no era suficiente, o cuando quieres aplicar otra operación al mismo rango sin reseleccionar desde cero.
+
+## Operar sobre la selección
+
+Con texto seleccionado, los comandos más útiles son:
+
+| Comando | Qué hace sobre la selección          |
+| ------- | ------------------------------------ |
+| `d`     | Borra la selección                   |
+| `c`     | Borra la selección y entra en Insert |
+| `y`     | Copia (yank) la selección            |
+| `>`     | Indenta la selección                 |
+| `<`     | Deindenta la selección               |
+| `=`     | Autoformatea la selección            |
+| `~`     | Alterna mayúsculas/minúsculas        |
+| `u`     | Convierte a minúsculas               |
+| `U`     | Convierte a mayúsculas               |
+
+Por ahora no te agobies con la tabla entera. `d`, `y` y `>` son el 90% del uso real. El resto lo irás incorporando cuando aparezca la necesidad.
+
+Una combinación que vale la pena conocer desde el principio: `vap` — entra en Visual mode y selecciona el párrafo completo (el _text object_ `ap` = "a paragraph"). En código, un párrafo es básicamente un bloque contiguo sin líneas vacías: en Python eso suele ser una función completa, en HTML un elemento. `vap` + `>` lo indenta, `vap` + `d` lo borra, `vap` + `y` lo copia.
+
+## El modo Visual de bloques
+
+Aquí es donde las cosas se ponen interesantes. De verdad.
+
+`Ctrl+v` activa el Visual de bloques. En lugar de seleccionar caracteres o líneas completas, seleccionas un **rectángulo**: un rango de columnas en múltiples líneas simultáneamente. Si mueves el cursor tres líneas abajo y cinco columnas a la derecha, seleccionas exactamente esa área rectangular.
+
+El caso de uso más clásico: añadir el mismo texto al principio de varias líneas a la vez.
+
+```vim
+" Tienes este código:
+const name = 'Alice'
+const age  = 30
+const role = 'admin'
+
+" Quieres comentar las tres líneas con //
+" 1. Coloca el cursor en la 'c' de la primera línea
+" 2. Ctrl+v → activa Visual de bloques
+" 3. 2j → expande la selección dos líneas hacia abajo
+" 4. I → entras en Insert al principio de la selección
+" 5. //  → escribes el comentario (solo ves el cambio en la primera línea)
+" 6. Esc → Vim replica el Insert en todas las líneas del bloque
+```
+
+Ese `Esc` final es el momento mágico: lo que escribiste aparece en todas las líneas del bloque a la vez. Esto es la simulación de múltiples cursores en Vim, sin plugins, sin `Ctrl+D` de VS Code, sin `Alt+click`. Solo `Ctrl+v`, `I`, texto, `Esc`.
+
+La misma mecánica funciona con `A` en lugar de `I` para añadir al final de cada línea — aunque las líneas tengan distinta longitud, Vim extiende la selección hasta la más larga.
+
+¿Sensación de que acabas de ver un truco de magia? Es exactamente lo que es. El Visual de bloques es uno de esos comandos que convierten a alguien que "usa Vim porque le toca" en alguien que empieza a entender por qué la gente lo defiende.
+
+## Visual o gramática de Vim: cuándo usar cada uno
+
+Después de aprender el modo Visual, alguien siempre pregunta lo mismo: "¿para qué seleccionar con Visual si puedo hacer `d3w` o `ci"` directamente desde el modo Normal?"
+
+Buena pregunta. La respuesta honesta: hay situaciones donde cada uno gana.
+
+**Usa Visual cuando:**
+- No sabes exactamente hasta dónde llega el rango y necesitas verlo antes de actuar
+- La selección tiene forma irregular que ningún movimiento describe de forma limpia
+- Quieres aplicar la misma operación al mismo rango varias veces (`gv` + operación)
+
+**Usa operador-movimiento cuando:**
+- Sabes exactamente qué quieres hacer y el movimiento lo describe con precisión
+- Vas a repetir la operación con `.` — porque el modo Visual rompe esa repetibilidad
+
+Ese último punto es crítico y pocas personas lo saben al principio. Cuando haces `d3w` en modo Normal, el comando `.` puede repetirlo exactamente: tres palabras borradas, donde sea que esté el cursor. Cuando seleccionas con `v` y luego borras, `.` solo repite el borrado pero no la selección. Pierde la "forma" del cambio.
+
+Si estás haciendo lo mismo en varios sitios del código, [la gramática del modo Normal](/es/tutoriales/modo-normal-el-poder-de-vim) con operadores y movimientos es más rápida y repetible. Si solo lo haces una vez y necesitas ver el rango antes de confirmar, el modo Visual es el correcto.
+
+## Conceptos clave de esta lección
+
+- **Tres variantes**: `v` (carácter), `V` (línea), `Ctrl+v` (bloque)
+- **`gv`** restaura la última selección visual — para operar sobre el mismo rango sin reseleccionar
+- **`vap`** selecciona el párrafo completo — útil con bloques de código
+- **Visual de bloques** + `I` / `A` + texto + `Esc` = múltiples cursores sin plugins
+- **Cuándo usar Visual**: rango incierto, selección irregular, sin necesidad de repetir con `.`
+- **Cuándo usar operador-movimiento**: rango conocido, cambio repetible, trabajo en serie
+
+---
+
+El modo Visual completa el trío de modos fundamentales de Vim. A partir de aquí la curva de aprendizaje cambia: lo que viene no son más modos, sino formas de moverte más rápido. El próximo tutorial cubre la **búsqueda con `/`, `?` y `*`** — la forma de saltar a cualquier punto del archivo en cuestión de caracteres.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/visual-mode-vim.mdx
+++ b/src/content/tutorials/visual-mode-vim.mdx
@@ -1,0 +1,119 @@
+---
+title: "Visual mode in Vim: select, operate, own it"
+post_slug: "visual-mode-vim"
+date: "2026-05-13"
+excerpt: "Visual mode isn't 'using the keyboard like a mouse'. It's a three-variant tool with direct operations and a block mode that simulates multiple cursors with zero plugins."
+language: "en"
+categories: ["vim"]
+course: "mastering-vim-from-scratch"
+order: 6
+cover: "/images/tutorials/cabecera-vim-curso.jpg"
+i18n: "modo-visual-vim"
+---
+
+Most people discover Visual mode and feel a small wave of relief: finally, something familiar. Select text, then do something with it. That's how every other editor works. That's how your hands already think.
+
+That's a perfectly fine starting point. The problem is if you stop there — using Visual mode as "keyboard-driven mouse selection" and nothing else. Because there are two things here that go well beyond that: operators that behave differently in this context, and a block mode that does things VS Code needs a plugin to simulate.
+
+## The three Visual modes
+
+Visual mode isn't one thing — it's three, each with distinct behavior:
+
+| Command  | Mode            | What it selects                                        |
+| -------- | --------------- | ------------------------------------------------------ |
+| `v`      | Characterwise   | Character by character                                 |
+| `V`      | Linewise        | Full lines, regardless of cursor position              |
+| `Ctrl+v` | Blockwise       | A rectangular region (columns across multiple lines)   |
+
+`v` is the intuitive one. Press `v`, move the cursor, the selection grows. Every Normal mode motion works: `w`, `e`, `$`, `gg`, `G`, even search patterns. If you can navigate in Normal mode, you already know how to select in characterwise Visual.
+
+`V` always grabs full lines. It doesn't matter where the cursor is when you enter — you get the entire current line, and each movement extends by whole lines. Useful when you're working with code blocks where character-level precision doesn't add anything.
+
+`Ctrl+v` is the interesting one. Its own section.
+
+### `gv`: bring back the last selection
+
+A small command worth knowing early: after operating on a selection and returning to Normal mode, `gv` restores exactly your last visual selection. Useful when you indented with `>` but not enough, or when you want a second operation on the same range without reselecting from scratch.
+
+## Operating on a selection
+
+With text selected, the most useful commands are:
+
+| Command | What it does to the selection        |
+| ------- | ------------------------------------ |
+| `d`     | Delete the selection                 |
+| `c`     | Delete the selection and enter Insert|
+| `y`     | Yank (copy) the selection            |
+| `>`     | Indent the selection                 |
+| `<`     | Dedent the selection                 |
+| `=`     | Auto-format the selection            |
+| `~`     | Toggle case                          |
+| `u`     | Lowercase                            |
+| `U`     | Uppercase                            |
+
+Don't try to memorize all of this now. `d`, `y`, and `>` cover 90% of real-world usage. The rest will show up naturally when you need them.
+
+One combination worth learning early: `vap` — enters Visual mode and selects the entire paragraph (the text object `ap` = "a paragraph"). In code, a paragraph is a contiguous block with no blank lines separating it: a Python function, an HTML element, a JSON object. `vap` + `>` indents it, `vap` + `d` deletes it, `vap` + `y` copies it.
+
+## Block Visual mode
+
+Here's where things get genuinely interesting.
+
+`Ctrl+v` activates blockwise Visual mode. Instead of selecting characters or full lines, you select a **rectangle**: a column range across multiple lines simultaneously. Move three lines down and five columns right — you've selected exactly that rectangular area.
+
+The most common use case: inserting the same text at the start of multiple lines at once.
+
+```vim
+" You have this code:
+const name = 'Alice'
+const age  = 30
+const role = 'admin'
+
+" You want to comment out all three lines with //
+" 1. Place the cursor on the 'c' of the first line
+" 2. Ctrl+v → activate blockwise Visual
+" 3. 2j → extend the selection two lines down
+" 4. I → enter Insert at the start of the selection
+" 5. //  → type the comment (you only see it on the first line)
+" 6. Esc → Vim replays the Insert across every line in the block
+```
+
+That `Esc` at the end is the magic moment: what you typed appears on all the lines at once. This is Vim's multiple cursors — no plugins, no `Ctrl+D` from VS Code, no `Alt+click`. Just `Ctrl+v`, `I`, text, `Esc`.
+
+The same mechanic works with `A` instead of `I` to append at the end of each line — even if the lines have different lengths, Vim extends the selection to match the longest one.
+
+If this feels like a magic trick, that's because it kind of is. Block Visual mode is one of those features that turns someone who uses Vim because they have to into someone who starts to get why people are so loud about it.
+
+## Visual vs Vim's grammar: when to use each
+
+After learning Visual mode, someone always asks: "why bother selecting with Visual when I can just do `d3w` or `ci"` straight from Normal mode?"
+
+Fair question. Honest answer: each one wins in different situations.
+
+**Use Visual when:**
+- You don't know exactly where the range ends and need to see it before committing
+- The selection has an irregular shape that no single motion describes cleanly
+- You want to apply multiple operations to the same range (`gv` + operation)
+
+**Use operator-motion when:**
+- You know exactly what you want and the motion describes it precisely
+- You're going to repeat the operation with `.` — because Visual mode breaks that repeatability
+
+That last point is what most people miss early on. When you do `d3w` in Normal mode, `.` can replay it exactly — three words deleted, wherever the cursor ends up next. When you select with `v` and then delete, `.` only repeats the deletion but not the selection. It loses the "shape" of the change.
+
+If you're making the same edit in multiple places, [Normal mode's grammar](/en/tutorials/normal-mode-power-of-vim) with operators and motions is faster and repeatable. If you're doing it once and need to see the range before confirming, Visual is the right call.
+
+## Key concepts from this lesson
+
+- **Three variants**: `v` (characterwise), `V` (linewise), `Ctrl+v` (blockwise)
+- **`gv`** restores the last visual selection — operate on the same range without reselecting
+- **`vap`** selects the entire paragraph — works well with code blocks
+- **Block Visual** + `I` / `A` + text + `Esc` = multiple cursors with no plugins
+- **When to use Visual**: uncertain range, irregular shape, no need to repeat with `.`
+- **When to use operator-motion**: known range, repeatable change, serial edits
+
+---
+
+Visual mode completes the trio of core Vim modes. From here the learning curve shifts: what comes next isn't more modes — it's ways to move faster. The next tutorial covers **searching with `/`, `?`, and `*`** — how to jump anywhere in a file in a handful of keystrokes.
+
+Never stop coding!


### PR DESCRIPTION
## Summary

Adds lesson 6 of the "Mastering Vim from Scratch" / "Domina Vim desde cero" course: **Visual Mode** (bilingual ES/EN).

### What it covers:

- The three Visual mode variants: `v` (characterwise), `V` (linewise), `Ctrl+v` (blockwise)
- Operating on selections: delete, yank, indent, change case
- `gv` to restore the last selection
- `vap` to select a paragraph (text objects)
- **Block Visual mode** as Vim's multi-cursor simulation without plugins (`Ctrl+v` + `I`/`A` + text + `Esc`)
- When to use Visual mode vs operator-motion grammar (and why `.` repeatability matters)

### Files

- `src/content/tutorials/visual-mode-vim.mdx` — English version
- `src/content/tutorials/modo-visual-vim.mdx` — Spanish version