### PR TITLE
feat(seo): add Course and WebSite schemas, fix dateModified

### DIFF
--- a/e2e/seo-schema-improvements.spec.ts
+++ b/e2e/seo-schema-improvements.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "@playwright/test";
+
+async function findSchema(page: ReturnType<typeof test.info>, type: string) {
+  const scripts = await page.locator('script[type="application/ld+json"]').all();
+  for (const script of scripts) {
+    const content = await script.textContent();
+    const schema = JSON.parse(content!);
+    if (schema["@type"] === type) return schema;
+  }
+  return null;
+}
+
+test.describe("SEO - WebSite Schema", () => {
+  test("should have WebSite schema on every page", async ({ page }) => {
+    await page.goto("/es/");
+
+    const schema = await findSchema(page, "WebSite");
+
+    expect(schema).toBeTruthy();
+    expect(schema!["@context"]).toBe("https://schema.org");
+    expect(schema!.name).toBeTruthy();
+    expect(schema!.url).toMatch(/^https?:\/\//);
+    expect(schema!.inLanguage).toBe("es");
+  });
+
+  test("should have WebSite schema with correct language on English pages", async ({ page }) => {
+    await page.goto("/en/");
+
+    const schema = await findSchema(page, "WebSite");
+
+    expect(schema).toBeTruthy();
+    expect(schema!.inLanguage).toBe("en");
+  });
+});
+
+test.describe("SEO - Course Schema", () => {
+  test("should have Course schema on Spanish course page", async ({ page }) => {
+    await page.goto("/es/cursos/domina-git-desde-cero/");
+
+    const schema = await findSchema(page, "Course");
+
+    expect(schema).toBeTruthy();
+    expect(schema!["@context"]).toBe("https://schema.org");
+    expect(schema!.name).toBeTruthy();
+    expect(schema!.url).toMatch(/^https?:\/\//);
+    expect(schema!.provider["@type"]).toBe("Person");
+    expect(schema!.inLanguage).toBe("es");
+  });
+
+  test("should include hasPart with all course tutorials", async ({ page }) => {
+    await page.goto("/es/cursos/domina-git-desde-cero/");
+
+    const schema = await findSchema(page, "Course");
+
+    expect(schema).toBeTruthy();
+    expect(Array.isArray(schema!.hasPart)).toBe(true);
+    expect(schema!.hasPart.length).toBeGreaterThan(0);
+
+    const firstPart = schema!.hasPart[0];
+    expect(firstPart["@type"]).toBe("LearningResource");
+    expect(firstPart.name).toBeTruthy();
+    expect(firstPart.url).toMatch(/^https?:\/\//);
+  });
+});
+
+test.describe("SEO - dateModified in schemas", () => {
+  test("should emit dateModified in BlogPosting schema when update_date is set", async ({ page }) => {
+    // This post has update_date: "2016-12-28" in its frontmatter
+    await page.goto("/es/publicaciones/libros-leidos-durante-2014/");
+
+    const schema = await findSchema(page, "BlogPosting");
+
+    expect(schema).toBeTruthy();
+    expect(schema!.dateModified).toBeTruthy();
+    expect(schema!.dateModified).toMatch(/^\d{4}-\d{2}-\d{2}/);
+  });
+});

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -175,6 +175,21 @@ const nextPageUrl =
         document.documentElement.setAttribute("data-theme", theme);
       })();
     </script>
+    <!-- WebSite schema (site-wide) -->
+    <script
+      type="application/ld+json"
+      set:html={JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        name: t(lang, "title"),
+        url: baseUrl,
+        inLanguage: lang,
+        author: {
+          "@type": "Person",
+          name: t(lang, "title"),
+        },
+      })}
+    />
     <!-- Person schema for site owner (site-wide, not page-specific) -->
     <script
       type="application/ld+json"

--- a/src/pages-templates/courses/CoursesDetailPage.astro
+++ b/src/pages-templates/courses/CoursesDetailPage.astro
@@ -17,7 +17,7 @@ import Title from "@components/Title.astro";
 import Layout from "@layouts/Layout.astro";
 import { t } from "@locales";
 import { buildCourseUrl, buildCoursesIndexUrl } from "@utils/routes";
