### PR TITLE
feat(tutorials): add list methods python tutorial (ES/EN)

### DIFF
--- a/src/content/tutorials/list-methods-python.mdx
+++ b/src/content/tutorials/list-methods-python.mdx
@@ -1,0 +1,208 @@
+---
+title: "List methods in Python: append, remove, and list comprehensions"
+post_slug: "list-methods-python"
+date: "2026-05-22"
+excerpt: "A list you can't modify is just a tuple with extra steps. Learn to add, remove, and transform elements with the most important list methods — and write your first list comprehensions."
+language: "en"
+categories: ["programming"]
+course: "learn-to-code-from-scratch-python"
+order: 10
+cover: "/images/tutorials/cabecera-python-curso.jpg"
+i18n: "metodos-listas-python"
+---
+
+You have the list. The one from the previous tutorial — shopping cart items, player names, search results. You created it, iterated over it with `for`, checked membership with `in`. All good. Then the user adds a product, removes another, and you want to know how many times "t-shirt" appears in their order history. And that's when you realize: knowing how to create a list isn't the same as knowing how to work with one.
+
+Methods are where lists stop being a static container and become actually useful.
+
+## Adding elements
+
+The most common operation by far is `append()` — it adds one element to the end:
+
+```python
+cart = ["t-shirt", "jeans"]
+
+cart.append("sneakers")
+print(cart)   # ["t-shirt", "jeans", "sneakers"]
+```
+
+If you need to insert at a specific position, `insert(index, value)`:
+
+```python
+cart.insert(1, "socks")   # Insert at index 1
+print(cart)   # ["t-shirt", "socks", "jeans", "sneakers"]
+```
+
+Here's the trap that catches everyone exactly once: `append()` vs `extend()`.
+
+`extend()` adds every element of another iterable, one by one. `append()` adds the object as a single element — if you pass it a list, it inserts that entire list as one nested element:
+
+```python
+cart = ["t-shirt", "jeans"]
+
+cart.extend(["sneakers", "cap"])
+print(cart)   # ["t-shirt", "jeans", "sneakers", "cap"] ✅
+
+cart2 = ["t-shirt", "jeans"]
+cart2.append(["sneakers", "cap"])
+print(cart2)  # ["t-shirt", "jeans", ["sneakers", "cap"]] ❌ — nested list
+```
+
+Simple rule: adding one item? `append()`. Merging two lists? `extend()`.
+
+## Removing elements
+
+Python gives you four ways to remove elements, and each one covers a slightly different case. It's not that the language is broken — the use cases are genuinely different.
+
+**`remove(value)`** deletes the first occurrence of a specific value:
+
+```python
+fruits = ["apple", "pear", "grape", "pear"]
+
+fruits.remove("pear")
+print(fruits)   # ["apple", "grape", "pear"] — only the first one removed
+```
+
+⚠️ If the value doesn't exist, `remove()` raises a `ValueError`. Guard with `in` if you're not sure:
+
+```python
+if "kiwi" in fruits:
+    fruits.remove("kiwi")
+```
+
+**`pop(index)`** removes by position and **returns the removed element**. Without an index, it removes the last one:
+
+```python
+fruits = ["apple", "pear", "grape"]
+
+last = fruits.pop()      # Removes "grape" and returns it
+print(last)    # "grape"
+print(fruits)  # ["apple", "pear"]
+
+first = fruits.pop(0)    # Removes "apple"
+print(first)   # "apple"
+```
+
+The key difference from `remove()`: `pop()` works with indexes and gives back what it removed. Useful when you need the element before discarding it — process and delete in one step.
+
+**`del`** is a language statement (not a method). It removes by index or slice, returning nothing:
+
+```python
+fruits = ["apple", "pear", "grape", "kiwi", "orange"]
+
+del fruits[1]       # Removes "pear"
+del fruits[1:3]     # Removes a slice — "grape" and "kiwi" after the previous del
+print(fruits)       # ["apple", "orange"]
+```
+
+And when you need to empty a list entirely while keeping the same reference, `clear()`:
+
+```python
+cart = ["t-shirt", "jeans", "sneakers"]
+cart.clear()
+print(cart)   # []
+```
+
+This isn't the same as `cart = []`. With `cart = []` you create a brand-new list and orphan the old one — anything else pointing to the original won't see the change. With `clear()` you empty the one you already have, in place.
+
+## Modifying elements directly
+
+Access an index and assign a new value:
+
+```python
+fruits = ["apple", "pear", "grape"]
+
+fruits[0] = "peach"
+print(fruits)   # ["peach", "pear", "grape"]
+```
+
+It also works with slices — replace an entire range at once:
+
+```python
+fruits[1:3] = ["mango", "papaya"]
+print(fruits)   # ["peach", "mango", "papaya"]
+```
+
+## Searching inside a list
+
+`index(value)` returns the position of the first occurrence:
+
+```python
+fruits = ["apple", "pear", "grape", "pear"]
+
+print(fruits.index("pear"))   # 1 — first occurrence
+```
+
+⚠️ Like `remove()`, it raises `ValueError` if the element doesn't exist. Protect yourself with `in` before calling it.
+
+`count(value)` counts how many times an element appears:
+
+```python
+votes = ["yes", "no", "yes", "yes", "no", "yes"]
+
+print(votes.count("yes"))   # 4
+print(votes.count("no"))    # 2
+```
+
+## List comprehensions: the first time Python surprises you
+
+This is the part where Python does something that, the first time you see it, looks too clean to be real — but it works, and after five minutes you'll wonder why every language doesn't do this.
+
+Say you have a list of numbers and you want a new list with all of them squared. The long way:
+
+```python
+numbers = [1, 2, 3, 4, 5]
+
+squares = []
+for n in numbers:
+    squares.append(n ** 2)
+
+print(squares)   # [1, 4, 9, 16, 25]
+```
+
+That works. Four lines. Now the same operation with a **list comprehension**:
+
+```python
+squares = [n ** 2 for n in numbers]
+
+print(squares)   # [1, 4, 9, 16, 25]
+```
+
+One line. Same result. Read it left to right: "give me `n ** 2` for every `n` in `numbers`." If that reads almost like plain English, it's because Python designed it exactly that way.
+
+The syntax is `[expression for variable in iterable]`. Add a condition to filter:
+
+```python
+evens = [n for n in numbers if n % 2 == 0]
+
+print(evens)   # [2, 4]
+```
+
+`[expression for variable in iterable if condition]`. Only elements that satisfy the condition make it into the result.
+
+Feeling like this shouldn't be this comfortable? Fair. Developers coming from Java or C++ stare at this with a mix of confusion and mild jealousy. JavaScript folks have `map()` and `filter()` that do the same thing, just with more ceremony. Don't stress if it feels like magic at first — write it slowly, read it aloud, and in a week you'll wonder how you lived without it.
+
+For now, stick to the simple cases: transforming elements and filtering lists. Comprehensions can get more complex, but the pattern is always the same.
+
+---
+
+## Key concepts from this lesson
+
+- `append(value)` adds one element to the end; `extend(iterable)` merges element by element
+- `remove(value)` deletes by value (first occurrence); raises `ValueError` if not found
+- `pop(index)` removes by position and returns the element; without index, removes the last
+- `del list[index]` removes by position without returning anything; also accepts slices
+- `clear()` empties the list keeping the same reference; different from `list = []`
+- `index(value)` returns the position of the first occurrence
+- `count(value)` counts how many times an element appears
+- List comprehension: `[expression for variable in iterable if condition]`
+
+---
+
+That wraps up the Control Flow module. You've gone from conditionals to loops, from basic lists to full method coverage and list comprehensions — you have the tools to handle real collections of data. Next up: functions. You'll learn to define reusable blocks of logic with `def`, pass parameters, return values, and write code that doesn't need to be read from top to bottom every time something breaks.
+
+Never stop coding!
+
+---
+
+**💡 Challenge**: Start with this task list: `["email", "call", "email", "meeting", "email"]`. Work through it step by step: (1) add `"report"` to the end with `append()`; (2) remove the first task using `pop(0)` and store it in a variable; (3) remove all occurrences of `"email"` using a `while` loop and `remove()`; (4) create a new list containing only tasks with more than 4 letters, using a list comprehension. Print the result after each step.

