### PR TITLE
feat(content): add BuildKit tutorial with build secrets, cache mounts, and multi-platform builds

### DIFF
--- a/src/content/tutorials/buildkit-docker.mdx
+++ b/src/content/tutorials/buildkit-docker.mdx
@@ -1,0 +1,222 @@
+---
+title: "BuildKit en Docker: secretos, cache de dependencias y builds multi-plataforma"
+post_slug: "buildkit-docker"
+date: "2026-06-11"
+excerpt: "BuildKit, el motor moderno de Docker: secretos sin rastro en capas, cache de dependencias entre builds, e imágenes para ARM y x86 desde la misma máquina."
+language: "es"
+categories: ["docker"]
+course: "domina-docker-desde-cero"
+order: 11
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "docker-buildkit"
+---
+
+Si llevas un tiempo usando Docker, hay una buena probabilidad de que cada build descargue los mismos paquetes desde cero. npm install, pip install, bundle install. Todo el catálogo. Desde cero. Aunque el build anterior los descargó hace tres minutos y no has tocado el lockfile.
+
+No es un principio filosófico de Docker sobre la pureza de los builds. Es que nadie te contó que existía una forma mejor.
+
+En [la lección anterior](/es/tutoriales/instrucciones-avanzadas-dockerfile) también quedó una deuda: `ARG` deja los valores en el historial de la imagen, así que no es un lugar seguro para secretos de build. BuildKit tiene la solución real para eso también.
+
+**BuildKit** es el motor de builds moderno de Docker. Lleva disponible desde Docker 18.09 y es el backend por defecto desde la versión 23.0. Si tienes Docker instalado en 2024 o 2025, ya lo tienes activo. Lo que quizás no tienes configurado son las funcionalidades que lo hacen útil de verdad.
+
+## Verificar BuildKit y el pragma de sintaxis
+
+En Docker Desktop (Mac y Windows), `docker buildx` viene incluido. En Linux instalado desde paquetes del sistema — Arch, Ubuntu, Debian — el plugin es opcional y hay que instalarlo por separado:
+
+```bash
+# macOS y Linux (Homebrew)
+brew install docker-buildx
+
+# Ubuntu / Debian
+apt install docker-buildx-plugin
+
+# Arch Linux
+pacman -S docker-buildx
+```
+
+Comprueba que está disponible con:
+
+```bash
+docker buildx version
+```
+
+```
+github.com/docker/buildx v0.34.1 ...
+```
+
+Si tienes Docker 23.0 o superior — que es cualquier instalación de 2023 en adelante — BuildKit ya es el backend por defecto. No hay nada más que activar. Si por algún motivo estás en una versión anterior, puedes forzarlo por sesión con:
+
+```bash
+DOCKER_BUILDKIT=1 docker build .
+```
+
+Independientemente de la versión, añade este comentario como primera línea de tus Dockerfiles:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+```
+
+Sí, es un comentario que hace algo. BuildKit usa "frontends" — parsers del Dockerfile que tienen sus propias versiones independientes. Este pragma fija el frontend al canal estable más reciente, y es lo que te da acceso a la sintaxis moderna como `--mount` en las instrucciones `RUN`. Sin él, Docker usa la versión empaquetada con tu instalación, que puede no incluir todo lo que vamos a ver.
+
+## Build secrets
+
+Recapitulando lo de la lección anterior: pasar secretos por `ARG` los deja grabados en el historial de la imagen, visible con `docker history`. Los build secrets de BuildKit resuelven esto de forma limpia: el build puede leer el secreto mientras lo necesita, pero no queda en ninguna capa.
+
+El mecanismo tiene dos partes. En el Dockerfile, montas el secreto en el `RUN` donde lo usas y solo ahí:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN --mount=type=secret,id=npm_token \
+    npm config set //registry.npmjs.org/:_authToken=$(cat /run/secrets/npm_token) && \
+    npm ci && \
+    npm config delete //registry.npmjs.org/:_authToken
+COPY . .
+RUN npm run build
+```
+
+En el comando de build, indicas de dónde viene el secreto:
+
+```bash
+# Desde un archivo
+docker build --secret id=npm_token,src=.npmtoken .
+
+# Desde una variable de entorno
+docker build --secret id=npm_token,env=NPM_TOKEN .
+```
+
+El secreto se monta en `/run/secrets/<id>` durante la ejecución de ese `RUN`. Cuando el comando termina, desaparece. No queda en la capa, no queda en el historial. Puedes comprobarlo:
+
+```bash
+docker history mi-imagen
+```
+
+```
+IMAGE         CREATED      CREATED BY
+a1b2c3d4e5f6  2 hours ago  CMD ["node", "dist/index.js"]
+...           ...          RUN --mount=type=secret,id=npm_token npm config set ...
+```
+
+Aparece el comando, no el valor. Exactamente lo que llevabas intentando conseguir desde [la lección de seguridad en Dockerfiles](/es/tutoriales/buenas-practicas-dockerfiles-seguridad).
+
+### SSH agent forwarding
+
+El mismo mecanismo existe para acceso SSH, útil cuando el build necesita clonar un repositorio privado sin que las claves entren en el contenedor:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM node:20-alpine
+WORKDIR /app
+RUN apk add --no-cache git openssh-client
+RUN --mount=type=ssh \
+    git clone git@github.com:tu-org/libreria-privada.git /deps
+COPY package*.json ./
+RUN npm ci
+```
+
+```bash
+docker build --ssh default .
+```
+
+`--ssh default` reenvía el agente SSH del host. Las claves nunca tocan el sistema de ficheros del contenedor, no quedan en ninguna capa, y cuando el `RUN` termina el acceso se cierra.
+
+## Cache mounts
+
+El problema del principio de la lección tiene una solución de exactamente un parámetro en el `RUN`:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
+COPY . .
+RUN npm run build
+```
+
+Eso es todo. En la primera ejecución, npm descarga todo de internet y almacena la cache en `/root/.npm`. En la segunda — aunque hayas ejecutado `docker build` desde cero, aunque hayas eliminado la imagen anterior — la cache sigue ahí. npm la encuentra, no descarga nada.
+
+La diferencia en tiempo es inmediata en proyectos con dependencias medianas:
+
+```
+Primera ejecución:  2m 21s  (descarga completa desde npm)
+Segunda ejecución:  8s      (cache hit, cero descargas)
+```
+
+El path del cache varía según el gestor de paquetes, pero el patrón es siempre el mismo:
+
+```dockerfile
+# npm
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
+
+# pip
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -r requirements.txt
+
+# Cargo (Rust)
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo build --release
+
+# apt (Debian/Ubuntu)
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt update && apt install -y curl
+```
+
+El parámetro `sharing=locked` en el ejemplo de apt evita que dos builds paralelos escriban en la cache al mismo tiempo — sin él, las bases de datos de apt pueden corromperse si ejecutas builds concurrentes.
+
+Una limitación honesta: la cache vive en la máquina donde haces el build, no en la imagen. Si añades un cache mount, compruebas que funciona perfecto en local, y luego ves que en CI los builds tardan exactamente lo mismo — eso es completamente normal y no significa que hayas hecho algo mal. Los runners de CI suelen ser efímeros: cada job empieza con una máquina limpia, sin cache previa. La solución existe, pero es específica de la plataforma: GitHub Actions, GitLab CI y la mayoría de proveedores modernos tienen soporte para persistir el estado de BuildKit entre ejecuciones. Busca "BuildKit cache" seguido del nombre de tu plataforma de CI.
+
+## Builds multi-plataforma
+
+¿Desarrollas en Mac con Apple Silicon? ¿Tu servidor corre en x86_64? ¿Hay algún Raspberry Pi en producción? Si más de una arquitectura está en juego, en algún momento habrás visto una imagen que arranca perfectamente en tu máquina y falla en el servidor. O has tenido que construirla en dos sitios distintos y gestionar dos etiquetas separadas.
+
+Los builds multi-plataforma de BuildKit resuelven esto: construyes la imagen para múltiples arquitecturas desde una sola máquina y la publicas bajo la misma etiqueta. Docker elige automáticamente la correcta al hacer `docker pull` según la arquitectura del host.
+
+Primero, crea un builder con soporte multi-plataforma:
+
+```bash
+docker buildx create --use --name multi-arch-builder
+```
+
+Luego construye y publica. Los builds multi-plataforma requieren `--push` o `--output` para tener destino — no pueden quedarse solo en cache local:
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -t tu-registro/mi-app:latest \
+  --push \
+  .
+```
+
+BuildKit construye las imágenes para cada plataforma en paralelo. Para arquitecturas distintas a la nativa del host, usa emulación QEMU — que funciona, pero convierte tu procesador en un actor interpretando a otro procesador, con todo lo que eso implica para el rendimiento. Un build de Go de 45 segundos puede convertirse en 8 minutos cuando QEMU traduce cada instrucción al vuelo. Para proyectos con código compilado (Go, Rust, C) en los que el tiempo de build importa, considera usar runners nativos de la arquitectura destino.
+
+Para proyectos en Node.js, Python o cualquier lenguaje interpretado, el coste de emulación es mucho menor: el Dockerfile instala un runtime que ya existe como imagen multi-arch, y el código fuente no requiere compilación.
+
+Comprueba qué plataformas soporta tu builder:
+
+```bash
+docker buildx inspect --bootstrap
+```
+
+```
+Name:      multi-arch-builder
+Driver:    docker-container
+Platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/386, ...
+```
+
+---
+
+BuildKit es la diferencia entre builds que hacen lo mínimo cada vez y builds que protegen secretos, reutilizan trabajo previo y funcionan en cualquier arquitectura. No es una funcionalidad avanzada para casos especiales — es la forma correcta de construir imágenes en 2026.
+
+En la próxima lección cerramos el módulo de imágenes con las técnicas de optimización final: imágenes distroless, análisis de tamaño con `dive`, y cómo llegar a imágenes de producción que contienen exactamente lo que necesitan y nada más.
+
+¡Nunca dejes de programar!
+
+---
+
+**💡 Reto**: Añade un cache mount al Dockerfile de cualquier proyecto que tengas. Ejecuta `docker build` dos veces y compara el tiempo de la sección de instalación de dependencias. Si no notas diferencia en la segunda ejecución, revisa que el path de cache es el correcto para tu gestor de paquetes.

--- a/src/content/tutorials/docker-buildkit.mdx
+++ b/src/content/tutorials/docker-buildkit.mdx
@@ -1,0 +1,222 @@
+---
+title: "BuildKit in Docker: build secrets, dependency caching, and multi-platform images"
+post_slug: "docker-buildkit"
+date: "2026-06-11"
+excerpt: "BuildKit, Docker's modern build engine: pass secrets safely without leaking them into image layers, cache package downloads between builds, and build for ARM and x86 from one machine."
+language: "en"
+categories: ["docker"]
+course: "mastering-docker-from-scratch"
+order: 11
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "buildkit-docker"
+---
+
+If you've been using Docker for a while, there's a good chance your builds spend a couple of minutes downloading the exact same packages every single time. npm install, pip install, bundle install. Everything. From scratch. The lockfile hasn't changed. The packages haven't changed. Docker just doesn't know that, and nobody told you it could.
+
+Not a Docker design philosophy about build purity. Just something nobody told you existed.
+
+There's also something we left hanging in the [previous lesson](/en/tutorials/advanced-dockerfile-instructions): `ARG` leaves values in the image history, visible to anyone who runs `docker history`. BuildKit has the real solution for that too.
+
+**BuildKit** is Docker's modern build engine. It's been available since Docker 18.09 and has been the default backend since version 23.0. If you have Docker installed in 2024 or 2025, it's already active. What you probably haven't set up are the features that make it actually useful.
+
+## Checking BuildKit and the syntax pragma
+
+On Docker Desktop (Mac and Windows), `docker buildx` comes included. On Linux installed from system packages — Arch, Ubuntu, Debian — the plugin is optional and needs to be installed separately:
+
+```bash
+# macOS and Linux (Homebrew)
+brew install docker-buildx
+
+# Ubuntu / Debian
+apt install docker-buildx-plugin
+
+# Arch Linux
+pacman -S docker-buildx
+```
+
+Verify it's available:
+
+```bash
+docker buildx version
+```
+
+```
+github.com/docker/buildx v0.34.1 ...
+```
+
+If you're on Docker 23.0 or later — which is any installation from 2023 onwards — BuildKit is already the default backend. Nothing else to enable. If you're on an older version for some reason, you can force it per-session with:
+
+```bash
+DOCKER_BUILDKIT=1 docker build .
+```
+
+Regardless of version, add this comment as the first line of your Dockerfiles:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+```
+
+Yes, it's a comment that does something. BuildKit uses "frontends" — versioned Dockerfile parsers with their own independent release cycle. This pragma pins the frontend to the latest stable channel and is what gives you access to modern syntax like `--mount` in `RUN` instructions. Without it, Docker uses the version bundled with your installation, which may or may not include everything we're about to use.
+
+## Build secrets
+
+Quick recap from the previous lesson: passing secrets through `ARG` leaves them embedded in the image history, readable by anyone with access to the image. BuildKit build secrets fix this cleanly: the build can read the secret while it needs it, but it never ends up in any layer.
+
+The mechanism has two parts. In the Dockerfile, you mount the secret inside the `RUN` where you use it — and only there:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN --mount=type=secret,id=npm_token \
+    npm config set //registry.npmjs.org/:_authToken=$(cat /run/secrets/npm_token) && \
+    npm ci && \
+    npm config delete //registry.npmjs.org/:_authToken
+COPY . .
+RUN npm run build
+```
+
+In the build command, you tell Docker where the secret comes from:
+
+```bash
+# From a file
+docker build --secret id=npm_token,src=.npmtoken .
+
+# From an environment variable
+docker build --secret id=npm_token,env=NPM_TOKEN .
+```
+
+The secret is mounted at `/run/secrets/<id>` for the duration of that `RUN`. When the command finishes, it's gone. Not in the layer, not in the history. You can verify:
+
+```bash
+docker history my-image
+```
+
+```
+IMAGE         CREATED      CREATED BY
+a1b2c3d4e5f6  2 hours ago  CMD ["node", "dist/index.js"]
+...           ...          RUN --mount=type=secret,id=npm_token npm config set ...
+```
+
+The command shows up. The value doesn't. Exactly what you've been trying to achieve since the [Dockerfile security best practices lesson](/en/tutorials/dockerfile-best-practices-security).
+
+### SSH agent forwarding
+
+The same mechanism exists for SSH access — useful when a build needs to clone a private repository without keys ever touching the container:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM node:20-alpine
+WORKDIR /app
+RUN apk add --no-cache git openssh-client
+RUN --mount=type=ssh \
+    git clone git@github.com:your-org/private-library.git /deps
+COPY package*.json ./
+RUN npm ci
+```
+
+```bash
+docker build --ssh default .
+```
+
+`--ssh default` forwards the host's SSH agent. Keys never touch the container filesystem, never end up in any layer, and once the `RUN` finishes the access is gone.
+
+## Cache mounts
+
+The problem from the opening of this lesson has a solution that's exactly one flag long:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
+COPY . .
+RUN npm run build
+```
+
+That's the whole thing. First run: npm downloads everything from the internet and stores the cache in `/root/.npm`. Second run — even if you built from scratch, even if you deleted the previous image — the cache is still there. npm finds it, downloads nothing.
+
+The time difference is immediate on projects with any meaningful dependencies:
+
+```
+First run:   2m 21s  (full download from npm)
+Second run:  8s      (cache hit, zero downloads)
+```
+
+The cache path changes depending on the package manager, but the pattern is always the same:
+
+```dockerfile
+# npm
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
+
+# pip
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -r requirements.txt
+
+# Cargo (Rust)
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo build --release
+
+# apt (Debian/Ubuntu)
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt update && apt install -y curl
+```
+
+The `sharing=locked` parameter in the apt example prevents two parallel builds from writing to the cache simultaneously — without it, the apt database can get corrupted if you run concurrent builds.
+
+One honest limitation: the cache lives on the build machine, not in the image. If you add a cache mount, it works great locally, and then you notice CI builds take exactly the same time as before — that's completely normal and doesn't mean you did anything wrong. CI runners are typically ephemeral: each job starts on a clean machine with no prior cache. The fix exists, but it's platform-specific. GitHub Actions, GitLab CI, and most modern providers support persisting BuildKit state between runs. Search "BuildKit cache" followed by your CI platform name.
+
+## Multi-platform builds
+
+Building on a Mac with Apple Silicon? Deploying to x86_64? Any Raspberry Pi in the mix? If more than one architecture is in the picture, you've already seen an image that works perfectly on your machine and fails on the server. Or you've been maintaining two separate tags by building it in two different places.
+
+Multi-platform builds in BuildKit solve this: build the image for multiple architectures from a single machine and publish it under the same tag. Docker automatically selects the right one on `docker pull` based on the host's architecture.
+
+First, create a builder with multi-platform support:
+
+```bash
+docker buildx create --use --name multi-arch-builder
+```
+
+Then build and push. Multi-platform builds need `--push` or `--output` — they can't live in local cache only:
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -t your-registry/my-app:latest \
+  --push \
+  .
+```
+
+BuildKit builds images for each platform in parallel. For architectures other than the host's native one, it uses QEMU emulation — which works, but turns your CPU into an actor playing a different CPU, with everything that implies for performance. A 45-second Go build can become an 8-minute one when QEMU translates every instruction on the fly. For compiled languages where build time matters, consider native runners for the target architecture.
+
+Node.js, Python, and other interpreted languages fare much better: the Dockerfile installs a runtime that already exists as a multi-arch image, and the source code doesn't require compilation.
+
+Check what platforms your builder supports:
+
+```bash
+docker buildx inspect --bootstrap
+```
+
+```
+Name:      multi-arch-builder
+Driver:    docker-container
+Platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/386, ...
+```
+
+---
+
+BuildKit is the difference between builds that redo the same work every time and builds that protect secrets, reuse prior work, and run on any architecture. Not an advanced feature for edge cases — just the correct way to build images in 2026.
+
+In the next lesson, we close the images module with the final optimization techniques: distroless images, size analysis with `dive`, and how to produce production images that contain exactly what they need and nothing else.
+
+Never stop coding!
+
+---
+
+**💡 Challenge**: Add a cache mount to the Dockerfile of any project you have. Run `docker build` twice and compare the install step timing. If the second run isn't noticeably faster, check that the cache path matches the correct location for your package manager.


### PR DESCRIPTION
## What

Adds the BuildKit tutorial (lesson 11 of the Docker course) in both Spanish and English.

## Content

- **BuildKit verification**: How to check and enable BuildKit, syntax pragma `# syntax=docker/dockerfile:1`
- **Build secrets**: Passing npm tokens and SSH keys securely without leaking into image layers via `--mount=type=secret` and `--mount=type=ssh`
- **Cache mounts**: Speeding up dependency installation with `--mount=type=cache`—examples for npm, pip, Cargo, and apt
- **Multi-platform builds**: Building for linux/amd64 and linux/arm64 from a single machine using `docker buildx build --platform`

## Files

- `src/content/tutorials/buildkit-docker.mdx` (ES)
- `src/content/tutorials/docker-buildkit.mdx` (EN)