-import type { CollectionEntry } from "astro:content";
+import { getCollection, type CollectionEntry } from "astro:content";
 
 import type { ContactItem } from "@/types/content";
 import type { Language } from "@/utils/routes";
@@ -68,7 +68,41 @@ const breadcrumbs: BreadcrumbItem[] = [
   { label: course.data.name }, // Current page, no URL
 ];
 
-const breadcrumbSchema = generateBreadcrumbSchema(breadcrumbs, t(lang, "metaData.url"));
+const baseUrl = t(lang, "metaData.url");
+const breadcrumbSchema = generateBreadcrumbSchema(breadcrumbs, baseUrl);
+
+// Course schema for Google rich results
+const courseSchema: Record<string, unknown> = {
+  "@context": "https://schema.org",
+  "@type": "Course",
+  name: course.data.name,
+  url: new URL(basePath, baseUrl).href,
+  provider: {
+    "@type": "Person",
+    name: t(lang, "title"),
+  },
+  inLanguage: lang,
+};
+
+if (course.data.description) {
+  courseSchema.description = course.data.description;
+}
+
+const allCourseTutorials = await getCollection(
+  "tutorials",
+  (t) => t.data.language === lang && t.data.course === course.data.course_slug,
+);
+allCourseTutorials.sort((a, b) => (a.data.order ?? 0) - (b.data.order ?? 0));
+
+if (allCourseTutorials.length > 0) {
+  const tutorialsRoute = t(lang, "routes.tutorials");
+  courseSchema.hasPart = allCourseTutorials.map((tutorial) => ({
+    "@type": "LearningResource",
+    name: tutorial.data.title,
+    url: new URL(`/${lang}/${tutorialsRoute}/${tutorial.data.post_slug}/`, baseUrl).href,
+    description: tutorial.data.excerpt,
+  }));
+}
 
 // Generate ItemList schema for SEO
 const itemListSchema = generateItemListSchema(
@@ -95,6 +129,7 @@ const itemListSchema = generateItemListSchema(
   translationSlug={course.data.i18n}
   hasTargetContent={hasTargetContent}
 >
+  <script slot="schema" type="application/ld+json" set:html={JSON.stringify(courseSchema)} />
   <script slot="schema" type="application/ld+json" set:html={JSON.stringify(itemListSchema)} />
   <script slot="schema" type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
 

--- a/src/pages-templates/posts/PostsDetailPage.astro
+++ b/src/pages-templates/posts/PostsDetailPage.astro
@@ -73,8 +73,8 @@ const articleSchema: Record<string, unknown> = {
 };
 
 // Add modified date if available
-if (post.updated) {
-  articleSchema.dateModified = post.updated.toISOString();
+if (post.update_date) {
+  articleSchema.dateModified = post.update_date.toISOString();
 }
 ---
 

--- a/src/pages-templates/tutorials/TutorialsDetailPage.astro
+++ b/src/pages-templates/tutorials/TutorialsDetailPage.astro
@@ -103,8 +103,8 @@ const tutorialSchema: Record<string, unknown> = {
 };
 
 // Add modified date if available
-if (tutorial.updated) {
-  tutorialSchema.dateModified = tutorial.updated.toISOString();
+if (tutorial.update_date) {
+  tutorialSchema.dateModified = tutorial.update_date.toISOString();
 }
 
 // Add course as part of series if available


### PR DESCRIPTION
## Description

Three SEO schema fixes found during a structured data audit:

- **Bug**: `dateModified` was never emitted in `BlogPosting` and `TechArticle` schemas. Both templates read `.updated` but the Zod schema defines the field as `update_date`.
- **Course schema**: course detail pages only had `ItemList` + `BreadcrumbList`. Added `@type: "Course"` with `hasPart` pulling all tutorials from the course (full collection, not just the paginated page).
- **WebSite schema**: added site-wide in `Layout.astro` alongside the existing `Person` schema.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] E2E tests added for all three changes (`e2e/seo-schema-improvements.spec.ts`)
- [x] Works in both languages (Spanish/English)