### PR TITLE
feat(tutorials): add Advanced Dockerfile instructions tutorial (ES/EN)

### DIFF
--- a/src/content/tutorials/advanced-dockerfile-instructions.mdx
+++ b/src/content/tutorials/advanced-dockerfile-instructions.mdx
@@ -1,0 +1,240 @@
+---
+title: "Advanced Dockerfile instructions: ARG, ENV, ENTRYPOINT and more"
+post_slug: "advanced-dockerfile-instructions"
+date: "2026-05-29"
+excerpt: "Understand once and for all the difference between ARG and ENV, ENTRYPOINT and CMD, and what HEALTHCHECK, VOLUME and EXPOSE actually do in your Dockerfiles."
+language: "en"
+categories: ["docker"]
+course: "mastering-docker-from-scratch"
+order: 10
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "instrucciones-avanzadas-dockerfile"
+---
+
+Most Dockerfiles have a few lines that everyone copies from an example that worked once and never questions again. `ENTRYPOINT` and `CMD` near the bottom. `ARG` and `ENV` somewhere near the top. The container starts, the app runs, and nobody asks too many questions.
+
+Until it breaks. Or until someone on the team notices the API key getting passed through `ARG` — which shows up in the image history for anyone to read — or asks why the container ignores the command you pass to `docker run`. That conversation should have happened earlier. This lesson is it.
+
+## ARG vs ENV
+
+`ARG` or `ENV`? Which one persists into the container? Which one disappears after the build? Can you combine them? Does the order in the Dockerfile matter? They look similar — both define variables, both accept a name and an optional default value — but they exist at completely different moments in the Docker lifecycle.
+
+**`ARG`** defines a variable that only exists during the build process. Once the image is built, it's gone. The container that runs from that image never sees it. Use `ARG` for things that affect how the image is built: the Node version, the app version string, a compile-time flag.
+
+**`ENV`** defines an environment variable that persists into the running container. Use `ENV` for anything your application needs at runtime.
+
+```dockerfile
+ARG NODE_VERSION=20
+FROM node:${NODE_VERSION}-alpine
+
+ARG APP_VERSION=1.0.0
+ENV APP_VERSION=${APP_VERSION}
+
+WORKDIR /app
+COPY . .
+RUN npm ci
+CMD ["node", "index.js"]
+```
+
+`NODE_VERSION` only exists long enough to pick the base image. After that, it's gone. `APP_VERSION` is explicitly bridged from `ARG` to `ENV` — that's how a build-time value makes it into the running container.
+
+You can override `ARG` at build time, and `ENV` at runtime:
+
+```bash
+# Override ARG during build
+docker build --build-arg NODE_VERSION=22 -t my-app .
+
+# Override ENV when running
+docker run -e APP_VERSION=2.0.0 my-app
+```
+
+### The security gotcha you need to know about
+
+`ARG` is not a safe place for secrets. Values passed through `ARG` end up in the image history:
+
+```bash
+docker history my-app
+```
+
+```
+IMAGE         CREATED       CREATED BY
+abc123def456  2 hours ago   CMD ["node", "index.js"]
+...           ...           ARG API_KEY=s3cr3t          ← right there
+```
+
+If you've passed an API key, token, or any credential through `ARG`, it's recoverable from the image by anyone who can pull it. This is covered in detail in [Dockerfile security best practices](/en/tutorials/dockerfile-best-practices-security) — if you skipped that one, it's worth going back.
+
+The rule: build-time secrets to BuildKit build secrets (next lesson). Runtime secrets to environment variables injected by your secrets management system, never hardcoded in the Dockerfile.
+
+## ENTRYPOINT vs CMD
+
+If you're like most people when they first encounter this, you've copied those lines from Stack Overflow, seen that sometimes both appear and sometimes only one, and assumed Docker has its quirks. It doesn't. It has concrete rules, and once you understand them everything clicks.
+
+**`CMD`** defines the default command a container runs. It's fully replaceable — pass a different command to `docker run` and `CMD` is ignored entirely.
+
+**`ENTRYPOINT`** defines the executable that always runs when the container starts. You can't override it with a regular argument — you need `--entrypoint` explicitly.
+
+When you use both, `CMD` provides the default arguments to `ENTRYPOINT`.
+
+```dockerfile
+# CMD only — fully replaceable command
+FROM ubuntu:22.04
+CMD ["echo", "hello world"]
+```
+
+```bash
+docker run my-image               # → "hello world"
+docker run my-image echo "bye"   # → "bye"  (CMD replaced)
+```
+
+```dockerfile
+# ENTRYPOINT only — fixed executable
+FROM ubuntu:22.04
+ENTRYPOINT ["echo"]
+```
+
+```bash
+docker run my-image               # → ""  (nothing, no args)
+docker run my-image "hello"      # → "hello"
+```
+
+```dockerfile
+# ENTRYPOINT + CMD — the most useful pattern
+FROM ubuntu:22.04
+ENTRYPOINT ["echo"]
+CMD ["hello world"]
+```
+
+```bash
+docker run my-image               # → "hello world"  (default)
+docker run my-image "other text" # → "other text"  (CMD replaced)
+```
+
+The `ENTRYPOINT + CMD` combination is what you want for CLI tools packaged as containers: the tool is fixed, the arguments are defaults you can override without knowing anything about the image internals.
+
+If you're following along but it's not fully clicking yet, that's fine — this is the combination that gets googled most often by people who've been using Docker for months. The 90% case is exec form in `ENTRYPOINT` with `CMD` as default arguments. The rest comes with practice.
+
+### Shell form vs exec form
+
+Both instructions come in two flavors:
+
+```dockerfile
+# Shell form — runs via /bin/sh -c
+CMD echo "hello"
+ENTRYPOINT echo "hello"
+
+# Exec form — executes directly, no shell involved
+CMD ["echo", "hello"]
+ENTRYPOINT ["echo", "hello"]
+```
+
+**Use exec form for `ENTRYPOINT`.** Shell form runs your process as a child of `/bin/sh`, which has two annoying consequences: OS signals like `SIGTERM` (sent when stopping a container) don't reach your process because the shell intercepts them, and on minimal images without a shell the container simply won't start. With exec form, your process is PID 1 and receives signals directly.
+
+## HEALTHCHECK
+
+This is the instruction no one adds until a container fails silently in production and it takes longer than it should to notice. After that, they add it to everything.
+
+`HEALTHCHECK` tells Docker how to verify a container is functioning correctly. Docker runs the specified command on a schedule and updates the container's status: `starting`, `healthy`, or `unhealthy`.
+
+```dockerfile
+FROM node:20-alpine
+WORKDIR /app
+COPY . .
+RUN npm ci
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:3000/health || exit 1
+
+CMD ["node", "index.js"]
+```
+
+The parameters:
+
+- `--interval`: how often the check runs (default: 30s)
+- `--timeout`: if the command takes longer than this, it's a failure (default: 30s)
+- `--start-period`: grace period at startup before failures start counting (default: 0s)
+- `--retries`: how many consecutive failures before marking as `unhealthy` (default: 3)
+
+The check command should return `0` for healthy and `1` for unhealthy. The `|| exit 1` ensures that if `curl` fails — because the server isn't responding or returns an HTTP error — the check reports failure too.
+
+```bash
+docker ps
+```
+
+```
+CONTAINER ID   IMAGE     STATUS
+a1b2c3d4e5f6   my-app    Up 2 minutes (healthy)
+```
+
+That `(healthy)` in `docker ps` means the HEALTHCHECK is running and passing. Docker Compose and orchestrators use this status to know whether a container is ready to accept traffic, whether it needs to be restarted, and whether to consider a deploy successful.
+
+If your image doesn't have `curl` — Alpine or distroless images — use `wget` or a small script in your app's runtime:
+
+```dockerfile
+# With wget (Alpine)
+HEALTHCHECK --interval=30s --timeout=5s \
+  CMD wget -q --spider http://localhost:3000/health || exit 1
+
+# With Node.js runtime
+HEALTHCHECK --interval=30s --timeout=5s \
+  CMD node -e "require('http').get('http://localhost:3000/health', r => process.exit(r.statusCode === 200 ? 0 : 1))"
+```
+
+## VOLUME and EXPOSE
+
+Here's the part nobody documents well because it's genuinely a bit odd: `EXPOSE` doesn't expose anything and `VOLUME` doesn't mount anything. They're very formal comments that Docker decided to turn into instructions. The naming is optimistic.
+
+### EXPOSE
+
+`EXPOSE` declares which port the container listens on. It does not open that port on the host. It does not make the container accessible from outside. It does nothing at runtime. It's executable documentation — it tells anyone reading the Dockerfile what port to publish, and tools like Docker Compose can discover it automatically.
+
+```dockerfile
+EXPOSE 3000
+```
+
+To actually publish the port to the host, you need `-p` when running:
+
+```bash
+docker run -p 8080:3000 my-app
+# Host port 8080 → container port 3000
+```
+
+`EXPOSE` without `-p` or `ports:` in Compose is invisible from the outside. Add it anyway — it's good documentation practice and some orchestrators use it for service discovery.
+
+### VOLUME
+
+`VOLUME` declares a mount point inside the container. Docker will automatically create an anonymous volume for that path when the container starts, ensuring data persists even if the container is removed.
+
+```dockerfile
+VOLUME ["/app/data", "/app/logs"]
+```
+
+What it doesn't do: it doesn't define where on the host the data lives (that's `-v` in `docker run` or `volumes:` in Compose), and it doesn't save you from having to specify the volume if you want control over it.
+
+```bash
+# Without specifying — Docker creates an anonymous volume
+docker run my-app
+
+# Named volume — recommended
+docker run -v my-data:/app/data my-app
+
+# Bind mount — host directory
+docker run -v $(pwd)/data:/app/data my-app
+```
+
+The primary use of `VOLUME` in a Dockerfile is to document which paths contain data that shouldn't be lost. It also has a practical side effect: any content copied into that path before the `VOLUME` instruction is included in the initial volume state. Any `COPY` or `RUN` that writes to that path after `VOLUME` won't behave as expected.
+
+⚠️ For this reason, put `VOLUME` near the end of the Dockerfile, after copying everything that needs to be there.
+
+---
+
+With `ARG`, `ENV`, `ENTRYPOINT`, `CMD`, `HEALTHCHECK`, `VOLUME`, and `EXPOSE` in your vocabulary, you have all the tools to write Dockerfiles that aren't just functional — they're configurable, predictable, and observable.
+
+Next up is BuildKit: how to enable it, what real advantages it brings over the classic builder, and how to use it to handle build secrets and package caches without compromising security.
+
+Never stop coding!
+
+---
+
+**💡 Challenge**: Open a Dockerfile from any project you have or from any open source repo. Check whether it uses shell form or exec form for `ENTRYPOINT` and `CMD`, whether it has a `HEALTHCHECK`, and whether environment variables are in `ARG` or `ENV`. Is there anything you'd change now?

--- a/src/content/tutorials/instrucciones-avanzadas-dockerfile.mdx
+++ b/src/content/tutorials/instrucciones-avanzadas-dockerfile.mdx
@@ -1,0 +1,242 @@
+---
+title: "Instrucciones avanzadas de Dockerfile: ARG, ENV, ENTRYPOINT y más"
+post_slug: "instrucciones-avanzadas-dockerfile"
+date: "2026-05-29"
+excerpt: "Entiende de una vez la diferencia entre ARG y ENV, ENTRYPOINT y CMD, y para qué sirven realmente HEALTHCHECK, VOLUME y EXPOSE en tus Dockerfiles."
+language: "es"
+categories: ["docker"]
+course: "domina-docker-desde-cero"
+order: 10
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "advanced-dockerfile-instructions"
+---
+
+Hay instrucciones de Dockerfile que todo el mundo escribe copiando de un ejemplo que funcionó una vez. `ARG`, `ENV`, `ENTRYPOINT`, `CMD`. Dos para variables, dos para arrancar el proceso. El contenedor arranca, la app funciona, y nadie pregunta demasiado.
+
+Hasta que falla. O hasta que alguien del equipo pregunta por qué están pasando la API key por `ARG` — que aparece en el historial de la imagen para quien quiera verla — o por qué el contenedor ignora el comando que le mandas al hacer `docker run`. Ahí empieza la conversación que debería haber pasado al principio.
+
+Si eres como yo cuando empecé, has copiado `ENTRYPOINT` y `CMD` de Stack Overflow más veces de las que te gustaría admitir, has visto que a veces aparecen las dos y a veces solo una, y has asumido que el universo Docker tiene sus caprichos. No los tiene. Tiene reglas concretas, y cuando las entiendes todo encaja.
+
+## ARG vs ENV
+
+¿`ARG` o `ENV`? ¿Cuál persiste en el contenedor? ¿Cuál desaparece después del build? ¿Se pueden combinar? ¿Importa el orden en el Dockerfile? Son similares en sintaxis y completamente distintas en cuándo existen.
+
+**`ARG`** define una variable que solo existe durante el proceso de build. El contenedor que ejecutas después no la ve. Sirve para parametrizar la construcción de la imagen: la versión de Node, la versión de tu app, un flag de compilación.
+
+**`ENV`** define una variable de entorno que estará disponible tanto durante el build como en el contenedor en ejecución. Es lo que usas cuando tu aplicación necesita esa variable para arrancar.
+
+```dockerfile
+ARG NODE_VERSION=20
+FROM node:${NODE_VERSION}-alpine
+
+ARG APP_VERSION=1.0.0
+ENV APP_VERSION=${APP_VERSION}
+
+WORKDIR /app
+COPY . .
+RUN npm ci
+CMD ["node", "index.js"]
+```
+
+Aquí `NODE_VERSION` solo existe para elegir la imagen base. En cuanto el build termina, desaparece. `APP_VERSION` se pasa explícitamente de `ARG` a `ENV` — esa es la forma de hacer que un valor del build llegue al contenedor en ejecución.
+
+Puedes sobreescribir `ARG` al hacer el build, y `ENV` al arrancar el contenedor:
+
+```bash
+# Sobreescribir ARG en build
+docker build --build-arg NODE_VERSION=22 -t mi-app .
+
+# Sobreescribir ENV al arrancar
+docker run -e APP_VERSION=2.0.0 mi-app
+```
+
+### El gotcha de seguridad que te va a importar
+
+`ARG` no es un lugar seguro para secretos. Los valores que pasas por `ARG` quedan en el historial de la imagen:
+
+```bash
+docker history mi-app
+```
+
+```
+IMAGE         CREATED       CREATED BY
+abc123def456  2 hours ago   CMD ["node", "index.js"]
+...           ...           ARG API_KEY=s3cr3t          ← aquí está
+```
+
+Si has pasado una API key, un token, o cualquier credencial a través de `ARG`, esa información es recuperable de la imagen. Esto lo vimos en detalle en las [buenas prácticas de seguridad en Dockerfiles](/es/tutoriales/buenas-practicas-dockerfiles-seguridad) — si te has saltado esa lección, es buen momento para volver.
+
+La regla es simple: secretos en tiempo de build en BuildKit build secrets (los vemos en la siguiente lección). Secretos en runtime en variables de entorno inyectadas por tu sistema de gestión de secretos, nunca hardcodeadas en el Dockerfile.
+
+## ENTRYPOINT vs CMD
+
+Aquí es donde Docker parece más críptico de lo que necesita ser. ¿Por qué tener dos instrucciones para arrancar el proceso? La respuesta es que no hacen lo mismo.
+
+**`CMD`** define el comando por defecto que ejecuta el contenedor. Se puede sobreescribir completamente al hacer `docker run` — basta con pasar un comando diferente.
+
+**`ENTRYPOINT`** define el ejecutable que siempre corre cuando arranca el contenedor. No se puede sobreescribir con un argumento normal; necesitas `--entrypoint` explícitamente.
+
+Cuando los combinas, `CMD` actúa como los argumentos por defecto de `ENTRYPOINT`.
+
+```dockerfile
+# Solo CMD — comando completamente reemplazable
+FROM ubuntu:22.04
+CMD ["echo", "hola mundo"]
+```
+
+```bash
+docker run mi-imagen                   # → "hola mundo"
+docker run mi-imagen echo "adiós"     # → "adiós" (CMD reemplazado)
+```
+
+```dockerfile
+# Solo ENTRYPOINT — ejecutable fijo
+FROM ubuntu:22.04
+ENTRYPOINT ["echo"]
+```
+
+```bash
+docker run mi-imagen                   # → "" (nada, sin argumentos)
+docker run mi-imagen "hola mundo"     # → "hola mundo"
+```
+
+```dockerfile
+# ENTRYPOINT + CMD — el patrón más útil en producción
+FROM ubuntu:22.04
+ENTRYPOINT ["echo"]
+CMD ["hola mundo"]
+```
+
+```bash
+docker run mi-imagen                   # → "hola mundo" (default)
+docker run mi-imagen "otro mensaje"   # → "otro mensaje" (CMD reemplazado)
+```
+
+La combinación `ENTRYPOINT + CMD` es el patrón más útil para herramientas CLI empaquetadas como contenedores: el ejecutable es fijo, los argumentos son defaults que cualquiera puede cambiar.
+
+Si en este punto tienes la sensación de que lo entiendes pero no del todo, no te agobies — esta es, de lejos, la combinación que más googlea la gente después de llevar meses usando Docker. El 90% de las veces usarás exec form en `ENTRYPOINT` con `CMD` como default, y el resto se aprende con práctica.
+
+### Shell form vs exec form
+
+Las dos instrucciones tienen dos formas de escritura:
+
+```dockerfile
+# Shell form — pasa por /bin/sh -c
+CMD echo "hola"
+ENTRYPOINT echo "hola"
+
+# Exec form — ejecuta directamente, sin shell
+CMD ["echo", "hola"]
+ENTRYPOINT ["echo", "hola"]
+```
+
+**Usa exec form para `ENTRYPOINT`**, casi siempre. La shell form lanza el proceso como hijo de `/bin/sh`, lo que tiene dos consecuencias incómodas: las señales del sistema (como `SIGTERM` al parar el contenedor) no llegan a tu proceso porque el shell las intercepta, y en imágenes minimalistas sin shell el contenedor directamente no arranca. Con exec form, tu proceso es el PID 1 y recibe las señales directamente.
+
+## HEALTHCHECK
+
+Esta es la instrucción que nadie añade hasta que un contenedor falla en silencio en producción y tarda más de lo que debería en darse cuenta. Después de eso, la añaden a todo.
+
+`HEALTHCHECK` le dice a Docker cómo verificar que el contenedor está funcionando correctamente. Docker ejecuta el comando de forma periódica y actualiza el estado: `starting`, `healthy`, o `unhealthy`.
+
+```dockerfile
+FROM node:20-alpine
+WORKDIR /app
+COPY . .
+RUN npm ci
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:3000/health || exit 1
+
+CMD ["node", "index.js"]
+```
+
+Los parámetros:
+
+- `--interval`: cada cuánto ejecuta el check (default: 30s)
+- `--timeout`: si el comando tarda más de esto, se considera fallo (default: 30s)
+- `--start-period`: tiempo de gracia al arrancar antes de contar fallos (default: 0s)
+- `--retries`: cuántos fallos consecutivos antes de marcar como `unhealthy` (default: 3)
+
+El comando del check debe devolver `0` para healthy y `1` para unhealthy. El `|| exit 1` del ejemplo asegura que si `curl` falla — porque el servidor no responde o devuelve un error HTTP — el check también falla.
+
+```bash
+docker ps
+```
+
+```
+CONTAINER ID   IMAGE     STATUS
+a1b2c3d4e5f6   mi-app    Up 2 minutes (healthy)
+```
+
+Ese `(healthy)` en `docker ps` indica que el HEALTHCHECK está corriendo y pasando. Docker Compose y los orquestadores usan este estado para saber si el contenedor está listo para recibir tráfico, si necesita reiniciarse, o si deben esperar antes de considerar que el deploy fue exitoso.
+
+Si tu imagen no tiene `curl` — imágenes Alpine o distroless, por ejemplo — puedes usar `wget` o un pequeño script en el runtime de tu app:
+
+```dockerfile
+# Con wget (Alpine)
+HEALTHCHECK --interval=30s --timeout=5s \
+  CMD wget -q --spider http://localhost:3000/health || exit 1
+
+# Con el runtime de Node.js
+HEALTHCHECK --interval=30s --timeout=5s \
+  CMD node -e "require('http').get('http://localhost:3000/health', r => process.exit(r.statusCode === 200 ? 0 : 1))"
+```
+
+## VOLUME y EXPOSE
+
+Aquí viene la parte que nadie documenta bien porque honestamente es un poco rara: `EXPOSE` no expone nada y `VOLUME` no monta nada. En serio. Son comentarios muy formales que Docker ha decidido convertir en instrucciones. El nombre es optimista.
+
+### EXPOSE
+
+`EXPOSE` declara en qué puerto escucha el contenedor. No abre ese puerto en el host. No lo hace accesible desde fuera. No hace absolutamente nada en tiempo de ejecución. Es documentación ejecutable — le dice a quien lea el Dockerfile qué puerto necesita publicar, y herramientas como Docker Compose lo usan para descubrirlo automáticamente.
+
+```dockerfile
+EXPOSE 3000
+```
+
+Para publicar el puerto al host de verdad, necesitas `-p` al arrancar:
+
+```bash
+docker run -p 8080:3000 mi-app
+# Puerto 8080 del host → puerto 3000 del contenedor
+```
+
+`EXPOSE` sin `-p` o sin `ports:` en Compose es invisible desde fuera. Ponlo igualmente — es buena documentación y algunos orquestadores lo usan para service discovery.
+
+### VOLUME
+
+`VOLUME` declara un punto de montaje dentro del contenedor. Docker creará automáticamente un volumen anónimo para ese path cuando arranque el contenedor, asegurando que los datos persistan aunque el contenedor se elimine.
+
+```dockerfile
+VOLUME ["/app/data", "/app/logs"]
+```
+
+Lo que no hace: no define dónde en el host se almacenan los datos (eso es cosa de `-v` en `docker run` o de `volumes:` en Compose), y no te ahorra tener que especificar el volumen si quieres controlarlo.
+
+```bash
+# Sin especificar — Docker crea un volumen anónimo
+docker run mi-app
+
+# Con volumen nombrado — recomendado
+docker run -v mi-data:/app/data mi-app
+
+# Con bind mount — directorio del host
+docker run -v $(pwd)/data:/app/data mi-app
+```
+
+El uso principal de `VOLUME` en el Dockerfile es documentar qué paths contienen datos importantes que no deben perderse. También tiene un efecto práctico: cualquier contenido que copies en ese path antes de la instrucción `VOLUME` queda incluido en el volumen inicial. Cualquier `COPY` o `RUN` que escriba en ese path después de `VOLUME` no funciona como esperas.
+
+⚠️ Por esta razón, pon `VOLUME` hacia el final del Dockerfile, después de copiar todo lo que necesite estar ahí.
+
+---
+
+Con `ARG`, `ENV`, `ENTRYPOINT`, `CMD`, `HEALTHCHECK`, `VOLUME` y `EXPOSE` en el vocabulario tienes todas las herramientas para escribir Dockerfiles que no solo funcionan, sino que son configurables, predecibles y observables.
+
+En la próxima lección entramos en BuildKit: cómo habilitarlo, qué ventajas reales aporta frente al builder clásico, y cómo usarlo para gestionar secretos de build y cachés de paquetes sin comprometer la seguridad.
+
+¡Nunca dejes de programar!
+
+---
+
+**💡 Reto**: Abre un Dockerfile de cualquier proyecto que tengas o de algún proyecto open source. Comprueba si usa shell form o exec form para `ENTRYPOINT` y `CMD`, si tiene `HEALTHCHECK`, y si las variables de entorno están en `ARG` o en `ENV`. ¿Hay algo que cambiarías después de esta lección?


### PR DESCRIPTION
Part of the **Mastering Docker from Scratch / Domina Docker desde cero** course (lesson 10).

Covers the Dockerfile instructions everyone copies from examples but rarely understands deeply:

- **ARG vs ENV** — build-time vs runtime variables, how to bridge them, and the security gotcha of passing secrets through ARG
- **ENTRYPOINT vs CMD** — fixed executables vs replaceable commands, shell form vs exec form, signal handling, and the `ENTRYPOINT + CMD` production pattern
- **HEALTHCHECK** — how to make your containers observable with periodic health checks, parameters, and alternatives for Alpine/distroless images
- **VOLUME and EXPOSE** — why EXPOSE doesn't expose anything and VOLUME doesn't mount anything, and what they actually do

Bilingual: ES + EN.