### PR TITLE
feat(tutorials): add git submodules tutorial (ES/EN)

### DIFF
--- a/src/content/tutorials/git-submodules.mdx
+++ b/src/content/tutorials/git-submodules.mdx
@@ -1,0 +1,372 @@
+---
+title: "Git submodules: repositories inside repositories without losing your mind"
+post_slug: "git-submodules"
+date: "2026-06-08"
+excerpt: "Learn what Git submodules are, how to add, clone, update, and remove them, and when to avoid creating a tiny .gitmodules-shaped monster."
+language: "en"
+categories: ["git"]
+course: "mastering-git-from-scratch"
+order: 32
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "submodulos-git"
+---
+
+You have a project. Inside that project, you need another project. But you don't want to copy it by hand, because every future update will turn into archaeology with `diff`. You also don't want a normal package dependency, because maybe it's an internal template, a private library, shared documentation, or a theme with its own history.
+
+Then someone says: "use a submodule".
+
+Silence. What does that even mean? Is it a dependency? A folder? Another repository? Why is there suddenly a `.gitmodules` file staring at you like you summoned something ancient? Good news: submodules are not dark magic. Bad news: they are one of those Git features that punish you if you treat them like a normal directory.
+
+## What a Git submodule is
+
+A **submodule** is a Git repository embedded inside another Git repository. The main repository is called the **superproject**, which sounds like a comic-book villain but simply means "the repo that contains the other one".
+
+Here is what trips most people up: you see a folder. Git sees a pointer. The main repo does not store the submodule files as its own — it records a note that says: **use this other repository, at exactly this commit**.
+
+It's saying:
+
+> "My project uses `vendor/theme`, but not just any version of `vendor/theme`: exactly commit `a1b2c3d`."
+
+That part matters. A submodule does not point to "the latest version" by default. It points to an exact commit. Git is being strict, yes, but for a reason: it wants anyone cloning your project to get the same state, not "whatever happens to be on `main` today, good luck in production".
+
+If you read the previous lesson on [Git tags](/en/tutorials/releasing-new-versions-of-our-projects-using-git-tags), this should feel familiar: Git is very good at pointing to precise places in history. With a submodule, instead of marking a point in your own repo, you're saying which exact point of another repo belongs to this project.
+
+## When to use submodules and when to run away
+
+Submodules have a reputation. Some of it is deserved. Some of it comes from people using them to solve problems that were never submodule problems.
+
+Use them when you need to keep two repositories separate, with separate histories, while one still needs to live inside the other:
+
+- A shared theme used by multiple static sites.
+- An internal library that is not published to a package registry.
+- Common documentation reused by several projects.
+- A repository of assets or examples that you want pinned to a specific version.
+
+Do not use them as your first option for normal dependencies. If you're in Node, Python, Ruby, Go, or any ecosystem with a decent package manager, use the package manager. That's what it's for. Using submodules where `npm install` would do is like bringing an excavator to plant basil.
+
+Also avoid them if the team doesn't understand the cost: every submodule is another repository to clone, update, review, push, and coordinate. One or two can be reasonable. Twelve nested submodules are a creative way to turn onboarding into an escape room.
+
+## Adding a submodule
+
+Let's use a realistic example: you have a website and want to add a shared theme under `vendor/site-theme`.
+
+```bash
+git submodule add https://github.com/example/site-theme.git vendor/site-theme
+```
+
+Git clones that repository into the path you provided:
+
+```
+Cloning into '/home/dev/my-site/vendor/site-theme'...
+remote: Enumerating objects: 42, done.
+remote: Counting objects: 100% (42/42), done.
+remote: Compressing objects: 100% (31/31), done.
+Receiving objects: 100% (42/42), done.
+```
+
+Now check the status:
+
+```bash
+git status
+```
+
+```
+Changes to be committed:
+  (use "git restore --staged <file>..." to unstage)
+	new file:   .gitmodules
+	new file:   vendor/site-theme
+```
+
+This is the first "wait, what just happened?" moment. Git did not add every file from `vendor/site-theme` to the main repository. It added two things:
+
+1. `.gitmodules`, with the submodule configuration.
+2. A special entry for `vendor/site-theme`, pointing to a specific commit.
+
+The `.gitmodules` file looks like this:
+
+```ini
+[submodule "vendor/site-theme"]
+	path = vendor/site-theme
+	url = https://github.com/example/site-theme.git
+```
+
+This file is versioned like any other file. When someone else clones your project, Git reads it to know where the submodule lives and where to fetch it from.
+
+Run the diff with the submodule flag and you will see what Git is actually recording:
+
+```bash
+git diff --cached --submodule
+```
+
+```
+Submodule vendor/site-theme 0000000...a1b2c3d (new submodule)
+```
+
+That `a1b2c3d` is the submodule commit your main project is recording. It is not recording "the folder". It is recording "this folder must be at this commit".
+
+Commit the change:
+
+```bash
+git commit -m "feat: add shared site theme submodule"
+```
+
+## Cloning a project with submodules
+
+This is the part that gets almost everyone the first time.
+
+You clone a project:
+
+```bash
+git clone https://github.com/example/my-site.git
+cd my-site
+ls vendor/site-theme
+```
+
+And the folder is empty. Or almost empty. If you're anything like me when I started, your first instinct was `git status` followed by staring at the ceiling. Git did not break. It did exactly what you asked: clone the main repository, nothing else.
+
+The painless way is to clone like this from the start:
+
+```bash
+git clone --recurse-submodules https://github.com/example/my-site.git
+```
+
+That makes Git clone the main repo, read `.gitmodules`, initialize the submodules, and check them out at the correct commits.
+
+If you already cloned and forgot the flag — because you're human, not a CI pipeline with repressed feelings — run this from the project root:
+
+```bash
+git submodule update --init --recursive
+```
+
+What each part does:
+
+- `update` checks out the submodule commit expected by the superproject.
+- `--init` initializes submodules not yet registered in your local `.git/config`.
+- `--recursive` does the same for submodules inside submodules.
+
+Yes, submodules inside submodules. This is where Git reminds you that you can technically build a Russian doll out of repositories. That doesn't mean you should.
+
+## Understanding submodule status
+
+The basic command is:
+
+```bash
+git submodule status
+```
+
+Normal output:
+
+```
+ a1b2c3d4e5f678901234567890abcdef12345678 vendor/site-theme (v1.2.0)
+```
+
+The hash is the commit currently checked out inside the submodule. The path is where it lives. The bit in parentheses, when present, comes from `git describe` and usually shows a nearby tag or name.
+
+The important part is the first character:
+
+| Prefix | Meaning                                                                           |
+| ------ | --------------------------------------------------------------------------------- |
+| space  | The submodule is initialized and matches the expected commit.                     |
+| `-`    | The submodule is not initialized. The folder may be empty.                        |
+| `+`    | The submodule is checked out at a different commit than the superproject expects. |
+| `U`    | The submodule has merge conflicts. Fun, but not the kind you asked for.           |
+
+The `+` prefix is the one that confuses people most at first. It means: "inside the submodule you have one commit checked out, but the main repo expects another". That is not necessarily wrong. It may be exactly what you want if you're updating the submodule. But until you run `git add vendor/site-theme` in the main repo and commit it, that change is not recorded.
+
+To see the change in a more human form:
+
+```bash
+git diff --submodule
+```
+
+```
+Submodule vendor/site-theme a1b2c3d..f6e7d8c:
+  > Improve button spacing
+  > Fix dark mode contrast
+```
+
+Much better than staring at two hex strings hoping one of them eventually starts making sense.
+
+## Updating a submodule
+
+Imagine the shared theme has moved forward. There are new commits in `site-theme`, and you want your project to use one of them.
+
+You can enter the submodule and update it like any Git repo:
+
+```bash
+cd vendor/site-theme
+git fetch
+git switch main
+git pull
+```
+
+Then go back to the main repo:
+
+```bash
+cd ../..
+git status
+```
+
+```
+Changes not staged for commit:
+	modified:   vendor/site-theme (new commits)
+```
+
+That message means: "the submodule now points to another commit". To save that update in the superproject:
+
+```bash
+git add vendor/site-theme
+git commit -m "chore: update site theme submodule"
+```
+
+A more direct option is:
+
+```bash
+git submodule update --remote vendor/site-theme
+```
+
+This fetches changes from the submodule remote and moves it to the configured remote branch. By default, that is usually the remote `HEAD` branch. If your team wants the submodule to follow a specific branch, record it:
+
+```bash
+git config -f .gitmodules submodule.vendor/site-theme.branch main
+git submodule update --remote vendor/site-theme
+git add .gitmodules vendor/site-theme
+git commit -m "chore: track main branch for site theme submodule"
+```
+
+Don't stress about this part if you're just starting. The practical rule is: **updating the submodule changes the commit the main repo points to**. That change must be added and committed from the main repo.
+
+## Working inside a submodule
+
+Here's where it gets interesting. And by "interesting" I mean "this is where people lose an afternoon".
+
+When you run `git submodule update`, Git usually leaves the submodule in **detached HEAD**. We've already seen detached HEAD is not the end of the world, but it's also not the place where you want to happily develop like nothing can go wrong.
+
+If you need to modify the submodule, enter it and switch to a branch:
+
+```bash
+cd vendor/site-theme
+git switch main
+```
+
+Make changes, commit, and push inside the submodule:
+
+```bash
+git add styles/buttons.css
+git commit -m "fix: improve button contrast"
+git push origin main
+```
+
+Then return to the main repo and record the new submodule commit:
+
+```bash
+cd ../..
+git add vendor/site-theme
+git commit -m "chore: update site theme submodule pointer"
+```
+
+The order matters:
+
+1. Commit inside the submodule.
+2. Push the submodule.
+3. Commit the pointer in the main repo.
+4. Push the main repo.
+
+If you do steps 3 and 4 without pushing the submodule, your main repo will point to a commit that only exists on your machine. For your teammates, that is like receiving a treasure map where the island doesn't exist.
+
+You can ask Git to check this when pushing:
+
+```bash
+git push --recurse-submodules=check
+```
+
+If any required submodule commit has not been pushed, Git aborts the push. There is also:
+
+```bash
+git push --recurse-submodules=on-demand
+```
+
+This tries to push the required submodules before pushing the main repo. Useful, but use it knowing what it does. Automating things you don't understand is how incidents get proper names.
+
+## Pulling main repo changes when submodules exist
+
+Another common case: someone on the team updates the submodule and pushes the main repo. You pull:
+
+```bash
+git pull
+```
+
+Git may bring the superproject commit, but your submodule folder can remain at the previous commit. If `git status` shows the submodule as modified, run:
+
+```bash
+git submodule update --init --recursive
+```
+
+This command means "put everything where the main repo expects it". It does not blindly update to the latest remote commit; it updates to the exact commit recorded by the superproject.
+
+If your repo uses submodules often, you can configure Git so many operations recurse automatically:
+
+```bash
+git config submodule.recurse true
+```
+
+Heads up: `git clone` still needs its own `--recurse-submodules`. Git had to leave one tiny trap in there. For humility, apparently.
+
+## Removing a submodule
+
+Removing a submodule should not be `rm -rf vendor/site-theme` followed by a short prayer to Linus Torvalds.
+
+The safe recipe is:
+
+```bash
+git submodule deinit -f vendor/site-theme
+git rm -f vendor/site-theme
+git commit -m "chore: remove site theme submodule"
+```
+
+What each command does:
+
+- `git submodule deinit -f vendor/site-theme` removes the local submodule checkout and its local configuration.
+- `git rm -f vendor/site-theme` removes the submodule entry from the index and updates `.gitmodules`.
+- The `commit` records the change for the rest of the team.
+
+Sometimes local metadata may remain under `.git/modules/vendor/site-theme`. If you need to clean it manually, be very careful:
+
+```bash
+rm -rf .git/modules/vendor/site-theme
+```
+
+Read that path again before pressing Enter. `rm -rf` has no sense of humor. You do. Your filesystem does not.
+
+## Best practices for submodules
+
+Submodules work best when the team treats them as what they are: separate repositories coordinated through a pointer.
+
+Practical rules:
+
+- **Document how to clone the project** with `--recurse-submodules` in the README.
+- **Use URLs everyone can access** in `.gitmodules`; your private SSH URL may work on your machine but fail in CI.
+- **Do not edit submodules in detached HEAD** if you want to keep the work. Switch to a branch first.
+- **Push the submodule before the superproject** when you've created new commits inside it.
+- **Avoid submodules for normal dependencies** if a reasonable package manager exists.
+- **Do not nest submodules unless there is a real need**. If you need a diagram to explain how to clone the repo, maybe Git is not the actual problem.
+
+A good sign that a submodule is justified: you can explain why that code needs its own repo, its own history, and its own release cadence. If the explanation is "I saw it on Stack Overflow", pause. Breathe. Reconsider.
+
+## Key concepts from this lesson
+
+- A submodule is a repository inside another repository.
+- The main repo does not store the submodule files: it stores a pointer to a specific commit.
+- `.gitmodules` records the submodule path and URL, and is versioned with the project.
+- To clone with submodules, use `git clone --recurse-submodules`.
+- If you already cloned, use `git submodule update --init --recursive`.
+- Updating a submodule changes the commit recorded by the superproject.
+- If you work inside the submodule, commit and push there before updating the main repo.
+
+---
+
+Submodules are useful when you need to coordinate separate repositories without mixing them together. They are not a normal dependency, not a normal folder, and definitely not something you add because it's Friday afternoon and you feel experimental. But when the use case fits, they give you a precise way to say: "this project depends on exactly this other repo, at exactly this commit".
+
+In the next tutorial we'll look at **Git hooks**, which let you run scripts automatically at specific moments in the Git workflow: before committing, while validating messages, after receiving changes on a server… useful, powerful, and with enough room for someone to turn `git commit` into an obstacle course. We'll take it slowly.
+
+Never stop coding!

