### PR TITLE
feat(tutorials): add branch naming conventions git tutorial (ES/EN)

### DIFF
--- a/src/content/tutorials/branch-naming-conventions-git.mdx
+++ b/src/content/tutorials/branch-naming-conventions-git.mdx
@@ -1,0 +1,172 @@
+---
+title: "Branch naming conventions in Git"
+post_slug: "branch-naming-conventions-git"
+date: "2026-05-14"
+excerpt: "How to name branches so your team understands at a glance what they contain, which ticket they map to, and when it's safe to delete them."
+language: "en"
+categories: ["git"]
+course: "mastering-git-from-scratch"
+order: 27
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "convenciones-nomenclatura-ramas-git"
+---
+
+You join a new project. Clone the repo. Run `git branch -a` to get a feel for the landscape. This is what you find:
+
+```
+  remotes/origin/test
+  remotes/origin/test2
+  remotes/origin/test-final
+  remotes/origin/johns-branch
+  remotes/origin/new-feature
+  remotes/origin/new-feature-v2
+  remotes/origin/TEMP
+  remotes/origin/fix
+  remotes/origin/actual-fix
+  remotes/origin/DO-NOT-MERGE
+  remotes/origin/main
+```
+
+Eleven branches. Zero information. Which ones are merged? What's in `johns-branch` — and does John still work here? When was `TEMP` created, and does anyone know what happens if you delete it? What's the difference between `fix` and `actual-fix`, and which one made it to production?
+
+The problem isn't that there are branches. Branches are one of Git's best features. The problem is that without a naming convention, each developer on the team invents their own system — and the remote ends up looking like a graveyard where you know things are buried but have no idea where.
+
+## Why branch names matter
+
+It's easy to think of a branch name as a minor detail, a label that only matters while the branch is alive. That framing is wrong.
+
+A branch name is a temporary contract with your team. It communicates what kind of work the branch contains, which ticket or feature it's tied to, and when it's appropriate to delete it. Without that contract, every branch interaction starts with the same question: "wait, what is this?"
+
+Three signs you have a naming problem:
+- Someone asks "can I delete this branch?" and no one knows the answer
+- You run `git branch -a` and spend more time reading names than doing actual work
+- There are two active branches called `feature-new` and `feature-new-v2` and no one remembers which one is current
+
+A good naming convention makes the branch self-documenting.
+
+## The common patterns
+
+Most teams use a prefix that describes the type of work, separated from the rest of the name by a forward slash:
+
+```
+feature/user-authentication
+fix/null-check-in-api-endpoint
+hotfix/critical-payment-failure
+release/2.3.0
+chore/update-dependencies
+docs/api-reference-v2
+```
+
+The most common prefixes:
+
+| Prefix | When to use |
+|--------|-------------|
+| `feature/` or `feat/` | New functionality |
+| `fix/` or `bugfix/` | Bug fix during active development |
+| `hotfix/` | Urgent fix going straight to production |
+| `release/` | Release preparation branch |
+| `chore/` | Maintenance: dependencies, config |
+| `docs/` | Documentation-only changes |
+| `refactor/` | Code refactoring without behavior change |
+| `test/` | Adding or fixing tests |
+
+If the [commit best practices](/en/tutorials/git-commit-best-practices) tutorial from last lesson looks familiar, you'll notice the prefixes map directly to Conventional Commits types — that's not a coincidence. When your branches and your commits speak the same language, the project history becomes much easier to read at a glance.
+
+You don't need to use all of them. A small team running `feature/`, `fix/`, and `hotfix/` has everything it needs. The key isn't exhaustiveness — it's consistency.
+
+## Including the issue number
+
+The type prefix is half the information. The other half is knowing which ticket or issue the branch corresponds to. The most widely used convention puts the issue number before the description:
+
+```
+feature/123-user-authentication
+fix/482-null-response-user-endpoint
+hotfix/561-payment-gateway-timeout
+```
+
+The number comes first for a practical reason: branches sort alphabetically in most tools, and putting the number first automatically groups branches for the same issue together. It also makes searching trivial — if you know the ticket number, you can filter directly.
+
+GitHub and GitLab also recognize issue numbers in branch names and link them automatically in the interface — a small detail that saves a surprising amount of navigation over time.
+
+If your team doesn't use an issue tracker (it happens, no judgment), just use the description alone. But if you do, the number is free and there's no reason not to include it.
+
+## Format rules
+
+A branch name is going to appear in `git log`, in pull requests, in CI/CD output, and possibly in changelogs. Worth making it look right in all of those contexts.
+
+**Always kebab-case**: lowercase, words separated by hyphens. No spaces (Git converts them and the result is a mess), no underscores, no camelCase.
+
+```
+feature/user-auth          # ✅
+feature/userAuth           # ❌
+feature/user_auth          # ❌
+feature/User Auth          # ❌ (and Git will complain)
+```
+
+**Descriptive but not a paragraph**: the name should be readable in `git log --oneline`. `feature/123-add-email-verification-to-user-registration-flow` is technically correct but unnecessarily verbose. `feature/123-email-verification` says the same thing.
+
+**Avoid "new", "final", "v2"**: these names age badly. `feature/new-login` becomes meaningless as soon as there's a second login implementation. `hotfix/final-fix` is a promise no software can keep.
+
+**No personal names on shared branches**: `johns-branch` is fine locally while you're exploring something. On the remote, a personal name carries no information relevant to the rest of the team — and once John leaves, the branch sits there forever, a mystery for everyone who comes after.
+
+## Team conventions vs personal preferences
+
+If you work alone, you can be as informal as you like with local branch names. No one's going to judge a branch called `wip-attempt-3` on your machine.
+
+On the remote, though, names are public. And a name that makes perfect sense to you right now might mean nothing to a teammate next week, or to yourself in three months (which is essentially the same thing).
+
+The most sustainable way to keep a convention alive on a team is to document it somewhere visible before someone creates their first branch — in the `README.md`, in `CONTRIBUTING.md`, or better yet, enforce it with a Git hook that validates the format automatically. It doesn't need to be sophisticated — a `pre-push` script that checks the name starts with a recognized prefix already eliminates 90% of poorly named branches without anyone having to play enforcer.
+
+If you're like me when I started, conventions can feel like unnecessary overhead. The project is moving fast, the branch name is the least of your problems, you'll sort it out later. You won't. And when you have 80 branches on the remote and no one knows what's safe to delete, you'll remember this conversation.
+
+## Branch lifecycle
+
+Branches have an expiration date. They're created for a specific purpose, they get merged, and they should die. In practice, they rarely do.
+
+To see which branches are already merged into `main`:
+
+```bash
+git branch --merged main
+```
+
+To delete a local branch that's been merged (safe — Git won't delete it if it has unmerged changes):
+
+```bash
+git branch -d feature/123-user-auth
+```
+
+To delete it even if it hasn't been merged (you're scrapping that work):
+
+```bash
+git branch -D feature/abandoned-experiment
+```
+
+The capital `D` is intentional — it's the "do it even though you think it's a bad idea" flag. Use it when you know what you're doing, not as a way to make Git stop complaining.
+
+To delete a branch on the remote:
+
+```bash
+git push origin --delete feature/123-user-auth
+```
+
+And to clean up local references to remote branches that no longer exist:
+
+```bash
+git fetch --prune
+# or equivalently
+git remote prune origin
+```
+
+If you'd rather manage all of this visually, `lazygit` has a dedicated branch view where you can browse, delete, and navigate entirely by keyboard — no syntax to remember, no Electron, no fan heroics. For those who prefer a mouse, GitLens in VS Code covers this reasonably well too.
+
+---
+
+A naming convention doesn't fix architectural problems or make the code better. But it eliminates an entire class of questions that shouldn't be questions: what's in here? Is this merged? Can I delete it? With consistent names, those answers live in the name itself.
+
+In the next tutorial, we'll look at **Git Flow**: the workflow that takes these branch prefixes and formalizes them into a structured process with clear roles for `main`, `develop`, `feature/`, `release/`, and `hotfix/` — a way to coordinate work across a team where multiple people are pushing to the same repository at the same time.
+
+---
+
+💡 **Challenge**: Open a repository you've worked on (or any popular open source project on GitHub) and run `git branch -a`. Evaluate the names against the conventions in this lesson — which ones are self-documenting? Which ones require additional context to understand? If you were naming those branches today, what would you call them?
+
+Never stop coding!

