### PR TITLE
feat(tutorials): add advanced RCTF application tutorial

### DIFF
--- a/src/content/tutorials/advanced-rctf-application.mdx
+++ b/src/content/tutorials/advanced-rctf-application.mdx
@@ -1,0 +1,377 @@
+---
+title: "Context, role, task, and format: advanced application"
+post_slug: "advanced-rctf-application"
+date: "2026-06-04"
+excerpt: "Turn RCTF into real development prompts: rich context, iterative rounds, and response formats you can plug directly into your daily workflow."
+language: "en"
+categories: ["ai"]
+course: "ai-for-developers"
+order: 8
+cover: "/images/tutorials/cabecera-ia-para-programadores-curso.jpg"
+i18n: "contexto-rol-tarea-formato-aplicacion-avanzada"
+---
+
+Here's how it goes: you discover RCTF, try it out, and something clicks. The AI stops handing you vague garbage. You're sold on it. Then the next day you ask it something real — a weird bug, a half-built feature, a module that needs structure — and it falls flat. Same framework, same four letters, completely hollow answer.
+
+Was RCTF a lie? Do you need more acronyms? Are we three lessons away from a full methodology with a keynote, a certification program, and a branded water bottle?
+
+No. The framework is fine. The problem is that last lesson we used it like a form to fill out. This lesson is about using it the way you'd actually use it at work: with real context, iteration, and formats that give you something you can act on — not just a well-formatted nothing.
+
+If the framework isn't fresh in your head, go back to [the prompt core principles lesson](/en/tutorials/the-art-of-the-prompt-core-principles). This lesson assumes you already know what **role**, **context**, **task**, and **format** mean.
+
+## The mistake: treating RCTF like a form
+
+A prompt can include RCTF and still be bad. That's important.
+
+Look at this:
+
+```text
+Role: act as a senior backend developer.
+Context: I have an API.
+Task: help me improve it.
+Format: give me a list.
+```
+
+It has all four letters. It also has the precision of a weather report written by someone glancing out the window: “there appears to be sky.”
+
+The role is too generic. The context doesn't say stack, problem, constraints, or goal. The task has no useful verb. The format asks for a list, but defines no criteria. It's RCTF in name only.
+
+Now compare it with this:
+
+```text
+Role: act as a backend engineer specialized in REST APIs with Node.js.
+
+Context: I'm maintaining an Express API that manages orders.
+Stack: Node.js 22, Express, PostgreSQL, zod for validation, and Vitest.
+Problem: the POST /orders endpoint has too much logic in the controller:
+it validates input, calculates discounts, writes to the database, and emits events.
+I want to refactor without changing behavior because this is already in production.
+
+Task: propose a refactor plan in small steps. Do not write code yet.
+
+Format:
+1. Diagnosis of mixed responsibilities
+2. Safe 4-6 step plan
+3. Risks for each step
+4. Tests I should add before touching code
+```
+
+Same structure. Completely different result.
+
+It's not about length. Each part removes an assumption. And every assumption the AI doesn't have to make is one fewer ticket in the nonsense lottery. Context is almost always where most of them pile up.
+
+## Rich context doesn't mean your life story
+
+Context is the most important part of RCTF, and also the easiest one to ruin. People often jump from “I give no context” to “here's half the company in Markdown.” Neither extreme helps.
+
+Rich context isn't long context. It's **relevant** context.
+
+A good context block answers these questions:
+
+- What are you building?
+- What stack or tools are you using?
+- What exact area are you touching?
+- What constraints must the solution respect?
+- What have you already tried?
+- What does “good” mean in this case?
+
+Project example:
+
+```text
+Project context:
+I'm working on an e-commerce backend with Django 5 and Django REST Framework.
+The database is PostgreSQL 15. We use Redis for cache and Celery for async jobs.
+The code has type hints, tests with pytest, and the goal is to avoid breaking
+compatibility with the public API.
+
+Relevant domain:
+- orders/: Order, OrderItem, Coupon
+- products/: Product, Category, Inventory
+- users/: CustomUser, Address
+
+Important constraint:
+I cannot change the endpoint contract because published mobile apps consume it.
+```
+
+This isn't a documentation dump. It's the minimum map the AI needs so it doesn't propose something that breaks production in sentence two.
+
+Don't overthink it. Keep a base context block for the project and adapt it per task. Think of it like an `.env.example` file: not the actual secrets, just enough structure that you're not starting from scratch every time.
+
+Project context gets you in the building. Code context puts you in the right room.
+
+## Code context: the bug doesn't live alone
+
+When you ask about a bug, project context helps, but code context does the heavy lifting.
+
+A decent debugging prompt should include four pieces:
+
+```text
+When asking for bug help, include:
+1. The relevant code
+2. The failing test or reproduction steps
+3. The full error message
+4. What you expected vs what actually happened
+```
+
+The fourth point sounds obvious until you forget it. The AI can read the error, but it can't infer your intent. “This fails” isn't a diagnosis; it's a scream. Understandable, yes. Useful, less so.
+
+Weak example:
+
+```text
+This function breaks for users without email. Fix it.
+```
+
+Useful example:
+
+`````text
+Role: act as a senior Python developer.
+
+Context:
+This function normalizes user data imported from CSV. Some users don't have an
+email because they come from old records. In that case I want to return None,
+not raise an exception.
+
+Code:
+````python
+def normalize_email(user):
+    return user["email"].strip().lower()
+````
+
+Error:
+KeyError: 'email'
+
+Expected behavior:
+
+- If user["email"] exists and contains text, return it normalized
+- If it doesn't exist or is empty, return None
+- Keep the function small and easy to test
+
+Task:
+Propose the implementation and 3 pytest tests.
+
+Format:
+
+1. Final code
+2. Tests
+3. Brief explanation of the covered cases
+
+`````
+
+The AI doesn't get better because it has become “smarter.” It gets better because it no longer has to guess the function contract. You gave it the walls of the room before asking it to arrange the furniture.
+
+## Iterate: a conversation, not a vending machine
+
+Here's the mental model most people skip: the AI is not a vending machine. You don't drop in a prompt, wait for the answer to fall out, and walk away with your solution. That's how you get responses that technically address the question and solve nothing.
+
+The next mental shift is this: don't try to solve everything in one giant prompt.
+
+AI works better when the conversation moves in rounds. The same way you'd work with a person: first define direction, then get into details, then review, correct, and test. You don't tell a teammate: “design, implement, test, document, optimize, and deploy this system; I'll be back in ten minutes.” Well, maybe at some companies. And then things happen.
+
+An iterative flow could look like this:
+
+```text
+Round 1:
+Propose a structure for implementing user registration in Flask.
+Architecture and files only, no code.
+
+Round 2:
+Now implement the User model and validation layer.
+Keep the code simple and testable.
+
+Round 3:
+Write tests for the happy path and these error cases:
+- invalid email
+- duplicate email
+- password too short
+
+Round 4:
+The duplicate email test fails with this error: [paste error]
+Diagnose the cause before proposing changes.
+
+Round 5:
+Refactor the validation to reduce duplication without changing behavior.
+```
+
+This avoids two classic problems: huge responses that mix incompatible decisions, and changes you can't evaluate because everything happened at once.
+
+Practical rule: **each round should change one main thing**. Architecture. Implementation. Tests. Debugging. Refactor. If you mix everything, you won't know which part worked and which part just smuggled a gremlin into your repository.
+
+## Format: ask for a response you can actually use
+
+Format isn't decoration. It's the interface between the AI's response and your workflow.
+
+If you ask “explain this,” you get an explanation. If you ask “give me a plan with risks and tests,” you get something you can execute. Sounds small, but it's the difference between reading content and moving work forward.
+
+Useful formats for development:
+
+### For code generation
+
+```text
+Format:
+1. Implementation code
+2. Example usage
+3. Minimal tests
+4. Technical decisions and trade-offs
+```
+
+### For debugging
+
+```text
+Format:
+1. Likely root cause
+2. Why it happens
+3. How to confirm it
+4. Minimal fix
+5. How to prevent it in the future
+```
+
+### For learning a concept
+
+```text
+Format:
+1. One-sentence definition
+2. Realistic analogy
+3. Minimal code example
+4. Common mistake to avoid
+```
+
+### For comparing options
+
+```text
+Format:
+Table with columns:
+- Option
+- When to use it
+- Advantages
+- Risks
+- Recommendation for my case
+```
+
+The trick is asking for the format that matches your next action. If you're deciding, ask for a comparison. If you're implementing, ask for steps and tests. If you're learning, ask for an explanation, analogy, and gotcha. The AI doesn't know your next move unless you tell it.
+
+## Templates you can reuse
+
+Here are three practical templates. Not to copy like scripture, but to adapt.
+
+### Reviewing code
+
+```text
+Role: act as a senior developer specialized in [language/framework].
+
+Context:
+[What the code does]
+[Relevant stack]
+[Constraints: don't change public API, keep compatibility, etc.]
+
+Code:
+[paste code]
+
+Task:
+Review the code for readability issues, potential bugs, and edge cases.
+Do not refactor yet.
+
+Format:
+1. 3-line summary
+2. Issues ordered by impact
+3. For each issue: why it matters and how you would confirm it
+4. Questions that must be answered before touching code
+```
+
+### Designing an implementation
+
+```text
+Role: act as a pragmatic software engineer.
+
+Context:
+[Feature you want to build]
+[Stack]
+[Constraints]
+[What already exists]
+
+Task:
+Propose a simple implementation design. Prioritize small, verifiable changes.
+Do not write code yet.
+
+Format:
+1. Assumptions
+2. Proposed design
+3. Files you would touch
+4. Step-by-step plan
+5. Tests needed
+6. Risks and alternatives
+```
+
+### Asking for a technical explanation
+
+```text
+Role: act as a technical mentor.
+
+Context:
+I'm learning [concept]. I already understand [previous knowledge], but I'm stuck on [specific blocker].
+
+Task:
+Explain [concept] by connecting it to what I already know.
+
+Format:
+1. Short explanation
+2. Analogy
+3. Minimal example
+4. Counterexample
+5. Question to check whether I understood it
+```
+
+A good template doesn't replace thinking. It removes mental boilerplate so you can focus on the actual problem. Like editor snippets: helpful when you know what you're inserting, dangerous when you fire them blindly.
+
+## What not to put in context
+
+Less fun, but necessary: not all context should be shared.
+
+Don't paste:
+
+- API keys
+- tokens
+- passwords
+- real personal data
+- company secrets
+- full database dumps
+- proprietary code if your tool or policy doesn't allow it
+
+Yes, the AI “needs context.” No, it doesn't need your production token. That sentence belongs on a mug, right next to “don't run commands you don't understand.”
+
+If you need to show data, anonymize it:
+
+```json
+{
+  "user_id": "user_123",
+  "email": "user@example.com",
+  "plan": "pro"
+}
+```
+
+And if the problem depends on a sensitive value, describe it:
+
+```text
+The token exists and has a valid JWT format, but the backend returns 401.
+I can't share the real token; I can share the anonymized header and claims.
+```
+
+Context quality isn't measured by how many secrets you expose. It's measured by how many assumptions you remove without creating a new problem.
+
+## Key concepts from this lesson
+
+- RCTF doesn't help if each block is generic; each part must reduce assumptions
+- Rich context means relevant context, not long context
+- For bugs, include code, reproduction, error, and expected behavior
+- AI conversations work better in small rounds than in one giant prompt
+- Each round should change one main thing
+- Format should connect the response to your next action
+- Templates help, but they don't replace thinking
+- Never share secrets, tokens, or real personal data as “context”
+
+---
+
+**💡 Challenge:** Take a real prompt you've used for code help and turn it into a three-round conversation: (1) context and diagnosis, (2) solution proposal, (3) tests or verification. In each round, specify a different format based on what you need to do next.
+
+RCTF is no longer just a checklist: it's a way to direct a technical conversation. In the next lesson we'll look at how to use AI to learn programming concepts without getting stuck with explanations that sound good but collapse under pressure — because real understanding isn't nodding at a convincing answer, it's being able to spot when someone is selling smoke with nice syntax.
+
+Never stop coding!

