### PR TITLE
feat(tutorials): add art of the prompt core principles tutorial (ES/EN)

### DIFF
--- a/src/content/tutorials/el-arte-del-prompt-principios-basicos.mdx
+++ b/src/content/tutorials/el-arte-del-prompt-principios-basicos.mdx
@@ -1,0 +1,209 @@
+---
+title: "El arte del prompt: principios básicos"
+post_slug: "el-arte-del-prompt-principios-basicos"
+date: "2026-05-25"
+excerpt: "El mismo modelo, el mismo día, treinta segundos de diferencia: dos respuestas completamente distintas según cómo planteas la pregunta. Aquí está el framework RCTF y por qué lo cambia todo."
+language: "es"
+categories: ["ia"]
+course: "ia-para-programadores"
+order: 7
+cover: "/images/tutorials/cabecera-ia-para-programadores-curso.jpg"
+i18n: "the-art-of-the-prompt-core-principles"
+---
+
+Hay un momento que casi todo el mundo tiene la primera semana usando IA para código. Escribes algo como "ayúdame con este error", la IA te da una respuesta genérica que aplica a cualquier cosa menos a tu problema concreto, te frustras, cierras la pestaña y llegas a la conclusión de que esto está sobrevalorado.
+
+Lo que nadie te dice en ese momento: la IA no falló. El prompt sí.
+
+Ese mismo modelo, treinta segundos después, con una pregunta estructurada, te habría dado exactamente lo que necesitabas. La diferencia entre esas dos preguntas no es conocimiento técnico avanzado — es estructura. Y la estructura se aprende.
+
+## Por qué el mismo modelo da respuestas tan distintas
+
+Hay que recordar algo del Módulo 1: la IA no "piensa" en el sentido humano. Predice tokens. Eso significa que si le das poco contexto, rellena los huecos con lo más probable — y en una pregunta vaga, lo más probable es una respuesta vaga. Si tienes curiosidad sobre los mecanismos concretos detrás de eso, [el tutorial sobre alucinaciones](/es/tutoriales/limitaciones-ia-detectar-alucinaciones) lo explica en detalle.
+
+Para ver la diferencia en la práctica, mismo modelo, mismo día, dos sesiones distintas.
+
+**Prompt A:**
+
+```
+¿Cómo manejo errores en Python?
+```
+
+Respuesta típica: una explicación de `try/except` con un ejemplo de `ZeroDivisionError`. Correcta. Completa. Útil para el examen de secundaria. Inútil para lo que probablemente necesitas tú ahora mismo.
+
+**Prompt B:**
+
+```
+Actúa como un senior Python developer.
+
+Contexto: estoy construyendo una CLI tool que hace peticiones HTTP a una API
+externa. Necesito que los errores sean informativos para el usuario final
+(sin traceback) pero que quede registrado el traceback completo en un log.
+
+Tarea: explícame cómo debería estructurar el error handling para este caso.
+
+Formato: respuesta concisa, un ejemplo de código funcional y los trade-offs
+entre las dos o tres opciones principales.
+```
+
+Respuesta típica: una clase `AppError` bien diseñada, dos patrones de manejo con sus pros y contras, un ejemplo completo que puedes adaptar directamente. Lo que necesitabas.
+
+Mismo modelo. Treinta segundos de diferencia. Todo cambia con la estructura.
+
+## El framework RCTF
+
+Si eres como yo cuando empecé, probablemente asumiste que "hacer buenas preguntas" era algo difuso que se aprendía con el tiempo, sin reglas claras. Y es verdad que la experiencia ayuda. Pero también hay un framework concreto que funciona desde el primer día.
+
+Se llama **RCTF**: **R**ol, **C**ontexto, **T**area, **F**ormato.
+
+No es magia — es una lista de comprobación mental que garantiza que la IA tiene lo suficiente para generar una respuesta útil. Vamos por partes.
+
+### R — Rol
+
+Le dices a la IA desde qué perspectiva tiene que responder. Esto no es solo cosmético: cambia cómo pondera y prioriza la información que conoce.
+
+```
+# Without a role — generic answer
+¿Cuál es la mejor estructura de carpetas para un proyecto de Node.js?
+
+# With a role — contextualized answer
+Actúa como un backend engineer con experiencia en proyectos Node.js a escala de equipo.
+¿Cuál es la mejor estructura de carpetas para un proyecto de Node.js?
+```
+
+Sin rol, la IA asume un punto de vista neutro — que en la práctica significa "principiante genérico". No porque sea maliciosa, sino porque en ausencia de instrucciones, apunta al denominador común. Con un rol concreto, cambia el nivel de la respuesta.
+
+La tentación es escribir algo elaborado: "eres un genio de la programación con décadas de experiencia y un doctorado en sistemas distribuidos...". No hace falta. "Actúa como un senior [lenguaje/tecnología] developer" funciona perfectamente en el 90% de los casos. Lo importante es que esté.
+
+### C — Contexto
+
+Aquí se gana o se pierde la calidad de la respuesta. El contexto es todo lo que la IA no puede saber de otra forma: qué stack usas, qué restricciones tienes, cuál es el problema real, qué ya has intentado.
+
+```
+# Without context
+Tengo un bug en mi código de autenticación
+
+# With context
+Tengo un bug en mi código de autenticación. Stack: Express + JWT + bcrypt.
+El problema: cuando el token expira, el middleware devuelve 500 en vez de 401.
+Ya revisé el middleware de validación y el try/catch parece correcto.
+```
+
+Cuanto más contexto das, menos rellena la IA con suposiciones. Una señal clara de contexto insuficiente: cuando la respuesta empieza con "Para ayudarte mejor, necesito saber..." — eso es la IA diciéndote, con mucha educación, que le diste poco.
+
+Un truco que funciona bien: piensa en lo que le dirías a un compañero que no sabe nada de tu proyecto pero es experto en la tecnología. Sin el PowerPoint de onboarding, sin el historial de Slack de los últimos seis meses — solo lo que necesita saber para entender tu problema ahora mismo. Exactamente eso es el contexto.
+
+### T — Tarea
+
+La acción concreta que quieres que realice. No "ayúdame con esto" — el verbo exacto: _revisa_, _refactoriza_, _explica_, _genera_, _compara_, _identifica_.
+
+```
+# Ambiguous task
+Ayúdame con esta función
+
+# Concrete task
+Revisa esta función e identifica posibles memory leaks. No la refactorices
+todavía — solo lista los problemas con una explicación de por qué son problemáticos.
+```
+
+La diferencia entre "ayúdame" y "revisa e identifica" es la diferencia entre una respuesta que lo hace todo (a medias) y una que hace exactamente lo que pediste.
+
+También sirve delimitar lo que _no_ quieres. La IA tiene cierta tendencia natural al over-engineering — si no la contienes, tu función de tres líneas acaba siendo un módulo con su propio sistema de logging y dos interfaces. "No la refactorices todavía" evita ese destino.
+
+### F — Formato
+
+Cómo quieres que se estructure la respuesta. Sin especificar formato, la IA adivina — y a veces acierta, pero muchas veces te da tres párrafos cuando necesitabas código, o código sin comentarios cuando necesitabas una explicación.
+
+```
+# Without format — free-form response
+Explícame cómo funciona el event loop de Node.js
+
+# With format — exactly what you can use:
+Explícame cómo funciona el event loop de Node.js.
+Formato: tres párrafos máximo, con un diagrama en ASCII si ayuda a visualizarlo,
+y un ejemplo de código que muestre la diferencia entre código síncrono y asíncrono.
+```
+
+Los formatos más útiles en desarrollo:
+
+- **Código con comentarios**: para implementaciones
+- **Lista numerada**: para pasos, procedimientos, prioridades
+- **Tabla comparativa**: para elegir entre opciones
+- **Antes / después**: para refactorizaciones
+- **Solo código, sin preámbulo**: cuando ya entiendes el patrón y solo necesitas el output
+
+El F es la parte que más gente omite porque parece opcional. Si lo saltas, la IA elige el formato que más le apetece en ese momento. Spoiler: rara vez coincide con el que tú necesitabas. No es opcional cuando tienes que conectar la respuesta a algo real.
+
+### El Prompt B revisitado
+
+Con el framework en mente, el Prompt B de antes ya no parece largo ni complejo — es simplemente las cuatro partes en orden:
+
+```
+[R] Actúa como un senior Python developer.
+
+[C] Estoy construyendo una CLI tool que hace peticiones HTTP a una API externa.
+    Necesito que los errores sean informativos para el usuario final (sin traceback)
+    pero que quede registrado el traceback completo en un archivo de log.
+
+[T] Explícame cómo debería estructurar el error handling para este caso.
+
+[F] Respuesta concisa, un ejemplo de código funcional y los trade-offs entre
+    las dos o tres opciones principales.
+```
+
+No te agobies si al principio el prompt sale largo. La longitud no es el problema — la falta de estructura sí. Con el tiempo, escribir en RCTF se vuelve tan automático que dejas de pensar en él como un framework y simplemente es cómo escribes.
+
+## Anti-patrones comunes
+
+Hay tres formas de arruinar un prompt que aparecen constantemente. Mejor nombrarlas directamente.
+
+### Demasiado vago
+
+```
+"Ayúdame con mi función de autenticación"
+"Esto no funciona"
+"¿Cómo mejoro este código?"
+```
+
+¿Qué función? ¿Qué no funciona exactamente? ¿Mejorarlo en qué sentido — performance, legibilidad, seguridad, cobertura de tests? La IA va a intentar responder, pero va a adivinar. La regla práctica: si el prompt no tiene al menos un verbo concreto y una pieza de contexto específico, es demasiado vago.
+
+### Sin restricciones
+
+```
+# ❌ Prompt sin restricciones
+"Escribe una función para gestionar usuarios"
+```
+
+¿En qué lenguaje? ¿Qué operaciones necesita? ¿Hay base de datos? ¿Qué campos tiene un usuario? ¿Es un CRUD completo o solo autenticación?
+
+Sin restricciones, la IA genera algo plausible que probablemente no es lo que necesitas. Las restricciones no limitan la respuesta — la enfocan.
+
+```
+# ✅ Con restricciones
+"Escribe una función en Python que reciba un user_id, consulte PostgreSQL y
+devuelva el usuario o None si no existe. Usa psycopg2. Sin ORM."
+```
+
+### Sin especificación de formato
+
+```
+# ❌ Respuesta libre → muro de texto
+"Explícame las diferencias entre SQL y NoSQL"
+
+# ✅ Formato especificado → respuesta que puedes usar directamente
+"Explícame las diferencias entre SQL y NoSQL.
+Formato: tabla comparativa con los criterios de elección más relevantes para
+un backend developer. Tres casos de uso concretos al final."
+```
+
+La versión sin formato te da una respuesta correcta. La versión con formato te da una respuesta correcta que puedes procesar y usar en los próximos dos minutos.
+
+---
+
+RCTF es, en el fondo, una checklist de cuatro items. No es glamuroso. Pero la diferencia en la calidad de las respuestas cuando los cuatro están presentes es suficiente como para que valga la pena convertirlo en hábito antes de que acabe este módulo. La mayoría de los prompts malos no fallan en cuatro cosas a la vez — fallan en una sola, y esa es suficiente para que la respuesta sea inútil.
+
+En el próximo tutorial vamos a profundizar en la **C** del framework: qué significa proporcionar contexto rico de verdad, cómo funciona el prompting iterativo, y cómo especificar formatos complejos para que la respuesta sea exactamente lo que puedes conectar directamente a tu flujo de trabajo.
+
+**💡 Desafío:** Toma tres preguntas que le hayas hecho a la IA esta semana (o invéntatelas si no usaste ninguna) y reescríbelas aplicando RCTF. Para cada una, identifica cuál de las cuatro partes cambia más el resultado. La respuesta suele sorprender.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/the-art-of-the-prompt-core-principles.mdx
+++ b/src/content/tutorials/the-art-of-the-prompt-core-principles.mdx
@@ -1,0 +1,209 @@
+---
+title: "The art of the prompt: core principles"
+post_slug: "the-art-of-the-prompt-core-principles"
+date: "2026-05-25"
+excerpt: "Same model, same day, thirty seconds apart — two completely different answers depending on how you frame the question. Here's the RCTF framework and why it changes everything."
+language: "en"
+categories: ["ai"]
+course: "ai-for-developers"
+order: 7
+cover: "/images/tutorials/cabecera-ia-para-programadores-curso.jpg"
+i18n: "el-arte-del-prompt-principios-basicos"
+---
+
+There's a moment almost everyone hits in their first week using AI for code. You type something like "help me with this error," the AI gives you a generic answer that applies to roughly everything except your actual problem, and you close the tab convinced this whole AI thing is overhyped.
+
+Here's what no one tells you in that moment: the AI didn't fail. The prompt did.
+
+That same model, thirty seconds later, with a structured question, would have given you exactly what you needed. The difference between those two questions isn't advanced technical knowledge — it's structure. And structure can be learned.
+
+## Why the same model gives such different answers
+
+A quick callback to Module 1: the AI doesn't "think" in the human sense. It predicts tokens. That means if you give it little context, it fills the gaps with the most probable continuation — and for a vague question, the most probable answer is a vague one. If you want to dig into the mechanics behind that, [the hallucinations tutorial](/en/tutorials/ai-limitations-detecting-hallucinations) covers exactly how this plays out.
+
+To make this concrete, same model, same day, two separate sessions.
+
+**Prompt A:**
+
+```
+How do I handle errors in Python?
+```
+
+Typical response: a clear explanation of `try/except` with a `ZeroDivisionError` example. Correct. Complete. Perfect for a CS101 assignment. Not remotely useful for whatever you're actually building.
+
+**Prompt B:**
+
+```
+Act as a senior Python developer.
+
+Context: I'm building a CLI tool that makes HTTP requests to an external API.
+I need errors to be informative for the end user (no traceback) but I also
+need the full traceback logged to a file.
+
+Task: explain how I should structure the error handling for this case.
+
+Format: concise answer, one working code example, and the trade-offs between
+the two or three main approaches.
+```
+
+Typical response: a well-designed `AppError` class, two handling patterns with their pros and cons, a complete example you can adapt directly. What you actually needed.
+
+Same model. Thirty seconds apart. All because of structure.
+
+## The RCTF framework
+
+If you're anything like I was when I started, you probably assumed that "asking good questions" was one of those fuzzy skills you pick up with experience — no rules, just intuition. And experience does help. But there's also a concrete framework that works from day one.
+
+It's called **RCTF**: **R**ole, **C**ontext, **T**ask, **F**ormat.
+
+It's not magic — it's a mental checklist that guarantees you're giving the AI enough to produce a useful answer. Let's go through each part.
+
+### R — Role
+
+You tell the AI what perspective it should respond from. This isn't just cosmetic: it changes how it weighs and prioritizes everything it knows.
+
+```
+# Without a role — generic answer
+What's the best folder structure for a Node.js project?
+
+# With a role — calibrated answer
+Act as a backend engineer with experience on team-scale Node.js projects.
+What's the best folder structure for a Node.js project?
+```
+
+Without a role, the AI assumes a neutral viewpoint — which in practice means "generic beginner." Not because it's trying to be unhelpful, but because when no instruction is given, it defaults to the lowest common denominator. With a concrete role, the level of the response shifts.
+
+The temptation is to write something elaborate: "you are a legendary engineer with thirty years of experience and three published papers on distributed systems..." Don't bother. "Act as a senior [language/technology] developer" covers 90% of cases. The important thing is that it's there.
+
+### C — Context
+
+This is where the quality of the response is won or lost. Context is everything the AI can't know on its own: what stack you're using, what constraints you're working under, what the real problem is, what you've already tried.
+
+```
+# Without context
+I have a bug in my authentication code
+
+# With context
+I have a bug in my authentication code. Stack: Express + JWT + bcrypt.
+The issue: when a token expires, the middleware returns 500 instead of 401.
+I've already checked the validation middleware and the try/catch looks correct.
+```
+
+The more context you provide, the less the AI fills in with assumptions. A dead giveaway that your context was too thin: when the response starts with "To help you better, I'd need to know..." — that's the AI politely telling you it's working with nothing.
+
+A useful mental model: think about what you'd tell a colleague who knows nothing about your project but is an expert in the technology. Skip the onboarding deck, skip the backstory — just the minimum they need to understand your problem right now. That's context.
+
+### T — Task
+
+The specific action you want performed. Not "help me with this" — the exact verb: _review_, _refactor_, _explain_, _generate_, _compare_, _identify_.
+
+```
+# Ambiguous task
+Help me with this function
+
+# Concrete task
+Review this function and identify potential memory leaks. Don't refactor it
+yet — just list the issues with an explanation of why each one is a problem.
+```
+
+The difference between "help me" and "review and identify" is the difference between a response that does everything (poorly) and one that does exactly what you asked.
+
+Negative constraints work too. The AI has a natural tendency toward over-engineering — leave it unchecked and your three-line function comes back as a module with its own logging system and two interfaces. "Don't refactor it yet" stops that from happening.
+
+### F — Format
+
+How you want the response structured. Without a format, the AI guesses — and sometimes it guesses right, but often you get three paragraphs when you needed code, or code without comments when you needed an explanation.
+
+```
+# Without format — free-form response
+Explain how the Node.js event loop works
+
+# With format — exactly what you can use:
+Explain how the Node.js event loop works.
+Format: three paragraphs max, an ASCII diagram if it helps visualize the flow,
+and a code example showing the difference between synchronous and async execution.
+```
+
+The most useful formats for development work:
+
+- **Code with comments**: for implementations
+- **Numbered list**: for steps, procedures, priorities
+- **Comparison table**: for choosing between options
+- **Before / after**: for refactors
+- **Code only, no preamble**: when you understand the pattern and just need the output
+
+The F is what most people skip because it feels optional. Skip it and the AI picks whatever format it feels like. Spoiler: it rarely matches what you needed. It's not optional when you have to actually use the response for something.
+
+### Prompt B, revisited
+
+With the framework in mind, Prompt B from earlier doesn't look long or complicated anymore — it's just the four parts in order:
+
+```
+[R] Act as a senior Python developer.
+
+[C] I'm building a CLI tool that makes HTTP requests to an external API.
+    I need errors to be informative for the end user (no traceback) but I also
+    need the full traceback logged to a file.
+
+[T] Explain how I should structure the error handling for this case.
+
+[F] Concise answer, one working code example, and the trade-offs between
+    the two or three main approaches.
+```
+
+Don't worry if your prompts feel long at first. Length isn't the problem — lack of structure is. Over time, writing in RCTF becomes automatic. You stop thinking of it as a framework and it's just how you write.
+
+## Common anti-patterns
+
+Three prompt failure modes show up over and over. Worth naming them directly.
+
+### Too vague
+
+```
+"Help me with my authentication function"
+"This isn't working"
+"How do I improve this code?"
+```
+
+Which function? What exactly isn't working? Improve it in what direction — performance, readability, security, test coverage? The AI will try to answer, but it'll be guessing. The practical rule: if your prompt doesn't have at least one concrete verb and one specific piece of context, it's too vague.
+
+### No constraints
+
+```
+# ❌ No constraints
+"Write a function to manage users"
+```
+
+What language? What operations does it need? Is there a database? What fields does a user have? Is this a full CRUD or just the authentication piece?
+
+Without constraints, the AI generates something plausible that probably isn't what you need. Constraints don't limit the response — they focus it.
+
+```
+# ✅ With constraints
+"Write a Python function that takes a user_id, queries PostgreSQL, and returns
+the user or None if not found. Use psycopg2. No ORM."
+```
+
+### No format specification
+
+```
+# ❌ No format → wall of text
+"Explain the differences between SQL and NoSQL"
+
+# ✅ Format specified → something you can actually use
+"Explain the differences between SQL and NoSQL.
+Format: a comparison table with the most relevant selection criteria for a
+backend developer, followed by three concrete use cases."
+```
+
+The no-format version gives you a correct answer. The with-format version gives you a correct answer you can process and use in the next two minutes.
+
+---
+
+RCTF is, at its core, a four-item checklist. Not glamorous. But the difference in response quality when all four are present is significant enough that it's worth making it a habit before this module is done. Most bad prompts don't fail on all four at once — they fail on one, and one is enough to make the answer useless.
+
+In the next tutorial, we go deep on the **C** in RCTF: what rich context actually looks like, how iterative prompting works, and how to specify complex formats so the response connects directly to your workflow.
+
+**💡 Challenge:** Take three questions you've asked an AI recently (or invent them if you haven't) and rewrite each one using RCTF. For each rewrite, identify which of the four parts changes the result the most. The answer tends to be surprising.
+
+Never stop coding!


### PR DESCRIPTION
## Description

New tutorial on the art of prompting for the AI for Developers course (tutorial #7). Introduces the RCTF framework (Role, Context, Task, Format) for crafting structured prompts. Covers why structured prompts produce dramatically better results than vague questions, walks through each RCTF component with examples, identifies three common anti-patterns, and includes a practical challenge. Bilingual ES/EN pair.

## Changes Made

- `src/content/tutorials/el-arte-del-prompt-principios-basicos.mdx` — Spanish version
- `src/content/tutorials/the-art-of-the-prompt-core-principles.mdx` — English version