--- a/src/content/tutorials/convenciones-nomenclatura-ramas-git.mdx
+++ b/src/content/tutorials/convenciones-nomenclatura-ramas-git.mdx
@@ -1,0 +1,173 @@
+---
+title: "Convenciones de nomenclatura de ramas en Git"
+post_slug: "convenciones-nomenclatura-ramas-git"
+date: "2026-05-14"
+excerpt: "Cómo nombrar las ramas para que el equipo entienda de un vistazo qué contienen, a qué ticket están asociadas y cuándo es seguro borrarlas."
+language: "es"
+categories: ["git"]
+course: "domina-git-desde-cero"
+order: 27
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "branch-naming-conventions-git"
+---
+
+Llevas tres meses en el proyecto. Clonas el repositorio en un ordenador nuevo, ejecutas `git branch -a` para ver el estado del mundo, y esto es lo que encuentras:
+
+```
+  remotes/origin/test
+  remotes/origin/test2
+  remotes/origin/test-final
+  remotes/origin/javi
+  remotes/origin/carlos-stuff
+  remotes/origin/nueva-feature
+  remotes/origin/nueva-feature-v2
+  remotes/origin/TEMP
+  remotes/origin/arreglo
+  remotes/origin/arreglo-de-verdad
+  remotes/origin/DO-NOT-MERGE
+  remotes/origin/main
+```
+
+Doce ramas. Cero información. ¿Cuáles están mergeadas? ¿Cuáles son activas? ¿Qué contiene `carlos-stuff`? ¿Carlos sigue trabajando aquí? ¿Cuándo se creó `TEMP`? ¿Alguien sabe qué pasa si la borramos? ¿Y qué diferencia hay entre `arreglo` y `arreglo-de-verdad`, cuál fue al remoto?
+
+El problema no son las ramas — las ramas son la herramienta más útil que tiene Git. El problema son los nombres. Sin una convención, cada desarrollador del equipo inventa los suyos, y el remote acaba pareciéndose a un cementerio sin lápidas: todo el mundo sabe que hay algo enterrado, pero nadie sabe exactamente qué.
+
+## Por qué importa el nombre de una rama
+
+Puedes pensar que el nombre de una rama es un detalle menor, cosmético. No lo es.
+
+Un nombre de rama es un contrato temporal con el equipo: dice qué tipo de trabajo contiene, a qué ticket o funcionalidad corresponde, y cuándo tiene sentido eliminarla. Cuando ese contrato falta, cada interacción con el historial de ramas empieza con la misma pregunta: "espera, ¿qué es esto?"
+
+Tres síntomas de que hay un problema:
+- Alguien pregunta "¿puedo borrar esta rama?" y nadie sabe la respuesta
+- Usas `git branch -a` y tardas más tiempo leyendo nombres que haciendo trabajo
+- Hay dos ramas activas llamadas `feature-nueva` y `feature-nueva-v2` y nadie recuerda cuál es la buena
+
+Una buena convención hace que el nombre de la rama se explique solo.
+
+## Los patrones más comunes
+
+La mayoría de equipos usa un prefijo que describe el tipo de trabajo, separado del resto del nombre con una barra:
+
+```
+feature/user-authentication
+fix/null-check-in-api-endpoint
+hotfix/critical-payment-failure
+release/2.3.0
+chore/update-dependencies
+docs/api-reference-v2
+```
+
+Los prefijos más habituales:
+
+| Prefijo | Cuándo usarlo |
+|---------|---------------|
+| `feature/` o `feat/` | Nueva funcionalidad |
+| `fix/` o `bugfix/` | Corrección de un bug en desarrollo |
+| `hotfix/` | Fix urgente que va directo a producción |
+| `release/` | Rama de preparación de una versión |
+| `chore/` | Mantenimiento: dependencias, configuración |
+| `docs/` | Cambios solo en documentación |
+| `refactor/` | Refactor sin cambio observable de comportamiento |
+| `test/` | Añadir o corregir tests |
+
+Si el tutorial anterior sobre [buenas prácticas de commits](/es/tutoriales/buenas-practicas-commits-git) te suena familiar, reconocerás los tipos — son exactamente los de Conventional Commits. No es casualidad. Cuando tus ramas y tus commits hablan el mismo idioma, el historial del proyecto se vuelve mucho más fácil de leer de un vistazo.
+
+No tienes que usarlos todos. Un equipo pequeño con `feature/`, `fix/` y `hotfix/` tiene suficiente para funcionar bien. La clave no es la exhaustividad, es la consistencia.
+
+## Añadir el número de issue
+
+El prefijo de tipo es la mitad de la información. La otra mitad es saber a qué ticket o issue corresponde la rama. La convención más extendida es incluir el número antes de la descripción:
+
+```
+feature/123-user-authentication
+fix/482-null-response-user-endpoint
+hotfix/561-payment-gateway-timeout
+```
+
+El número va primero por una razón práctica: las ramas se ordenan alfabéticamente en la mayoría de herramientas, y poner el número al principio agrupa automáticamente las ramas del mismo issue. También facilita la búsqueda: si sabes el número del ticket, filtras directamente.
+
+GitHub y GitLab además reconocen los números de issue en los nombres de rama y los enlazan automáticamente en la interfaz. Un detalle pequeño que ahorra una cantidad sorprendente de clics a lo largo del tiempo.
+
+Si tu equipo no usa un issue tracker (pasa, no te juzgo), puedes usar solo la descripción. Pero si lo usáis, el número es gratis y no cuesta nada incluirlo.
+
+## Las reglas de formato
+
+El nombre de una rama va a aparecer en `git log`, en pull requests, en mensajes de CI/CD y posiblemente en el changelog. Vale la pena que tenga buena pinta en todos esos contextos.
+
+**kebab-case siempre**: minúsculas, palabras separadas por guiones. Sin espacios (Git los convierte y el resultado es un desastre), sin underscores, sin camelCase.
+
+```
+feature/user-auth          # ✅
+feature/userAuth           # ❌
+feature/user_auth          # ❌
+feature/User Auth          # ❌ (y Git se quejará)
+```
+
+**Descriptivo pero no un párrafo**: el nombre debería ser legible en `git log --oneline`. `feature/123-add-email-verification-to-user-registration-flow` es técnicamente correcto pero innecesariamente largo. `feature/123-email-verification` dice lo mismo.
+
+**Sin "new", "final", "v2"**: esos nombres envejecen fatal. `feature/new-login` deja de tener sentido en cuanto hay una segunda implementación del login. `hotfix/final-fix` es una promesa que el software no puede cumplir.
+
+**Sin nombres personales en ramas compartidas**: `carlos-stuff` tiene sentido en local mientras estás explorando algo. En el remote, un nombre personal no aporta información relevante para el equipo — y cuando Carlos se va, la rama queda ahí para siempre, siendo un misterio para todo el que llegue después.
+
+## Convenciones del equipo vs preferencias personales
+
+Si trabajas solo, puedes ser tan informal como quieras con los nombres de tus ramas de trabajo local. Nadie va a juzgar una rama llamada `wip-intento-3` en tu máquina.
+
+En el remote, en cambio, el nombre es público. Y un nombre que tiene sentido para ti ahora mismo puede no tenerlo para un colega la semana que viene, o para ti mismo dentro de tres meses (que a efectos prácticos es prácticamente lo mismo).
+
+La forma más sostenible de mantener una convención en equipo es documentarla donde alguien la vea antes de crear su primera rama: en el `README.md`, en el `CONTRIBUTING.md`, o mejor todavía, reforzarla con un hook de Git que valide el formato automáticamente. No hace falta que sea sofisticado — un script de `pre-push` que verifique que el nombre empieza con un prefijo reconocido ya elimina el 90% de los nombres incorrectos sin que nadie tenga que hacer de policía.
+
+Si eres como yo cuando empecé, puede que la convención parezca burocracia innecesaria. El proyecto va rápido, el nombre de la rama es lo de menos, ya lo arreglaremos después. Ese "ya lo arreglaremos" raramente ocurre. Y cuando tienes 80 ramas en el remote y nadie sabe cuáles se pueden borrar, te acuerdas de esta conversación.
+
+## El ciclo de vida de las ramas
+
+Las ramas tienen fecha de caducidad. Nacen para un propósito concreto, se mergean, y deberían morir. El problema es que en la práctica raramente mueren.
+
+Para ver qué ramas ya están mergeadas en `main`:
+
+```bash
+git branch --merged main
+```
+
+Para borrar una rama local que ya fue mergeada (safe — Git no la borrará si tiene cambios sin mergear):
+
+```bash
+git branch -d feature/123-user-auth
+```
+
+Si necesitas borrarla aunque no esté mergeada (por ejemplo, decidiste descartar ese trabajo):
+
+```bash
+git branch -D feature/abandoned-experiment
+```
+
+La `D` en mayúscula es intencional — es el flag de "hazlo aunque crea que no está bien". Úsalo cuando sabes lo que haces, no como forma de que Git deje de quejarse.
+
+Para borrar una rama en el remote:
+
+```bash
+git push origin --delete feature/123-user-auth
+```
+
+Y para limpiar las referencias locales a ramas remotas que ya no existen:
+
+```bash
+git fetch --prune
+# o equivalente
+git remote prune origin
+```
+
+Si prefieres gestionar todo esto de forma visual, `lazygit` tiene una vista dedicada para ramas donde puedes navegar, borrar y fusionar con teclado sin tener que recordar la sintaxis. Sin Electron, sin que el ventilador decida que ahora es el momento de imitar un motor de avión. Para los que prefieren el ratón, GitLens en VS Code también cubre esto bastante bien.
+
+---
+
+Una convención de nomenclatura no resuelve problemas de arquitectura ni hace que el código sea mejor. Pero elimina toda una clase de preguntas que no deberían ser preguntas: ¿qué hay aquí? ¿esto está mergeado? ¿puedo borrarlo? Con nombres consistentes, esas respuestas están en el propio nombre.
+
+En el siguiente tutorial vemos **Git Flow**: el workflow que toma estos prefijos de rama y los formaliza en un proceso estructurado con roles claros para `main`, `develop`, `feature/`, `release/` y `hotfix/`. Una manera de coordinar el trabajo en equipos donde varias personas tocan el mismo repositorio al mismo tiempo.
+
+---
+
+💡 **Desafío**: Abre un repositorio en el que hayas trabajado (o uno open source de GitHub) y ejecuta `git branch -a`. Evalúa los nombres según las convenciones de esta lección: ¿cuáles son autoexplicativos? ¿cuáles requieren contexto adicional? Si los reescribieras hoy, ¿cómo quedarían?
+
+¡Nunca dejes de programar!


### PR DESCRIPTION
## Summary

Tutorial on Git branch naming conventions, covering:

- Why branch names matter and common anti-patterns
- Prefix conventions (feature/, fix/, hotfix/, release/, chore/, docs/, refactor/, test/)
- How they map to Conventional Commits types
- Including issue numbers in branch names
- Format rules: kebab-case, descriptive but concise, avoiding new/final/v2 and personal names
- Team conventions vs personal preferences
- Branch lifecycle: checking merged branches, deleting locally and remotely, pruning stale references

Part of the **mastering-git-from-scratch** / **domina-git-desde-cero** course.