--- a/src/content/tutorials/contexto-rol-tarea-formato-aplicacion-avanzada.mdx
+++ b/src/content/tutorials/contexto-rol-tarea-formato-aplicacion-avanzada.mdx
@@ -1,0 +1,377 @@
+---
+title: "Contexto, rol, tarea y formato: aplicación avanzada"
+post_slug: "contexto-rol-tarea-formato-aplicacion-avanzada"
+date: "2026-06-04"
+excerpt: "Aprende a convertir RCTF en prompts de trabajo reales: contexto rico, iteración por rondas y formatos que puedes conectar directamente a tu flujo diario."
+language: "es"
+categories: ["ia"]
+course: "ia-para-programadores"
+order: 8
+cover: "/images/tutorials/cabecera-ia-para-programadores-curso.jpg"
+i18n: "advanced-rctf-application"
+---
+
+Hay una escena muy típica: descubres RCTF, escribes un prompt con rol, contexto, tarea y formato, y la respuesta mejora. Funciona. Te vienes arriba. Al día siguiente le pides a la IA algo más real — revisar un bug raro, ayudarte con una feature a medias, proponer una estructura para un módulo — y la respuesta vuelve a oler a plantilla genérica con perfume caro.
+
+¿Qué ha pasado? ¿No era RCTF la solución? ¿Hay que añadir más siglas? ¿Estamos a tres tutoriales de inventar una metodología con póster, consultoría y taza corporativa?
+
+No. El problema no es el framework. El problema es que en el tutorial anterior usamos RCTF como una lista básica. Ahora toca usarlo como lo usarías de verdad en desarrollo: con contexto rico, iteración y formatos pensados para que la respuesta no sea bonita, sino útil.
+
+Si no tienes fresco el framework, vuelve un momento al [tutorial de principios básicos del prompt](/es/tutoriales/el-arte-del-prompt-principios-basicos). Este tutorial asume que ya sabes qué significan **rol**, **contexto**, **tarea** y **formato**.
+
+## El error: usar RCTF como formulario
+
+Un prompt con RCTF puede seguir siendo malo. Esto es importante.
+
+Mira este ejemplo:
+
+```text
+Rol: actúa como senior backend developer.
+Contexto: tengo una API.
+Tarea: ayúdame a mejorarla.
+Formato: dame una lista.
+```
+
+Tiene las cuatro letras. También tiene la precisión de un parte meteorológico escrito por alguien mirando por la ventana: “parece que hay cielo”.
+
+El rol es demasiado genérico. El contexto no dice stack, problema, restricciones ni objetivo. La tarea no tiene verbo útil. El formato pide una lista, pero no define criterios. Es RCTF de cartón piedra.
+
+Ahora compáralo con esto:
+
+```text
+Rol: actúa como backend engineer especializado en APIs REST con Node.js.
+
+Contexto: estoy manteniendo una API Express que gestiona pedidos.
+Stack: Node.js 22, Express, PostgreSQL, zod para validación y Vitest.
+Problema: el endpoint POST /orders tiene demasiada lógica en el controller:
+valida input, calcula descuentos, escribe en base de datos y envía eventos.
+Quiero refactorizar sin cambiar comportamiento porque ya está en producción.
+
+Tarea: propón un plan de refactor en pasos pequeños. No escribas código todavía.
+
+Formato:
+1. Diagnóstico de responsabilidades mezcladas
+2. Plan en 4-6 pasos seguros
+3. Riesgos de cada paso
+4. Tests que debería añadir antes de tocar código
+```
+
+Misma estructura. Otro mundo.
+
+La diferencia no es escribir más por escribir más. La diferencia es que cada parte reduce una suposición. Y cada suposición que no tenga que inventar la IA es una papeleta menos en la tómbola del disparate. El sitio donde más papeletas se acumulan casi siempre es el mismo: el contexto.
+
+## Contexto rico no significa contar tu vida
+
+El contexto es la parte más importante de RCTF y también la que más se estropea. Mucha gente pasa de “no doy contexto” a “te pego media empresa en Markdown”. Ninguno de los dos extremos ayuda.
+
+El contexto rico no es contexto largo. Es contexto **relevante**.
+
+Un buen bloque de contexto responde a estas preguntas:
+
+- ¿Qué estás construyendo?
+- ¿Qué stack o herramientas usas?
+- ¿Qué parte concreta estás tocando?
+- ¿Qué restricciones no puede romper la solución?
+- ¿Qué ya has intentado?
+- ¿Qué significa “bien” en este caso?
+
+Ejemplo para proyecto:
+
+```text
+Contexto del proyecto:
+Estoy trabajando en un backend de e-commerce con Django 5 y Django REST Framework.
+La base de datos es PostgreSQL 15. Usamos Redis para caché y Celery para tareas
+asíncronas. El código tiene type hints, tests con pytest y el objetivo es no romper
+compatibilidad con la API pública.
+
+Dominio relevante:
+- orders/: Order, OrderItem, Coupon
+- products/: Product, Category, Inventory
+- users/: CustomUser, Address
+
+Restricción importante:
+No puedo cambiar el contrato del endpoint porque lo consumen apps móviles ya publicadas.
+```
+
+Esto no es un volcado de documentación. Es el mapa mínimo para que la IA no proponga una solución que rompe producción en la segunda frase.
+
+Y no te agobies con escribirlo perfecto. Puedes tener un bloque base del proyecto y reutilizarlo. Lo ajustas según la tarea. Como tener una mochila preparada: no metes la casa entera, pero tampoco sales sin llaves.
+
+El contexto de proyecto te mete en el edificio. El contexto de código te pone en la habitación correcta.
+
+## Contexto de código: el bug no vive solo
+
+Cuando preguntas por un bug, el contexto de proyecto ayuda, pero el contexto de código manda.
+
+Un prompt de debugging decente debería incluir cuatro piezas:
+
+```text
+Cuando pidas ayuda con un bug, incluye:
+1. El código relevante
+2. El test que falla o los pasos para reproducirlo
+3. El error completo
+4. Qué esperabas que pasara y qué pasa realmente
+```
+
+El cuarto punto parece obvio hasta que no lo pones. La IA puede leer el error, pero no puede adivinar tu intención. “Esto falla” no es un diagnóstico; es un grito. Comprensible, sí. Útil, menos.
+
+Ejemplo flojo:
+
+```text
+Esta función falla con usuarios sin email. Arréglala.
+```
+
+Ejemplo útil:
+
+`````text
+Rol: actúa como senior Python developer.
+
+Contexto:
+Esta función normaliza datos de usuarios importados desde CSV. Algunos usuarios
+no tienen email porque vienen de registros antiguos. En ese caso quiero devolver
+None, no lanzar excepción.
+
+Código:
+````python
+def normalize_email(user):
+    return user["email"].strip().lower()
+````
+
+Error:
+KeyError: 'email'
+
+Comportamiento esperado:
+
+- Si user["email"] existe y tiene texto, devolverlo normalizado
+- Si no existe o está vacío, devolver None
+- Mantener la función pequeña y fácil de testear
+
+Tarea:
+Propón la implementación y 3 tests con pytest.
+
+Formato:
+
+1. Código final
+2. Tests
+3. Explicación breve de los casos cubiertos
+
+`````
+
+La IA no mejora porque “sea más lista”. Mejora porque ya no tiene que adivinar el contrato de la función. Le has dado las paredes de la habitación antes de pedirle que coloque los muebles.
+
+## Iterar: una conversación, no una moneda en una máquina
+
+Aquí está el modelo mental que mucha gente se salta: la IA no es una máquina expendedora. No metes la moneda del prompt, esperas que salga la respuesta por el cajetín y te vas. Así es como consigues respuestas que técnicamente responden a la pregunta y no resuelven nada.
+
+El siguiente salto mental es este: no intentes resolver todo en un prompt gigante.
+
+La IA funciona mejor cuando la conversación avanza por rondas. Igual que trabajarías con una persona: primero defines dirección, luego bajas a detalles, después revisas, corriges y pruebas. No le dices a un compañero: “diseña, implementa, testea, documenta, optimiza y despliega este sistema; vuelvo en diez minutos”. Bueno, quizá en algunas empresas sí. Y luego pasa lo que pasa.
+
+Un flujo iterativo podría ser:
+
+```text
+Ronda 1:
+Propón una estructura para implementar registro de usuarios en Flask.
+Solo arquitectura y archivos, sin código.
+
+Ronda 2:
+Ahora implementa el modelo User y la capa de validación.
+Mantén el código simple y testeable.
+
+Ronda 3:
+Escribe tests para el happy path y estos casos de error:
+- email inválido
+- email duplicado
+- password demasiado corta
+
+Ronda 4:
+El test de email duplicado falla con este error: [pegar error]
+Diagnostica la causa antes de proponer cambios.
+
+Ronda 5:
+Refactoriza la validación para reducir duplicación, sin cambiar comportamiento.
+```
+
+Esto evita dos problemas clásicos: respuestas enormes que mezclan decisiones incompatibles, y cambios que no sabes evaluar porque han ocurrido todos a la vez.
+
+La regla práctica: **cada ronda debe cambiar una cosa principal**. Arquitectura. Implementación. Tests. Debugging. Refactor. Si mezclas todo, luego no sabes qué parte salió bien y cuál te acaba de meter un gremlin en el repositorio.
+
+## Formato: pedir una respuesta que puedas usar
+
+El formato no es decoración. Es la interfaz entre la respuesta de la IA y tu flujo de trabajo.
+
+Si pides “explícame esto”, recibes una explicación. Si pides “dame un plan con riesgos y tests”, recibes algo que puedes ejecutar. Parece una tontería, pero es la diferencia entre leer contenido y avanzar trabajo.
+
+Formatos útiles para desarrollo:
+
+### Para generar código
+
+```text
+Formato:
+1. Código de implementación
+2. Ejemplo de uso
+3. Tests mínimos
+4. Decisiones técnicas y trade-offs
+```
+
+### Para debugging
+
+```text
+Formato:
+1. Causa raíz probable
+2. Por qué ocurre
+3. Cómo confirmarlo
+4. Fix mínimo
+5. Cómo evitar que vuelva a pasar
+```
+
+### Para aprender un concepto
+
+```text
+Formato:
+1. Definición en una frase
+2. Analogía realista
+3. Ejemplo mínimo de código
+4. Error común que debería evitar
+```
+
+### Para comparar opciones
+
+```text
+Formato:
+Tabla con columnas:
+- Opción
+- Cuándo usarla
+- Ventajas
+- Riesgos
+- Recomendación para mi caso
+```
+
+El truco es pedir el formato que encaja con la siguiente acción. Si vas a decidir, pide comparación. Si vas a implementar, pide pasos y tests. Si vas a aprender, pide explicación, analogía y gotcha. La IA no sabe cuál es tu siguiente movimiento si no se lo dices.
+
+## Plantillas que puedes reutilizar
+
+Aquí tienes tres plantillas prácticas. No para copiarlas como religión, sino para adaptarlas.
+
+### Revisar código
+
+```text
+Rol: actúa como senior developer especializado en [lenguaje/framework].
+
+Contexto:
+[Qué hace el código]
+[Stack relevante]
+[Restricciones: no cambiar API pública, mantener compatibilidad, etc.]
+
+Código:
+[pegar código]
+
+Tarea:
+Revisa el código buscando problemas de legibilidad, bugs potenciales y casos borde.
+No refactorices todavía.
+
+Formato:
+1. Resumen en 3 líneas
+2. Lista de problemas ordenada por impacto
+3. Para cada problema: por qué importa y cómo lo confirmarías
+4. Preguntas que necesitas resolver antes de tocar código
+```
+
+### Diseñar una implementación
+
+```text
+Rol: actúa como software engineer pragmático.
+
+Contexto:
+[Feature que quieres construir]
+[Stack]
+[Restricciones]
+[Qué ya existe]
+
+Tarea:
+Propón un diseño de implementación sencillo. Prioriza cambios pequeños y verificables.
+No escribas código todavía.
+
+Formato:
+1. Supuestos
+2. Diseño propuesto
+3. Archivos que tocaría
+4. Plan en pasos
+5. Tests necesarios
+6. Riesgos y alternativas
+```
+
+### Pedir una explicación técnica
+
+```text
+Rol: actúa como mentor técnico.
+
+Contexto:
+Estoy aprendiendo [concepto]. Ya entiendo [conocimiento previo], pero me cuesta [bloqueo concreto].
+
+Tarea:
+Explícame [concepto] conectándolo con lo que ya sé.
+
+Formato:
+1. Explicación breve
+2. Analogía
+3. Ejemplo mínimo
+4. Contraejemplo
+5. Pregunta para comprobar si lo entendí
+```
+
+Una buena plantilla no reemplaza pensar. Te quita el boilerplate mental para que puedas concentrarte en el problema real. Como los snippets del editor: útiles si sabes qué estás insertando, peligrosos si los disparas a ciegas.
+
+## Qué no debes meter en el contexto
+
+Hay una parte menos divertida pero necesaria: no todo contexto debe compartirse.
+
+No pegues:
+
+- API keys
+- tokens
+- contraseñas
+- datos personales reales
+- secretos de empresa
+- dumps completos de base de datos
+- código propietario si tu herramienta o política no lo permite
+
+Sí, la IA “necesita contexto”. No, no necesita tu token de producción. Esa frase debería estar en una taza, justo al lado de “no ejecutes comandos que no entiendes”.
+
+Si necesitas mostrar datos, anonimiza:
+
+```json
+{
+  "user_id": "user_123",
+  "email": "user@example.com",
+  "plan": "pro"
+}
+```
+
+Y si el problema depende de un valor sensible, descríbelo:
+
+```text
+El token existe y tiene formato JWT válido, pero el backend devuelve 401.
+No puedo compartir el token real; puedo compartir el header y claims anonimizados.
+```
+
+La calidad del contexto no se mide por cuántos secretos expones. Se mide por cuántas suposiciones eliminas sin crear un problema nuevo.
+
+## Conceptos clave de esta lección
+
+- RCTF no sirve si cada bloque es genérico; cada parte debe reducir suposiciones
+- Contexto rico significa contexto relevante, no contexto largo
+- Para bugs, incluye código, reproducción, error y comportamiento esperado
+- La conversación con IA funciona mejor por rondas pequeñas que con un prompt gigante
+- Cada ronda debería cambiar una cosa principal
+- El formato debe conectar la respuesta con tu siguiente acción
+- Las plantillas ayudan, pero no sustituyen pensar
+- Nunca compartas secretos, tokens ni datos personales reales como “contexto”
+
+---
+
+**💡 Desafío:** Toma un prompt real que hayas usado para pedir ayuda con código y conviértelo en una conversación de tres rondas: (1) contexto y diagnóstico, (2) propuesta de solución, (3) tests o verificación. En cada ronda, especifica un formato distinto según lo que necesites hacer después.
+
+RCTF ya no es solo una lista de comprobación: ahora es una forma de dirigir una conversación técnica. En el próximo tutorial veremos cómo usar la IA para aprender conceptos de programación sin quedarte en explicaciones bonitas pero frágiles — porque entender de verdad no es asentir ante una respuesta convincente, es poder detectar cuándo te están vendiendo humo con buena sintaxis.
+
+¡Nunca dejes de programar!


### PR DESCRIPTION
## Summary

New bilingual tutorial (ES/EN) on advanced RCTF prompting for developers.

**What it covers:**
- Why generic RCTF prompts fail and how to fix them
- Writing rich, relevant context (not long context)
- Code context for effective debugging prompts
- Multi-round iterative prompting workflow
- Format templates for code review, implementation design, and technical explanations
- Security warnings about sharing secrets in prompts

Part of the **AI for Developers** course.