--- a/src/content/tutorials/submodulos-git.mdx
+++ b/src/content/tutorials/submodulos-git.mdx
@@ -1,0 +1,372 @@
+---
+title: "Submódulos en Git: repositorios dentro de repositorios sin perder la cabeza"
+post_slug: "submodulos-git"
+date: "2026-06-08"
+excerpt: "Aprende qué son los submódulos de Git, cómo añadirlos, clonarlos, actualizarlos y cuándo conviene evitarlos antes de crear un pequeño monstruo con .gitmodules."
+language: "es"
+categories: ["git"]
+course: "domina-git-desde-cero"
+order: 32
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "git-submodules"
+---
+
+Tienes un proyecto. Dentro de ese proyecto necesitas otro proyecto. Pero no quieres copiarlo a mano, porque entonces cada actualización futura será arqueología con `diff`. Tampoco quieres meterlo como dependencia normal, porque quizá es una plantilla interna, una librería privada, documentación compartida o un tema que tiene su propio historial.
+
+Y entonces aparece alguien y dice: "usa un submodule".
+
+Silencio en la sala. ¿Eso qué significa? ¿Es una dependencia? ¿Es una carpeta? ¿Es otro repositorio? ¿Por qué de repente hay un `.gitmodules` mirándote como si hubieras invocado algo antiguo? Buenas noticias: los submódulos no son magia negra. Malas noticias: sí son una de esas partes de Git que no perdonan si los tratas como una carpeta normal.
+
+## Qué es un submódulo de Git
+
+Un **submódulo** es un repositorio Git metido dentro de otro repositorio Git. El repositorio principal se llama **superproject**, que suena a villano de Marvel pero solo significa "el repo que contiene al otro".
+
+La trampa mental está aquí: aunque tú ves una carpeta, Git no la trata como “otra carpeta más”. Para el repo principal, ese submódulo es básicamente una nota que dice: **usa este otro repositorio exactamente en este commit**.
+
+Es como decir:
+
+> "Mi proyecto usa `vendor/theme`, pero no cualquier versión de `vendor/theme`: exactamente el commit `a1b2c3d`."
+
+Esa parte es crucial. Un submódulo no apunta a "la última versión" por defecto. Apunta a un commit exacto. Git está siendo pesado, sí, pero con motivo: quiere que cualquiera que clone tu proyecto obtenga el mismo estado, no "lo que haya hoy en `main`, suerte con producción".
+
+Si vienes del tutorial anterior sobre [Git tags](/es/tutoriales/lanzando-versiones-tags-git), la idea te sonará: Git es muy bueno poniendo nombres o referencias a puntos concretos del historial. Con un submódulo, en vez de marcar un punto de tu repo, estás diciendo qué punto exacto de otro repo forma parte de este proyecto.
+
+## Cuándo usar submódulos y cuándo salir corriendo
+
+Los submódulos tienen mala fama. Parte merecida, parte porque mucha gente los usa para resolver problemas que no eran de submódulos.
+
+Úsalos cuando de verdad necesites que dos repositorios sigan siendo independientes, pero uno tenga que viajar dentro del otro:
+
+- Un tema compartido entre varios sitios estáticos.
+- Una librería interna que no se publica en un package registry.
+- Documentación común reutilizada por varios proyectos.
+- Un repositorio de assets o ejemplos que quieres fijar a una versión concreta.
+
+No los uses como primera opción para dependencias normales. Si estás en Node, Python, Ruby, Go o cualquier ecosistema con gestor de paquetes decente, usa el gestor de paquetes. Para eso existe. Meter submódulos donde bastaba con `npm install` es como llevar una excavadora para plantar una albahaca.
+
+Tampoco los uses si el equipo no entiende el coste: cada submódulo añade otro repositorio que clonar, actualizar, revisar, pushear y coordinar. Uno o dos pueden ser razonables. Doce submódulos anidados son una forma muy creativa de convertir el onboarding en escape room.
+
+## Añadir un submódulo
+
+Vamos a usar un ejemplo realista: tienes una web y quieres añadir un tema compartido en `vendor/site-theme`.
+
+```bash
+git submodule add https://github.com/example/site-theme.git vendor/site-theme
+```
+
+Git clonará ese repositorio dentro de la ruta indicada:
+
+```
+Cloning into '/home/dev/my-site/vendor/site-theme'...
+remote: Enumerating objects: 42, done.
+remote: Counting objects: 100% (42/42), done.
+remote: Compressing objects: 100% (31/31), done.
+Receiving objects: 100% (42/42), done.
+```
+
+Ahora mira el estado:
+
+```bash
+git status
+```
+
+```
+Changes to be committed:
+  (use "git restore --staged <file>..." to unstage)
+	new file:   .gitmodules
+	new file:   vendor/site-theme
+```
+
+Aquí está el primer momento de "espera, ¿qué acaba de pasar?". Git no ha añadido todos los archivos de `vendor/site-theme` al repositorio principal. Ha añadido dos cosas:
+
+1. `.gitmodules`, con la configuración del submódulo.
+2. Una entrada especial para `vendor/site-theme`, que apunta a un commit concreto.
+
+El fichero `.gitmodules` se parece a esto:
+
+```ini
+[submodule "vendor/site-theme"]
+	path = vendor/site-theme
+	url = https://github.com/example/site-theme.git
+```
+
+Este fichero se versiona como cualquier otro. Cuando otra persona clone tu proyecto, Git leerá de ahí dónde está el submódulo y en qué ruta debe colocarlo.
+
+Si haces un diff con detalle, verás algo bastante revelador:
+
+```bash
+git diff --cached --submodule
+```
+
+```
+Submodule vendor/site-theme 0000000...a1b2c3d (new submodule)
+```
+
+Ese `a1b2c3d` es el commit del submódulo que tu proyecto principal está registrando. No está registrando "la carpeta". Está registrando "esta carpeta debe estar en este commit".
+
+Para guardar el cambio:
+
+```bash
+git commit -m "feat: add shared site theme submodule"
+```
+
+## Clonar un proyecto que tiene submódulos
+
+Aquí es donde mucha gente se da el primer golpe contra la mesa.
+
+Clonas un proyecto:
+
+```bash
+git clone https://github.com/example/my-site.git
+cd my-site
+ls vendor/site-theme
+```
+
+Y la carpeta está vacía. O casi vacía. Si eres como yo cuando empecé, tu primer instinto fue `git status` seguido de mirar al techo y preguntarte qué has roto. La respuesta es: nada. Git ha hecho exactamente lo que le pediste: clonar el repositorio principal, nada más.
+
+La forma cómoda es clonar así desde el principio:
+
+```bash
+git clone --recurse-submodules https://github.com/example/my-site.git
+```
+
+Con eso Git clona el repo principal, lee `.gitmodules`, inicializa los submódulos y los coloca en el commit correcto.
+
+Si ya clonaste el repo y se te olvidó el flag — porque eres humano, no un pipeline de CI con sentimientos reprimidos — ejecuta esto desde la raíz del proyecto:
+
+```bash
+git submodule update --init --recursive
+```
+
+Qué hace cada parte:
+
+- `update` coloca el submódulo en el commit que espera el superproject.
+- `--init` inicializa submódulos que todavía no están registrados en tu `.git/config` local.
+- `--recursive` hace lo mismo también para submódulos dentro de submódulos.
+
+Sí, submódulos dentro de submódulos. Aquí es donde Git te recuerda que técnicamente puedes construir una muñeca rusa con repositorios. Que puedas hacerlo no significa que debas.
+
+## Entender el estado de un submódulo
+
+El comando básico es:
+
+```bash
+git submodule status
+```
+
+Salida normal:
+
+```
+ a1b2c3d4e5f678901234567890abcdef12345678 vendor/site-theme (v1.2.0)
+```
+
+El hash es el commit actualmente checked out dentro del submódulo. La ruta es dónde vive. Lo del paréntesis, si aparece, viene de `git describe` y suele mostrar un tag o un nombre cercano.
+
+Lo importante está en el primer carácter:
+
+| Prefijo | Significado                                                                           |
+| ------- | ------------------------------------------------------------------------------------- |
+| espacio | El submódulo está inicializado y coincide con el commit esperado.                     |
+| `-`     | El submódulo no está inicializado. La carpeta puede estar vacía.                      |
+| `+`     | El submódulo está en un commit distinto al que espera el superproject.                |
+| `U`     | Hay un conflicto de merge dentro del submódulo. Diversión, pero de la que no apetece. |
+
+El prefijo `+` es el que más confunde al principio. Significa: "dentro del submódulo tienes checked out un commit, pero el repo principal espera otro". No necesariamente está mal. Puede ser justo lo que quieres si estás actualizando el submódulo. Pero hasta que hagas `git add vendor/site-theme` en el repo principal y lo commitees, ese cambio no queda registrado.
+
+Para ver el cambio de forma más humana:
+
+```bash
+git diff --submodule
+```
+
+```
+Submodule vendor/site-theme a1b2c3d..f6e7d8c:
+  > Improve button spacing
+  > Fix dark mode contrast
+```
+
+Mucho mejor que mirar dos hashes como si fueran matrículas de coches sospechosos.
+
+## Actualizar un submódulo
+
+Imagina que el tema compartido ha avanzado. Hay nuevos commits en `site-theme` y quieres que tu proyecto use uno de ellos.
+
+Puedes entrar al submódulo y actualizarlo como cualquier repo Git:
+
+```bash
+cd vendor/site-theme
+git fetch
+git switch main
+git pull
+```
+
+Luego vuelves al repo principal:
+
+```bash
+cd ../..
+git status
+```
+
+```
+Changes not staged for commit:
+	modified:   vendor/site-theme (new commits)
+```
+
+Ese mensaje significa: "el submódulo ahora apunta a otro commit". Para guardar esa actualización en el superproject:
+
+```bash
+git add vendor/site-theme
+git commit -m "chore: update site theme submodule"
+```
+
+Otra forma más directa es:
+
+```bash
+git submodule update --remote vendor/site-theme
+```
+
+Este comando le dice a Git: “entra en el submódulo, mira su remoto y muévelo a la rama configurada”. Por defecto suele ser la rama `HEAD` del remoto. Si tu equipo quiere que el submódulo siga una rama concreta, puedes dejarlo registrado:
+
+```bash
+git config -f .gitmodules submodule.vendor/site-theme.branch main
+git submodule update --remote vendor/site-theme
+git add .gitmodules vendor/site-theme
+git commit -m "chore: track main branch for site theme submodule"
+```
+
+No te agobies con esta parte si estás empezando. La regla práctica es: **actualizar el submódulo cambia el commit al que apunta el repo principal**. Ese cambio hay que añadirlo y commitearlo desde el repo principal.
+
+## Trabajar dentro de un submódulo
+
+Aquí es donde se pone interesante. Y por "interesante" quiero decir "aquí es donde mucha gente pierde una tarde".
+
+Cuando ejecutas `git submodule update`, Git suele dejar el submódulo en **detached HEAD**. Ya vimos que el detached HEAD no es el fin del mundo, pero tampoco es el sitio ideal para desarrollar alegremente como si nada.
+
+Si necesitas modificar el submódulo, entra y ponte en una rama:
+
+```bash
+cd vendor/site-theme
+git switch main
+```
+
+Haz cambios, commitea y pushea dentro del submódulo:
+
+```bash
+git add styles/buttons.css
+git commit -m "fix: improve button contrast"
+git push origin main
+```
+
+Después vuelve al repo principal y registra el nuevo commit del submódulo:
+
+```bash
+cd ../..
+git add vendor/site-theme
+git commit -m "chore: update site theme submodule pointer"
+```
+
+El orden importa:
+
+1. Commit dentro del submódulo.
+2. Push del submódulo.
+3. Commit del puntero en el repo principal.
+4. Push del repo principal.
+
+Si haces el paso 3 y 4 sin haber pusheado el submódulo, tu repo principal apuntará a un commit que solo existe en tu máquina. Para tus compañeros será como recibir un mapa del tesoro donde la isla no existe.
+
+Puedes pedirle a Git que compruebe esto al pushear:
+
+```bash
+git push --recurse-submodules=check
+```
+
+Si falta pushear algún commit del submódulo, Git aborta el push. También existe:
+
+```bash
+git push --recurse-submodules=on-demand
+```
+
+Este intenta pushear los submódulos necesarios antes de pushear el repo principal. Útil, pero úsalo sabiendo qué está haciendo. Automatizar cosas que no entiendes es cómo nacen los incidentes con nombre propio.
+
+## Traer cambios del repo principal cuando hay submódulos
+
+Otro caso típico: alguien del equipo actualiza el submódulo y pushea el repo principal. Tú haces pull:
+
+```bash
+git pull
+```
+
+Git puede traer el commit del superproject, pero tu carpeta del submódulo puede quedarse en el commit anterior. Si `git status` muestra el submódulo como modificado, ejecuta:
+
+```bash
+git submodule update --init --recursive
+```
+
+Este comando es tu "pon todo como espera el repo principal". No actualiza al último commit remoto porque sí; actualiza al commit exacto que el superproject tiene registrado.
+
+Si tu repo usa submódulos a menudo, puedes configurar Git para que muchas operaciones recursen automáticamente:
+
+```bash
+git config submodule.recurse true
+```
+
+Ojo: `git clone` sigue necesitando su propio `--recurse-submodules`. Porque Git tenía que dejar alguna pequeña trampa para mantenernos humildes.
+
+## Eliminar un submódulo
+
+Eliminar un submódulo no debería hacerse con `rm -rf vendor/site-theme` y una oración breve a Linus Torvalds.
+
+La receta segura es:
+
+```bash
+git submodule deinit -f vendor/site-theme
+git rm -f vendor/site-theme
+git commit -m "chore: remove site theme submodule"
+```
+
+Qué hace cada comando:
+
+- `git submodule deinit -f vendor/site-theme` elimina el checkout local del submódulo y borra su configuración local.
+- `git rm -f vendor/site-theme` elimina la entrada del submódulo del índice y actualiza `.gitmodules`.
+- El `commit` registra el cambio para el resto del equipo.
+
+A veces puede quedar metadata local en `.git/modules/vendor/site-theme`. Si necesitas limpiarla manualmente, hazlo con muchísimo cuidado:
+
+```bash
+rm -rf .git/modules/vendor/site-theme
+```
+
+Relee esa ruta antes de pulsar Enter. `rm -rf` no tiene sentido del humor. Tú sí, pero tu sistema de ficheros no.
+
+## Buenas prácticas con submódulos
+
+Los submódulos funcionan mejor cuando el equipo los trata como lo que son: repositorios separados coordinados por un puntero.
+
+Reglas prácticas:
+
+- **Documenta cómo clonar el proyecto** con `--recurse-submodules` en el README.
+- **Usa URLs accesibles para todo el equipo** en `.gitmodules`; tu URL SSH privada quizá funciona en tu máquina, pero no en CI.
+- **No edites submódulos en detached HEAD** si quieres conservar trabajo. Cambia a una rama antes.
+- **Pushea el submódulo antes que el superproject** cuando hayas creado commits nuevos dentro.
+- **Evita submódulos para dependencias normales** si existe un gestor de paquetes razonable.
+- **No anides submódulos salvo necesidad real**. Si necesitas un diagrama para explicar cómo clonar el repo, igual el problema no es Git.
+
+Una buena señal de que un submódulo está justificado: puedes explicar por qué ese código necesita su propio repo, su propio historial y su propia cadencia de versiones. Si la explicación es "porque así lo vi en Stack Overflow", pausa. Respira. Reconsidera.
+
+## Conceptos clave de esta lección
+
+- Un submódulo es un repositorio dentro de otro repositorio.
+- El repo principal no guarda los archivos del submódulo: guarda un puntero a un commit concreto.
+- `.gitmodules` registra la ruta y URL del submódulo, y se versiona con el proyecto.
+- Para clonar con submódulos, usa `git clone --recurse-submodules`.
+- Si ya clonaste, usa `git submodule update --init --recursive`.
+- Actualizar un submódulo cambia el commit registrado por el superproject.
+- Si trabajas dentro del submódulo, commitea y pushea allí antes de actualizar el repo principal.
+
+---
+
+Los submódulos son útiles cuando necesitas coordinar repositorios separados sin mezclarlos. No son una dependencia normal, no son una carpeta normal y definitivamente no son algo que quieras añadir por aburrimiento un viernes por la tarde. Pero cuando el caso encaja, te dan una forma precisa de decir: "este proyecto depende exactamente de este otro repo, en este commit".
+
+En el siguiente tutorial veremos **Git hooks**, que permiten ejecutar scripts automáticamente en momentos concretos del flujo de Git: antes de commitear, al validar mensajes, después de recibir cambios en un servidor… útil, potente y con suficiente margen para que alguien convierta `git commit` en una gymkana. Por eso lo veremos con calma.
+
+¡Nunca dejes de programar!


### PR DESCRIPTION
## Summary

Learn what Git submodules are, how to add, clone, update, and remove them, and when to avoid creating a tiny .gitmodules-shaped monster.

## Changes

- Add `git-submodules.mdx` (English)
- Add `submodulos-git.mdx` (Spanish)
- Part of the `mastering-git-from-scratch` course