### PR TITLE
feat(tutorials): add dockerfile best practices security tutorial (ES/EN)

### DIFF
--- a/src/content/tutorials/buenas-practicas-dockerfiles-seguridad.mdx
+++ b/src/content/tutorials/buenas-practicas-dockerfiles-seguridad.mdx
@@ -1,0 +1,289 @@
+---
+title: "Buenas prácticas en Dockerfiles: seguridad"
+post_slug: "buenas-practicas-dockerfiles-seguridad"
+date: "2026-05-19"
+excerpt: "Aprende a crear imágenes Docker seguras: cómo evitar correr como root, escanear vulnerabilidades con Trivy, fijar versiones de forma correcta, y gestionar secretos sin que acaben horneados en tu imagen."
+language: "es"
+categories: ["docker"]
+course: "domina-docker-desde-cero"
+order: 8
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "dockerfile-best-practices-security"
+---
+
+Imagina esta situación: llevas semanas construyendo tu proyecto, llegas al punto de publicarlo, haces `docker push`, y dos días después recibes un email de GitGuardian. O peor, de tu jefe. Tu imagen en Docker Hub tiene una API key de producción hardcodeada, visible para cualquiera que ejecute `docker history tu-imagen`.
+
+¿Cómo ha pasado? En algún momento pusiste `ENV DATABASE_URL=postgres://admin:supersecret@db.prod/app` en el Dockerfile "solo para probar", y se quedó ahí. Docker no juzga. Solo almacena.
+
+Esta no es una historia inventada. Hay investigadores que se dedican a escanear Docker Hub buscando exactamente eso, y lo encuentran con una frecuencia que nadie querría admitir. La lección anterior cubrió eficiencia — [builds rápidos, imágenes ligeras](/es/tutoriales/buenas-practicas-dockerfiles-eficiencia). Esta cubre lo que puede hacerte perder el trabajo o a tu empresa sus clientes.
+
+## No correr como root
+
+Por defecto, los procesos dentro de un contenedor corren como `root`. No como un root limitado ni como un usuario con permisos elevados — como el usuario `root` real, UID 0. Y aunque el contenedor esté aislado del host, ese aislamiento tiene límites que no siempre funcionan como uno espera.
+
+¿Por qué es un problema? ¿Qué puede hacer de malo un root dentro de un contenedor? ¿Acaso el contenedor no está aislado?
+
+Sí y no. Si hay una vulnerabilidad en tu aplicación — y las hay, en todas — un atacante que comprometa el proceso tiene acceso total al sistema de archivos del contenedor como root. Si además hay un fallo de escape del contenedor (que existen, aunque son raros), ese root dentro puede convertirse en root fuera. El principio de mínimo privilegio existe precisamente para este escenario: si tu app no necesita ser root, no debería serlo.
+
+```dockerfile
+# ❌ Default — el proceso corre como root
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY . .
+CMD ["python", "app.py"]
+```
+
+```dockerfile
+# ✅ Con usuario no-root
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY . .
+
+# Create non-root user and group
+RUN groupadd --system appgroup && \
+    useradd --system --no-create-home --gid appgroup appuser
+
+# Transfer ownership, then switch user
+RUN chown -R appuser:appgroup /app
+USER appuser
+
+CMD ["python", "app.py"]
+```
+
+El orden importa: crea el usuario, transfiere la propiedad de los archivos, y luego usa `USER` para cambiar. Todo lo que venga después del `USER appuser` correrá con ese usuario, incluyendo el `CMD` final.
+
+Un detalle que tropieza a la gente: `WORKDIR` crea el directorio como root antes de que exista el usuario. Por eso el `chown` va después de la creación del usuario pero antes del `USER`. Puedes combinarlo todo en un solo `RUN` para ahorrar capas:
+
+```dockerfile
+RUN groupadd --system appgroup && \
+    useradd --system --no-create-home --gid appgroup appuser && \
+    chown -R appuser:appgroup /app
+USER appuser
+```
+
+Para Node.js, las imágenes oficiales ya incluyen un usuario `node` preparado para esto:
+
+```dockerfile
+FROM node:20-slim
+WORKDIR /app
+COPY package*.json .
+RUN npm ci --only=production
+COPY . .
+
+# node user comes built into official Node.js images
+RUN chown -R node:node /app
+USER node
+
+CMD ["node", "server.js"]
+```
+
+## Escanear vulnerabilidades
+
+Tu imagen hereda las vulnerabilidades de su imagen base y de los paquetes instalados. Con `python:3.12-slim` puedes estar arrastrando decenas de CVEs que no tienen nada que ver con tu código pero sí con lo que tu contenedor expone en producción.
+
+La buena noticia: escanear es trivial. La mala: la mayoría de la gente no lo hace hasta que alguien se lo exige.
+
+**[Trivy](https://trivy.dev)** es el estándar de facto para escaneo de imágenes. Código abierto, rápido, sin configuración necesaria para empezar:
+
+```bash
+# macOS y Linux (Homebrew)
+brew install trivy
+
+# Ubuntu / Debian
+wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | \
+  gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] \
+  https://aquasecurity.github.io/trivy-repo/deb generic main" | \
+  sudo tee /etc/apt/sources.list.d/trivy.list
+sudo apt-get update && sudo apt-get install -y trivy
+
+# Arch Linux (AUR)
+paru -S trivy
+```
+
+Con eso instalado, escanear es una línea:
+
+```bash
+trivy image python:3.12-slim
+```
+
+```
+python:3.12-slim (debian 12.10)
+===============================
+Total: 47 (UNKNOWN: 0, LOW: 28, MEDIUM: 14, HIGH: 4, CRITICAL: 1)
+```
+
+Ese output no es exagerado. La imagen base incluye componentes del sistema operativo con CVEs conocidos. La mayoría son LOW o MEDIUM — ruido de fondo con el que convives. Los HIGH y CRITICAL son los que merecen atención inmediata. Para ver solo esos y no ahogarte en el resto:
+
+```bash
+trivy image --severity HIGH,CRITICAL mi-app:latest
+```
+
+También puedes escanear tu propia imagen construida, no solo las bases:
+
+```bash
+trivy image mi-app:latest
+```
+
+Si ya tienes Docker Desktop o Docker >= 24, **Docker Scout** viene incluido y hace algo similar desde la terminal o desde el dashboard:
+
+```bash
+docker scout cves mi-app:latest
+```
+
+Trivy tiende a ser más completo y es el que verás en la mayoría de pipelines de CI/CD; Scout es conveniente si prefieres el ecosistema Docker Desktop y su interfaz visual (para los que prefieren el ratón y no les importa abrir otra pestaña en el navegador — sin juicios).
+
+### Reducir vulnerabilidades reconstruyendo
+
+El escaneo te dice qué hay. La solución en muchos casos es más sencilla de lo que parece: reconstruir desde la imagen base actualizada.
+
+```bash
+docker pull python:3.12-slim      # Actualiza la imagen base
+docker build --no-cache .         # Reconstruye sin caché para usar la nueva base
+docker scout cves mi-app:latest   # Comprueba si los CVEs han desaparecido
+```
+
+Muchas vulnerabilidades en imágenes "viejas" desaparecen simplemente reconstruyendo contra la base más reciente. Los mantenedores de las imágenes oficiales parchean continuamente. Si no reconstruyes, no recibes esos parches.
+
+## Fijar versiones correctamente
+
+En la lección anterior viste que fijar el tag de la imagen base — `python:3.12.10-slim` en vez de `python:3.12-slim` — da reproducibilidad. Pero hay un problema de seguridad que los tags no resuelven: **los tags son mutables**.
+
+Cualquiera con acceso al registry puede hacer `docker push mi-imagen:3.12.10-slim` con un contenido diferente y el tag seguirá siendo el mismo. Para imágenes oficiales en Docker Hub esto es prácticamente imposible, pero en pipelines de CI/CD con imágenes privadas o de terceros es un vector real de supply chain attacks.
+
+La alternativa inmutable es usar el **digest SHA256** de la imagen:
+
+```bash
+# Obtener el digest de una imagen
+docker inspect python:3.12-slim --format='{{index .RepoDigests 0}}'
+```
+
+```
+python@sha256:f4f0ef4e6a9a7bbd4954d6e5f4cd89b21f483d39beee63c3a17c840c10f5dd96
+```
+
+```dockerfile
+# ❌ Tag flotante — puede cambiar
+FROM python:3.12-slim
+
+# ✅ Tag fijado — mejor, pero mutable
+FROM python:3.12.10-slim-bookworm
+
+# ✅✅ Digest SHA256 — completamente inmutable
+FROM python:3.12-slim@sha256:f4f0ef4e6a9a7bbd4954d6e5f4cd89b21f483d39beee63c3a17c840c10f5dd96
+```
+
+El digest es inmutable por definición: es el hash del contenido. Esa imagen es exactamente esa imagen, siempre, en cualquier máquina.
+
+El mismo principio aplica a los paquetes del sistema. Si no fijas versiones, `apt-get install curl` instala lo que haya disponible hoy, que puede no ser lo mismo que había ayer:
+
+```dockerfile
+# ❌ Versión sin fijar
+RUN apt-get update && apt-get install -y curl
+
+# ✅ Versión específica
+RUN apt-get update && apt-get install -y curl=8.5.0-2ubuntu1
+```
+
+Para ver las versiones disponibles:
+
+```bash
+apt-cache madison curl
+```
+
+¿Necesitas hacer todo esto en todos tus proyectos? Probablemente no en un side project personal. Sí en imágenes que van a producción, especialmente las que manejan datos sensibles o están en sistemas críticos.
+
+## Secretos: lo que nunca debe estar en tu imagen
+
+Aquí es donde más se lía la gente. Y lo entiendo: durante el desarrollo necesitas credenciales, tokens, API keys. La solución obvia es meterlas en el Dockerfile como `ENV` o `ARG`. Es conveniente, funciona, y es una bomba de tiempo.
+
+El problema no es solo el obvio ("está en mi Dockerfile que está en git"). Es que aunque el Dockerfile nunca llegue a ningún repositorio, **cada capa de Docker queda registrada en la imagen**. Puedes eliminar un `ENV` en una capa posterior y el valor sigue ahí, accesible en el historial:
+
+```dockerfile
+# ❌ El "delete" posterior no borra nada de nada
+FROM python:3.12-slim
+ENV API_KEY=super-secret-key-12345
+RUN make some-api-call-using-the-key
+RUN unset API_KEY   # Completamente inútil — sigue en la capa anterior
+```
+
+```bash
+docker history mi-imagen --no-trunc
+# IMAGE          CREATED BY
+# ...            ENV API_KEY=super-secret-key-12345  ← visible para siempre
+```
+
+Lo mismo con `ARG`, aunque mucha gente piensa que es más seguro porque no persiste como variable de entorno en el contenedor final. Persiste igualmente en la capa del `RUN` que lo usó:
+
+```dockerfile
+ARG API_KEY
+# ❌ El valor queda registrado en esta capa
+RUN curl -H "Authorization: Bearer ${API_KEY}" https://api.example.com/setup
+```
+
+La solución correcta para secretos en tiempo de build es **BuildKit `--mount=type=secret`**:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM python:3.12-slim
+WORKDIR /app
+COPY . .
+
+# The secret is mounted only during this RUN, never stored in any layer
+RUN --mount=type=secret,id=api_key \
+    API_KEY=$(cat /run/secrets/api_key) && \
+    curl -H "Authorization: Bearer ${API_KEY}" https://api.example.com/setup
+```
+
+Lo pasas al build así:
+
+```bash
+docker build --secret id=api_key,src=./secrets/api_key.txt .
+```
+
+El secreto está disponible durante ese `RUN` específico y no aparece en ninguna capa ni en el historial de la imagen. La directiva `# syntax=docker/dockerfile:1` al inicio activa la sintaxis extendida de BuildKit — sin ella, Docker no reconocerá el `--mount`.
+
+Para secretos en **tiempo de ejecución** — credenciales de base de datos, tokens de API que la app necesita mientras corre — la respuesta es directa: **no los metas en la imagen**. Los secretos de runtime se inyectan desde fuera, en el momento del despliegue:
+
+```dockerfile
+# ✅ La imagen no contiene ninguna credencial
+FROM python:3.12-slim
+WORKDIR /app
+COPY . .
+RUN groupadd --system appgroup && \
+    useradd --system --no-create-home --gid appgroup appuser && \
+    chown -R appuser:appgroup /app
+USER appuser
+CMD ["python", "app.py"]
+# La app lee DATABASE_URL desde el entorno en runtime, nunca desde la imagen
+```
+
+```bash
+# En desarrollo
+docker run -e DATABASE_URL=postgres://... mi-app
+
+# En producción con Docker Compose
+services:
+  app:
+    image: mi-app:latest
+    environment:
+      DATABASE_URL: ${DATABASE_URL}  # Variable del sistema, nunca en el Dockerfile
+```
+
+Para entornos con requisitos más serios: Docker Secrets en Swarm, Kubernetes Secrets con acceso controlado, o un gestor de secretos dedicado como HashiCorp Vault. Pero incluso el enfoque básico de inyectar las variables en runtime es infinitamente mejor que hornearlas en la imagen.
+
+---
+
+Usuario no-root, escaneo de vulnerabilidades con Trivy, digest SHA256 en vez de tags flotantes, y secretos fuera de la imagen. Cuatro prácticas que no son complicadas pero que la mayoría ignora hasta que algo sale muy mal.
+
+En la próxima lección llegamos a una de las funcionalidades más potentes de Docker para producción: los **multi-stage builds**. Aprenderás a separar el entorno de compilación del entorno de ejecución, con ejemplos reales en Go y Node.js que consiguen reducir el tamaño de la imagen final de varios cientos de MB a unos pocos.
+
+¡Nunca dejes de programar!
+
+---
+
+**💡 Reto**: Toma la imagen del reto anterior. Añade un usuario no-root y escanéala con `trivy image --severity HIGH,CRITICAL`. Luego compara el resultado contra `python:3.12-alpine` — hay una sorpresa esperando.

--- a/src/content/tutorials/dockerfile-best-practices-security.mdx
+++ b/src/content/tutorials/dockerfile-best-practices-security.mdx
@@ -1,0 +1,289 @@
+---
+title: "Dockerfile Best Practices: Security"
+post_slug: "dockerfile-best-practices-security"
+date: "2026-05-19"
+excerpt: "Build secure Docker images: avoid running as root, scan for vulnerabilities with Trivy, pin versions the right way, and manage secrets without baking them into your image."
+language: "en"
+categories: ["docker"]
+course: "mastering-docker-from-scratch"
+order: 8
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "buenas-practicas-dockerfiles-seguridad"
+---
+
+Run this against your current containers:
+
+```bash
+docker inspect $(docker ps -q) --format '{{ .Name }}: {{ .Config.User }}'
+```
+
+Most of them will return a blank after the colon. Blank means root. You're running production workloads as the most privileged user on the system, and nobody sent you a warning email about it.
+
+Security in Dockerfiles isn't glamorous. It doesn't make it into conference talks the way Kubernetes migrations do. But these four practices are the difference between an image you can deploy to production with confidence and one that's a liability waiting to be discovered. The [last lesson covered efficiency](/en/tutorials/dockerfile-best-practices-efficiency) — fast builds, lean images. This one covers what keeps you employed.
+
+## Don't run as root
+
+Every Docker container runs as `root` by default. Not a sandboxed root, not an elevated user — actual UID 0, the same root that owns your filesystem. The container is isolated, yes, but isolation has failure modes.
+
+If your application has a vulnerability (and every application does), an attacker who compromises the process gets root-level access to everything in the container. If there's a container escape bug — rare, but they exist and get discovered — that root inside becomes root outside. The principle of least privilege isn't a DevSecOps buzzword; it's the reason you create separate database users instead of using `postgres` for everything.
+
+```dockerfile
+# ❌ Default — process runs as root
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY . .
+CMD ["python", "app.py"]
+```
+
+```dockerfile
+# ✅ Non-root user
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY . .
+
+# Create non-root user and group
+RUN groupadd --system appgroup && \
+    useradd --system --no-create-home --gid appgroup appuser
+
+# Transfer ownership, then switch
+RUN chown -R appuser:appgroup /app
+USER appuser
+
+CMD ["python", "app.py"]
+```
+
+The order matters. `WORKDIR` creates the directory as root before your user exists. Create the user, transfer ownership, then switch — everything after `USER appuser` runs as that user, including the final `CMD`.
+
+You can compress the setup into one layer:
+
+```dockerfile
+RUN groupadd --system appgroup && \
+    useradd --system --no-create-home --gid appgroup appuser && \
+    chown -R appuser:appgroup /app
+USER appuser
+```
+
+Official Node.js images include a `node` user out of the box, which saves a step:
+
+```dockerfile
+FROM node:20-slim
+WORKDIR /app
+COPY package*.json .
+RUN npm ci --only=production
+COPY . .
+
+# node user is already there in official Node.js images
+RUN chown -R node:node /app
+USER node
+
+CMD ["node", "server.js"]
+```
+
+## Scan for vulnerabilities
+
+Your image inherits every vulnerability in its base image and installed packages. A fresh `python:3.12-slim` can carry dozens of CVEs that have nothing to do with your code. Most developers have no idea what's in their images because they've never looked.
+
+**[Trivy](https://trivy.dev)** is the de facto standard for image scanning — open source, fast, zero configuration to get started:
+
+```bash
+# macOS and Linux (Homebrew)
+brew install trivy
+
+# Ubuntu / Debian
+wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | \
+  gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] \
+  https://aquasecurity.github.io/trivy-repo/deb generic main" | \
+  sudo tee /etc/apt/sources.list.d/trivy.list
+sudo apt-get update && sudo apt-get install -y trivy
+
+# Arch Linux (AUR)
+paru -S trivy
+```
+
+Scan any image with one command:
+
+```bash
+trivy image python:3.12-slim
+```
+
+```
+python:3.12-slim (debian 12.10)
+===============================
+Total: 47 (UNKNOWN: 0, LOW: 28, MEDIUM: 14, HIGH: 4, CRITICAL: 1)
+```
+
+That's not a contrived example — base images carry OS-level CVEs from Debian, OpenSSL, and system libraries. Most are LOW or MEDIUM: background noise you live with. HIGH and CRITICAL are what you act on. Filter to see only those:
+
+```bash
+trivy image --severity HIGH,CRITICAL my-app:latest
+```
+
+You can scan your own built images too, not just bases:
+
+```bash
+trivy image my-app:latest
+```
+
+If you're on Docker Desktop or Docker >= 24, **Docker Scout** is already installed and covers similar ground:
+
+```bash
+docker scout cves my-app:latest
+```
+
+Trivy tends to be more thorough and is what you'll see in most CI/CD pipelines. Scout is convenient if you prefer the Docker Desktop dashboard and don't want another CLI tool — for those who like their metrics with a GUI and don't mind clicking around (no judgment, it works).
+
+### Fixing vulnerabilities by rebuilding
+
+Scanning tells you what's there. The fix is often simpler than expected: rebuild against an updated base image.
+
+```bash
+docker pull python:3.12-slim      # Pull the latest base
+docker build --no-cache .         # Rebuild without cache to pick up updates
+trivy image --severity HIGH,CRITICAL my-app:latest   # Check again
+```
+
+A surprising number of CVEs in "old" images disappear just from rebuilding. The maintainers of official images patch continuously. If you never rebuild, you never get those patches.
+
+## Pin versions correctly
+
+The [last lesson](/en/tutorials/dockerfile-best-practices-efficiency) covered pinning your base image tag — `python:3.12.10-slim` instead of `python:3.12-slim` — for reproducibility. But tags have a security problem: **tags are mutable**.
+
+Anyone with push access to a registry can overwrite a tag with different content. For official Docker Hub images this essentially never happens, but in CI/CD pipelines pulling from private registries or third-party sources, it's a real supply chain attack vector.
+
+The immutable alternative is the **SHA256 digest**:
+
+```bash
+# Get the digest of an image
+docker inspect python:3.12-slim --format='{{index .RepoDigests 0}}'
+```
+
+```
+python@sha256:f4f0ef4e6a9a7bbd4954d6e5f4cd89b21f483d39beee63c3a17c840c10f5dd96
+```
+
+```dockerfile
+# ❌ Floating tag — can change without warning
+FROM python:3.12-slim
+
+# ✅ Pinned tag — better, but still mutable
+FROM python:3.12.10-slim-bookworm
+
+# ✅✅ SHA256 digest — immutable by definition
+FROM python:3.12-slim@sha256:f4f0ef4e6a9a7bbd4954d6e5f4cd89b21f483d39beee63c3a17c840c10f5dd96
+```
+
+A digest is the hash of the image content. That image is exactly that image, forever, on any machine. If someone replaces the tag, the digest still points to the original content.
+
+The same logic applies to system packages. Unpinned installs grab whatever's available today:
+
+```dockerfile
+# ❌ Unpinned — installs whatever version is current
+RUN apt-get update && apt-get install -y curl
+
+# ✅ Pinned version — reproducible
+RUN apt-get update && apt-get install -y curl=8.5.0-2ubuntu1
+```
+
+To see what versions are available:
+
+```bash
+apt-cache madison curl
+```
+
+Do you need digest pinning for every project? Probably not for a personal side project. Yes for production images handling sensitive data or sitting in regulated environments.
+
+## Secrets: what must never be in your image
+
+This is where most people trip up. And it makes sense: you need credentials during development. The obvious solution is `ENV` or `ARG` in the Dockerfile. It's convenient, it works, and it's a ticking clock.
+
+The obvious problem is "it ends up in git." The less obvious problem is worse: **even if it never touches git, every Docker layer is permanently recorded in the image**. Delete an `ENV` in a later layer and the value is still there, visible in the build history:
+
+```dockerfile
+# ❌ The "cleanup" layer changes nothing
+FROM python:3.12-slim
+ENV API_KEY=super-secret-key-12345
+RUN make some-api-call-using-the-key
+RUN unset API_KEY   # Completely useless — still in the previous layer
+```
+
+```bash
+docker history my-image --no-trunc
+# IMAGE          CREATED BY
+# ...            ENV API_KEY=super-secret-key-12345  ← visible forever
+```
+
+`ARG` has the same problem, despite what the docs imply. It doesn't persist as an environment variable in the final image — but it does persist in the layer of the `RUN` that used it:
+
+```dockerfile
+ARG API_KEY
+# ❌ The value is baked into this layer's metadata
+RUN curl -H "Authorization: Bearer ${API_KEY}" https://api.example.com/setup
+```
+
+The right solution for build-time secrets is **BuildKit's `--mount=type=secret`**:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM python:3.12-slim
+WORKDIR /app
+COPY . .
+
+# The secret is available only during this RUN — never stored in any layer
+RUN --mount=type=secret,id=api_key \
+    API_KEY=$(cat /run/secrets/api_key) && \
+    curl -H "Authorization: Bearer ${API_KEY}" https://api.example.com/setup
+```
+
+Pass the secret at build time:
+
+```bash
+docker build --secret id=api_key,src=./secrets/api_key.txt .
+```
+
+The secret is mounted in a tmpfs during that specific `RUN` and never written to any layer. The `# syntax=docker/dockerfile:1` line at the top enables BuildKit's extended syntax — without it, Docker won't recognize the `--mount` option.
+
+For **runtime secrets** — database passwords, API tokens your application needs while running — the answer is straightforward: **don't put them in the image**. Runtime secrets are injected from outside, at deploy time:
+
+```dockerfile
+# ✅ The image contains no credentials
+FROM python:3.12-slim
+WORKDIR /app
+COPY . .
+RUN groupadd --system appgroup && \
+    useradd --system --no-create-home --gid appgroup appuser && \
+    chown -R appuser:appgroup /app
+USER appuser
+CMD ["python", "app.py"]
+# The app reads DATABASE_URL from the environment at runtime — never from the image
+```
+
+```bash
+# In development
+docker run -e DATABASE_URL=postgres://... my-app
+
+# In production with Docker Compose
+services:
+  app:
+    image: my-app:latest
+    environment:
+      DATABASE_URL: ${DATABASE_URL}  # From the host environment, never in the Dockerfile
+```
+
+For more rigorous setups: Docker Secrets in Swarm, Kubernetes Secrets with proper RBAC, or a dedicated secrets manager like HashiCorp Vault. But even the basic pattern of injecting at runtime is infinitely better than credentials baked into a layer that follows the image everywhere it goes.
+
+---
+
+Non-root user, vulnerability scanning with Trivy, immutable digests instead of mutable tags, secrets out of the image. Four practices that aren't complicated — they just require actually doing them.
+
+Next up is one of the most powerful Docker features for production images: **multi-stage builds**. You'll learn how to separate the build environment from the runtime environment, with real examples in Go and Node.js that shrink final image sizes from hundreds of megabytes down to a fraction.
+
+Never stop coding!
+
+---
+
+**💡 Challenge**: Take your image from the previous lesson's challenge. Add a non-root user and scan it with `trivy image --severity HIGH,CRITICAL`. Then compare against `python:3.12-alpine` — there's a surprise waiting for you there.


### PR DESCRIPTION
Add tutorial 'Dockerfile Best Practices: Security' (ES/EN), lesson 8 of the 'Mastering Docker from Scratch' course.

Covers:
- Non-root user: principle of least privilege in Dockerfiles
- Vulnerability scanning with Trivy and Docker Scout
- Version pinning with SHA256 digests vs mutable tags
- Build-time secrets with BuildKit `--mount=type=secret`
- Runtime secrets injected from outside the image
- Practical challenge comparing python:3.12-slim vs alpine