--- a/src/content/tutorials/metodos-listas-python.mdx
+++ b/src/content/tutorials/metodos-listas-python.mdx
@@ -1,0 +1,208 @@
+---
+title: "Métodos de listas en Python: append, remove y list comprehensions"
+post_slug: "metodos-listas-python"
+date: "2026-05-22"
+excerpt: "Una lista que no puedes modificar es solo una tupla con más pasos. Aprende a añadir, eliminar y transformar elementos con los métodos más importantes — y da tus primeros pasos con las list comprehensions."
+language: "es"
+categories: ["programacion"]
+course: "aprende-a-programar-desde-cero-python"
+order: 10
+cover: "/images/tutorials/cabecera-python-curso.jpg"
+i18n: "list-methods-python"
+---
+
+Tienes la lista. Los artículos del carrito de esa tienda del tutorial anterior. La creaste, la recorriste con `for`, comprobaste si algo estaba dentro con `in`. Todo bien. Y entonces el usuario añade un producto, elimina otro, quieres saber cuántas veces aparece "camiseta" en su historial de pedidos. Y ahí te das cuenta de que saber crear una lista no es lo mismo que saber trabajar con ella.
+
+Los métodos son la parte donde las listas dejan de ser un contenedor estático y se vuelven útiles de verdad.
+
+## Añadir elementos
+
+El más frecuente de todos es `append()` — añade un elemento al final de la lista:
+
+```python
+carrito = ["camiseta", "pantalón"]
+
+carrito.append("zapatillas")
+print(carrito)   # ["camiseta", "pantalón", "zapatillas"]
+```
+
+Si necesitas añadir en una posición específica, `insert(índice, valor)`:
+
+```python
+carrito.insert(1, "calcetines")   # Insert at index 1
+print(carrito)   # ["camiseta", "calcetines", "pantalón", "zapatillas"]
+```
+
+Aquí entra la primera trampa con la que, si eres como yo cuando empecé, caerás exactamente una vez y nunca más: `append()` vs `extend()`.
+
+`extend()` añade todos los elementos de otro iterable, uno por uno. `append()` añade el objeto como un elemento único — si le pasas una lista, mete esa lista entera como un solo elemento anidado:
+
+```python
+carrito = ["camiseta", "pantalón"]
+
+carrito.extend(["zapatillas", "gorro"])
+print(carrito)   # ["camiseta", "pantalón", "zapatillas", "gorro"] ✅
+
+carrito2 = ["camiseta", "pantalón"]
+carrito2.append(["zapatillas", "gorro"])
+print(carrito2)  # ["camiseta", "pantalón", ["zapatillas", "gorro"]] ❌ — nested list
+```
+
+La regla es directa: ¿quieres añadir un elemento? `append()`. ¿Quieres fusionar dos listas? `extend()`.
+
+## Eliminar elementos
+
+Python te da cuatro formas de eliminar elementos y cada una cubre un caso ligeramente distinto. No es que el lenguaje esté roto — es que los casos de uso son genuinamente diferentes.
+
+**`remove(valor)`** elimina la primera ocurrencia de un valor concreto:
+
+```python
+frutas = ["manzana", "pera", "uva", "pera"]
+
+frutas.remove("pera")
+print(frutas)   # ["manzana", "uva", "pera"] — only the first one removed
+```
+
+⚠️ Si el valor no existe, `remove()` lanza un `ValueError`. Comprueba con `in` antes si no estás seguro de que el elemento está ahí:
+
+```python
+if "kiwi" in frutas:
+    frutas.remove("kiwi")
+```
+
+**`pop(índice)`** elimina por posición y **devuelve el elemento eliminado**. Sin índice, elimina el último:
+
+```python
+frutas = ["manzana", "pera", "uva"]
+
+ultimo = frutas.pop()        # Removes "uva" and returns it
+print(ultimo)   # "uva"
+print(frutas)   # ["manzana", "pera"]
+
+primero = frutas.pop(0)      # Removes "manzana"
+print(primero)  # "manzana"
+```
+
+La diferencia clave con `remove()`: `pop()` trabaja con índices y te devuelve lo que eliminó. Útil cuando necesitas el elemento antes de tirarlo — procesar y eliminar en el mismo paso.
+
+**`del`** es una sentencia del lenguaje (no un método). Elimina por índice o por slice, sin devolver nada:
+
+```python
+frutas = ["manzana", "pera", "uva", "kiwi", "naranja"]
+
+del frutas[1]       # Removes "pera"
+del frutas[1:3]     # Removes a slice — "uva" and "kiwi" after the previous del
+print(frutas)       # ["manzana", "naranja"]
+```
+
+Y si necesitas vaciar la lista completamente conservando la misma referencia, `clear()`:
+
+```python
+carrito = ["camiseta", "pantalón", "zapatillas"]
+carrito.clear()
+print(carrito)   # []
+```
+
+Esto no es lo mismo que hacer `carrito = []`. Con `carrito = []` creas una lista nueva y abandonas la original — si algo más apuntaba a la misma lista, no se entera. Con `clear()` vacías la que ya tienes, sin crear nada nuevo.
+
+## Modificar elementos directamente
+
+Acceder a un índice y asignarle un valor nuevo:
+
+```python
+frutas = ["manzana", "pera", "uva"]
+
+frutas[0] = "melocotón"
+print(frutas)   # ["melocotón", "pera", "uva"]
+```
+
+También funciona con slices — puedes reemplazar un rango completo de una vez:
+
+```python
+frutas[1:3] = ["mango", "papaya"]
+print(frutas)   # ["melocotón", "mango", "papaya"]
+```
+
+## Buscar dentro de una lista
+
+`index(valor)` devuelve la posición de la primera ocurrencia:
+
+```python
+frutas = ["manzana", "pera", "uva", "pera"]
+
+print(frutas.index("pera"))   # 1 — first occurrence
+```
+
+⚠️ Como `remove()`, lanza `ValueError` si el elemento no existe. Protégete con `in` antes de llamarlo.
+
+`count(valor)` cuenta cuántas veces aparece un elemento:
+
+```python
+votos = ["sí", "no", "sí", "sí", "no", "sí"]
+
+print(votos.count("sí"))   # 4
+print(votos.count("no"))   # 2
+```
+
+## List comprehensions: la primera vez que Python te sorprende
+
+Llegamos al momento en que Python hace algo que, la primera vez que lo ves, parece que no debería ser tan limpio — pero funciona, y no entiendes por qué no todos los lenguajes hacen lo mismo.
+
+Imagina que tienes una lista de números y quieres otra con todos esos números elevados al cuadrado. La forma larga:
+
+```python
+numeros = [1, 2, 3, 4, 5]
+
+cuadrados = []
+for n in numeros:
+    cuadrados.append(n ** 2)
+
+print(cuadrados)   # [1, 4, 9, 16, 25]
+```
+
+Funciona. Cuatro líneas. Y ahora la misma operación con una **list comprehension**:
+
+```python
+cuadrados = [n ** 2 for n in numeros]
+
+print(cuadrados)   # [1, 4, 9, 16, 25]
+```
+
+Una línea. Misma semántica. Léela de izquierda a derecha: "dame `n ** 2` para cada `n` en `numeros`". Si eso suena casi a lenguaje natural, es porque Python lo diseñó exactamente así.
+
+La sintaxis es `[expresión for variable in iterable]`. Y puedes añadir una condición para filtrar:
+
+```python
+pares = [n for n in numeros if n % 2 == 0]
+
+print(pares)   # [2, 4]
+```
+
+`[expresión for variable in iterable if condición]`. Solo los elementos que cumplan la condición entran en la lista resultante.
+
+¿Sensación de que eso no debería ser tan cómodo? Normal. Los que vienen de Java o C++ se quedan mirando esto con una mezcla de desconcierto y envidia (los de JavaScript también, aunque ellos tienen el `map` y el `filter`, que hacen lo mismo pero más barrocamente). No te agobies si al principio te parece magia — escríbela despacio, léela en voz alta, y en una semana te preguntarás cómo vivías sin ellas.
+
+Por ahora quédate con los casos simples: transformar elementos y filtrar listas. Las comprehensions pueden volverse más complejas, pero el patrón es siempre el mismo.
+
+---
+
+## Conceptos clave de esta lección
+
+- `append(valor)` añade un elemento al final; `extend(iterable)` fusiona dos listas elemento a elemento
+- `remove(valor)` elimina por valor (primera ocurrencia); lanza `ValueError` si no existe
+- `pop(índice)` elimina por posición y devuelve el elemento; sin índice, elimina el último
+- `del lista[índice]` elimina por posición sin devolver nada; también admite slices
+- `clear()` vacía la lista conservando la referencia; distinto de `lista = []`
+- `index(valor)` devuelve la posición de la primera ocurrencia
+- `count(valor)` cuenta cuántas veces aparece un elemento
+- List comprehension: `[expresión for variable in iterable if condición]`
+
+---
+
+Con esto cierra el módulo de Control Flow. Has pasado de condicionales a bucles, de listas básicas a métodos completos y list comprehensions — y ya tienes las herramientas para manejar colecciones de datos reales. En el próximo tutorial empieza un módulo nuevo: las funciones. Aprenderás a definir bloques de lógica reutilizable con `def`, a pasar parámetros y devolver valores — el primer paso para que tu código no sea un bloque monolítico de instrucciones que hay que releer entero cada vez que algo falla.
+
+¡Nunca dejes de programar!
+
+---
+
+**💡 Reto**: Tienes una lista de tareas: `["email", "llamada", "email", "reunión", "email"]`. Resuelve lo siguiente paso a paso: (1) añade `"informe"` al final con `append()`; (2) elimina la primera tarea de la lista con `pop(0)` y guárdala en una variable; (3) elimina todas las ocurrencias de `"email"` usando un bucle con `while` y `remove()`; (4) crea una nueva lista con todas las tareas que tengan más de 5 letras usando una list comprehension. Imprime el resultado después de cada paso.


### PR DESCRIPTION
Add the tenth tutorial of the "Learn to Code from Scratch / Aprende a programar desde cero" Python course, covering list methods in both English and Spanish.

**Topics covered:**
- `append()`, `insert()`, `extend()` — adding elements
- `remove()`, `pop()`, `del`, `clear()` — removing elements
- Direct assignment and slice modification
- `index()` and `count()` — searching
- List comprehensions: `[expr for var in iterable if condition]`

Includes practical examples (shopping cart, task list) and a challenge exercise.