### PR TITLE
feat(content): add Docker image optimization tutorial with distroless, dive, and layer optimization

### DIFF
--- a/src/content/tutorials/docker-image-optimization.mdx
+++ b/src/content/tutorials/docker-image-optimization.mdx
@@ -1,0 +1,272 @@
+---
+title: "Docker image optimization: from 1.2 GB to 85 MB"
+post_slug: "docker-image-optimization"
+date: "2026-06-12"
+excerpt: "How to go from Docker images that weigh hundreds of MB to production images that contain exactly what they need: minimal base images, distroless, dive, and layer optimization."
+language: "en"
+categories: ["docker"]
+course: "mastering-docker-from-scratch"
+order: 12
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "optimizacion-imagenes-docker"
+---
+
+At some point you run `docker images` and see a number that doesn't look right. A Node.js API with three endpoints and a database connection: 1.2 GB. A Go binary that compiled to 8 MB, sitting inside an 823 MB image. A Python script that reads a CSV and returns JSON: 980 MB.
+
+The container works. It deploys fine. And it's carrying a compiler, a package manager, three versions of libssl, and an entire Debian system that hasn't executed a single instruction since it booted.
+
+This is the last lesson in the images module, and it's where we close the loop: take everything from [multi-stage builds](/en/tutorials/docker-multi-stage-builds), [BuildKit](/en/tutorials/docker-buildkit), and [security practices](/en/tutorials/dockerfile-best-practices-security) and produce images that contain exactly what they need and nothing more.
+
+## The base image pyramid
+
+The choice of base image is the single highest-leverage decision in image optimization. The size differences aren't marginal:
+
+| Base                  | Approximate size  |
+|-----------------------|-------------------|
+| `node:20`             | ~1.1 GB           |
+| `ubuntu:22.04`        | ~77 MB            |
+| `debian:12-slim`      | ~74 MB            |
+| `node:20-alpine`      | ~135 MB           |
+| `alpine:3.19`         | ~7 MB             |
+| `scratch`             | 0 MB              |
+
+`node:20` is built on `debian:12`. `node:20-alpine` is built on `alpine:3.19`. The difference isn't which version of Node they ship — both ship Node 20. The difference is how much operating system comes with it.
+
+Alpine uses musl libc instead of glibc, busybox instead of bash and coreutils, and apk instead of apt. For most applications this makes no difference. For some it does — native dependencies that expect glibc will fail in ways that aren't immediately obvious. Worth testing before assuming compatibility.
+
+Switching from `node:20` to `node:20-alpine` is the highest-ROI optimization in this entire lesson. One line change. 88% smaller image.
+
+### scratch: the extreme case
+
+`FROM scratch` is exactly what it sounds like: an empty filesystem. No OS, no shell, nothing. It only works for fully static binaries, which in Go is the default with `CGO_ENABLED=0`:
+
+```dockerfile
+FROM golang:1.22-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o app .
+
+FROM scratch
+COPY --from=builder /app/app /app
+ENTRYPOINT ["/app"]
+```
+
+The first time you see the result — 8 MB where there used to be 800 — it feels like finding a cheat code. The second time you try it on a different application, it doesn't start because there are no SSL certificates for outbound HTTPS, and you realize scratch means it. No certificates, no timezone data, nothing you didn't explicitly copy.
+
+Both reactions are completely expected. For runtimes like Node.js, Python, or Java, scratch isn't the answer. That's where distroless comes in.
+
+## Distroless images
+
+Google maintains a set of images designed for exactly this scenario: they contain only what's needed to run your application — the runtime, SSL certificates, timezone data — without a shell, without a package manager, without anything you'd use to poke around inside a container.
+
+If someone asks "what's the most secure minimal base for a production container?", distroless is the answer without needing to think about it. No shell means no shell exploitation. No package manager means no package manager exploitation. Minimal attack surface as a design principle, not as an afterthought.
+
+For Go (or any static binary):
+
+```dockerfile
+FROM golang:1.22-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN CGO_ENABLED=0 go build -o app .
+
+FROM gcr.io/distroless/static-debian12
+COPY --from=builder /app/app /app
+ENTRYPOINT ["/app"]
+```
+
+`static-debian12` ships SSL certificates and timezone data. It weighs around 2 MB. The benefits of scratch without having to remember what you forgot to include.
+
+For Node.js:
+
+```dockerfile
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build && npm prune --production
+
+FROM gcr.io/distroless/nodejs22-debian12
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+EXPOSE 3000
+CMD ["dist/index.js"]
+```
+
+Available distroless images for the most common runtimes:
+
+| Runtime          | Image                                     |
+|------------------|-------------------------------------------|
+| Static binary    | `gcr.io/distroless/static-debian12`       |
+| glibc            | `gcr.io/distroless/base-debian12`         |
+| Node.js 22       | `gcr.io/distroless/nodejs22-debian12`     |
+| Python 3         | `gcr.io/distroless/python3-debian12`      |
+| Java 21          | `gcr.io/distroless/java21-debian12`       |
+
+One honest limitation: no shell means no `docker exec -it <container> sh`. If you're used to jumping inside containers to inspect things, distroless changes that workflow. The `:debug` variant adds busybox and enables exec — use it for development environments where you need to debug, not for production.
+
+## Analyzing your image with dive
+
+Before optimizing anything, you need to know what's taking up space. `docker history` gives you layer sizes:
+
+```bash
+docker history my-app:latest
+```
+
+```
+IMAGE         CREATED BY                                      SIZE
+a1b2c3d4e5f6  CMD ["node", "dist/index.js"]                  0B
+...           COPY --from=builder /app/dist ./dist            2.3MB
+...           COPY --from=builder /app/node_modules ./node_m  198MB
+...           RUN npm ci --only=production                    0B
+```
+
+Useful, but it doesn't tell you what's inside each layer. For that, there's `dive`.
+
+### Installation
+
+```bash
+# macOS and Linux (Homebrew)
+brew install dive
+
+# Ubuntu / Debian — dive isn't in the official repos; easiest path is running it via Docker:
+docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock wagoodman/dive:latest <image>
+
+# Arch Linux
+pacman -S dive
+```
+
+### Basic usage
+
+```bash
+dive my-app:latest
+```
+
+Opens an interactive terminal UI where you can navigate through each layer and see exactly which files were added, modified, or deleted.
+
+There's a specific moment everyone has in their first dive session: you find the layer taking up 60% of the image size, expand it, and recognize it. It's your dev dependencies. Not the base image's — yours. The ones that ended up there because `COPY --from=builder /app/node_modules` copied everything without filtering, and the build stage installed everything including typescript, jest, all the `@types/*` packages, and whatever else your development workflow needs.
+
+```
+Total Image size: 487 MB
+Potential wasted space: 0 B
+Image efficiency score: 87%
+
+Layer 3: COPY --from=builder /app/node_modules ./node_modules  [312 MB]
+  └── node_modules/
+       ├── typescript/          [28 MB]  ← not needed at runtime
+       ├── @types/              [15 MB]  ← definitely not
+       ├── jest/                [12 MB]  ← also no
+       └── ...
+```
+
+```bash
+# CI mode: returns pass/fail based on image efficiency
+CI=true dive my-app:latest
+```
+
+In CI pipelines, this flag evaluates whether files are deleted in later layers (a sign that cleanup could have happened earlier) and returns a non-zero exit code if the image doesn't pass the efficiency threshold. Useful for preventing poorly optimized images from reaching production.
+
+## Layer optimization
+
+Choosing the right base gets you most of the way there. The rest comes from how you write `RUN` instructions.
+
+### Clean up in the same layer
+
+Each `RUN` instruction creates a new layer. If you add files in one `RUN` and delete them in the next, **the files are still in the image** — they're marked as deleted in the new layer, but the original layer with the files is still there:
+
+```dockerfile
+# ❌ The apt files are still in the image — the previous layer keeps them
+RUN apt update && apt install -y curl
+RUN rm -rf /var/lib/apt/lists/*
+
+# ✅ Cleanup happens in the same layer, no trace left
+RUN apt update && apt install -y curl \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+The same principle applies to anything that downloads temporary files during installation: do it all in one instruction.
+
+### npm prune --production
+
+If your Dockerfile installs all dependencies (including dev) to compile the application and then copies `node_modules` to the final stage unfiltered, you're shipping bundlers, linters, TypeScript types, and testing frameworks to production:
+
+```dockerfile
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci                     # Installs everything: dev + production
+COPY . .
+RUN npm run build
+RUN npm prune --production     # Removes dev dependencies before copying
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+CMD ["node", "dist/index.js"]
+```
+
+### .dockerignore
+
+The easiest thing to forget and one of the highest-impact optimizations. Without a `.dockerignore`, you're sending `node_modules`, `.git`, logs, and everything in your working directory to the Docker daemon before the build even starts. That slows down the build context transfer and can end up in the image if you have any imprecise `COPY .` instructions.
+
+A minimal `.dockerignore` for Node.js projects:
+
+```
+node_modules
+.git
+.env
+*.log
+dist
+coverage
+.DS_Store
+```
+
+## Before and after: the complete Dockerfile
+
+Putting it all together — multi-stage builds, BuildKit cache mounts, non-root user, and the optimization techniques from this lesson:
+
+```dockerfile
+# ❌ BEFORE: 1.2 GB
+FROM node:20
+WORKDIR /app
+COPY . .
+RUN npm install
+CMD ["node", "index.js"]
+```
+
+```dockerfile
+# ✅ AFTER: ~85 MB (93% reduction)
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
+COPY src/ ./src/
+COPY tsconfig.json ./
+RUN npm run build && npm prune --production
+
+FROM node:20-alpine
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -u 1001 -S appuser -G appgroup
+WORKDIR /app
+COPY --from=builder --chown=appuser:appgroup /app/node_modules ./node_modules
+COPY --from=builder --chown=appuser:appgroup /app/dist ./dist
+USER appuser
+EXPOSE 3000
+CMD ["node", "dist/index.js"]
+```
+
+The differences: Alpine instead of full Debian, multi-stage to isolate the build environment, prune to keep only runtime dependencies, non-root user. None of these changes take more than a few minutes — and the result is an image that transfers ten times faster and has a fraction of the attack surface.
+
+---
+
+That closes the images module. We've gone from knowing what a Dockerfile is to building images that are efficient, secure, and production-ready. Next up is Module 3 — Docker Compose: how to orchestrate multiple containers that need to work together — database, backend, frontend — with a single configuration file and one command.
+
+Never stop coding!
+
+---
+
+**💡 Challenge**: Run `dive` against any image you have over 500 MB. Find the three heaviest layers and identify which technique from this lesson would reduce the size the most. If you can get it under 100 MB, you've got it.

--- a/src/content/tutorials/optimizacion-imagenes-docker.mdx
+++ b/src/content/tutorials/optimizacion-imagenes-docker.mdx
@@ -1,0 +1,272 @@
+---
+title: "Optimización de imágenes Docker: de 1.2 GB a 85 MB"
+post_slug: "optimizacion-imagenes-docker"
+date: "2026-06-12"
+excerpt: "Cómo pasar de imágenes Docker que pesan cientos de MB a imágenes de producción que contienen exactamente lo que necesitan: bases mínimas, distroless, dive y optimización de capas."
+language: "es"
+categories: ["docker"]
+course: "domina-docker-desde-cero"
+order: 12
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "docker-image-optimization"
+---
+
+Abres `docker images` en un proyecto reciente y ahí está: 1.2 GB. Para una API de Node.js con tres endpoints y dos consultas a base de datos. Tu binario compilado de Go pesa 8 MB, pero la imagen pesa 823 MB. Un script de Python que lee un CSV y devuelve JSON: 980 MB.
+
+El contenedor arranca. Funciona en producción. Y arrastra consigo un compilador, un gestor de paquetes, tres versiones de libssl y toda la infraestructura de Debian que no va a ejecutar ni una instrucción desde que se desplegó.
+
+No es solo un problema estético. Es superficie de ataque innecesaria, velocidad de despliegue que se resiente y coste de transferir imágenes que no deberían pesar lo que pesan. Cerramos el módulo de imágenes con las técnicas que convierten esos números en algo razonable.
+
+## La pirámide de bases mínimas
+
+No todas las imágenes base son iguales, y la diferencia en tamaño no es marginal:
+
+| Base                  | Tamaño aproximado |
+|-----------------------|-------------------|
+| `node:20`             | ~1.1 GB           |
+| `ubuntu:22.04`        | ~77 MB            |
+| `debian:12-slim`      | ~74 MB            |
+| `node:20-alpine`      | ~135 MB           |
+| `alpine:3.19`         | ~7 MB             |
+| `scratch`             | 0 MB              |
+
+`node:20` viene de `debian:12`. `node:20-alpine` viene de `alpine:3.19`. La diferencia no es qué versión de Node trae — ambas traen Node 20. La diferencia es cuánto sistema operativo arrastra con él.
+
+Alpine pesa 7 MB. Usa musl libc en vez de glibc, busybox en vez de bash y coreutils, y apk en vez de apt. Para la mayoría de aplicaciones, esto no cambia nada en el comportamiento. Para algunas, sí: si tus dependencias nativas esperan glibc, Alpine te va a dar un error críptico en el momento menos conveniente. Vale la pena hacer la prueba antes de asumir que funciona.
+
+El cambio de `node:20` a `node:20-alpine` es la optimización con mejor ratio esfuerzo/resultado que existe en este módulo. Una línea en el Dockerfile, un 88% menos de imagen.
+
+### scratch: el caso extremo
+
+`FROM scratch` es literalmente una imagen vacía. Sin sistema operativo. Sin shell. Sin nada. Solo funciona para binarios completamente estáticos, y en Go esto es el caso por defecto con `CGO_ENABLED=0`:
+
+```dockerfile
+FROM golang:1.22-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o app .
+
+FROM scratch
+COPY --from=builder /app/app /app
+ENTRYPOINT ["/app"]
+```
+
+La primera vez que ves el número final — 8 MB para lo que antes pesaba 800 — parece un truco de magia. La segunda vez que intentas aplicarlo a otra aplicación, no arranca: le faltan los certificados SSL para hacer llamadas HTTPS, y te das cuenta de que scratch significa exactamente eso. Literalmente vacío. Sin certificados, sin tzdata, sin nada que no hayas copiado explícitamente.
+
+Las dos experiencias son completamente normales. Para aplicaciones con dependencias de runtime — Node.js, Python, Java — scratch no es la respuesta. Ahí entran las imágenes distroless.
+
+## Imágenes distroless
+
+Google mantiene un conjunto de imágenes diseñadas exactamente para este caso: contienen solo el runtime necesario para ejecutar tu aplicación, sin shell, sin gestores de paquetes, sin utilidades del sistema.
+
+La pregunta práctica no es "¿qué base uso para máxima seguridad?" — es "¿qué base reduce al mínimo lo que tengo que mantener y parchear?". Distroless gana esa respuesta sin discusión.
+
+Para Go (o cualquier binario estático):
+
+```dockerfile
+FROM golang:1.22-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN CGO_ENABLED=0 go build -o app .
+
+FROM gcr.io/distroless/static-debian12
+COPY --from=builder /app/app /app
+ENTRYPOINT ["/app"]
+```
+
+`static-debian12` viene con certificados SSL y datos de zona horaria incluidos. Pesa unos 2 MB. Los beneficios de scratch sin la gestión manual de "¿qué le falta ahora?".
+
+Para Node.js:
+
+```dockerfile
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build && npm prune --production
+
+FROM gcr.io/distroless/nodejs22-debian12
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+EXPOSE 3000
+CMD ["dist/index.js"]
+```
+
+Las variantes disponibles para los runtimes más comunes:
+
+| Runtime          | Imagen                                    |
+|------------------|-------------------------------------------|
+| Binario estático | `gcr.io/distroless/static-debian12`       |
+| glibc            | `gcr.io/distroless/base-debian12`         |
+| Node.js 22       | `gcr.io/distroless/nodejs22-debian12`     |
+| Python 3         | `gcr.io/distroless/python3-debian12`      |
+| Java 21          | `gcr.io/distroless/java21-debian12`       |
+
+Una advertencia real: sin shell, no puedes hacer `docker exec -it <container> sh` para entrar a inspeccionar. Si en producción tienes el hábito de entrar en contenedores a ver qué está pasando, distroless va a requerir ajustar ese flujo. La variante `:debug` añade busybox y permite exec, pero solo para entornos de desarrollo donde necesites depurar.
+
+## Analizando tu imagen con dive
+
+Antes de optimizar algo, necesitas saber qué está ocupando espacio. `docker history` te da los tamaños por capa:
+
+```bash
+docker history mi-app:latest
+```
+
+```
+IMAGE         CREATED BY                                      SIZE
+a1b2c3d4e5f6  CMD ["node", "dist/index.js"]                  0B
+...           COPY --from=builder /app/dist ./dist            2.3MB
+...           COPY --from=builder /app/node_modules ./node_m  198MB
+...           RUN npm ci --only=production                    0B
+```
+
+Útil, pero limitado: ves el tamaño de cada capa, pero no qué ficheros hay dentro. Para eso existe `dive`.
+
+### Instalación
+
+```bash
+# macOS y Linux (Homebrew)
+brew install dive
+
+# Ubuntu / Debian — dive no está en los repos oficiales, la opción más rápida es usarlo vía Docker:
+docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock wagoodman/dive:latest <imagen>
+
+# Arch Linux
+pacman -S dive
+```
+
+### Uso básico
+
+```bash
+dive mi-app:latest
+```
+
+Abre una interfaz interactiva donde puedes navegar por cada capa y ver exactamente qué ficheros añadió, modificó o eliminó.
+
+Hay un momento que todo el mundo tiene en la primera sesión con dive: encontrar la capa que ocupa el 60% de la imagen y reconocer que son los dev dependencies. No los de la imagen base. Los tuyos. Los que el `COPY --from=builder /app/node_modules` copió enteros desde el stage de build sin que te dieras cuenta de que ahí estaban typescript, jest, todos los `@types/*` y el resto del zoológico de desarrollo.
+
+```
+Total Image size: 487 MB
+Potential wasted space: 0 B
+Image efficiency score: 87%
+
+Layer 3: COPY --from=builder /app/node_modules ./node_modules  [312 MB]
+  └── node_modules/
+       ├── typescript/          [28 MB]  ← ¿en producción?
+       ├── @types/              [15 MB]  ← definitivamente no
+       ├── jest/                [12 MB]  ← tampoco
+       └── ...
+```
+
+```bash
+# Modo CI: devuelve pass/fail según eficiencia de la imagen
+CI=true dive mi-app:latest
+```
+
+En pipelines de CI, este flag evalúa si hay ficheros eliminados en capas posteriores (señal de que se podría haber limpiado antes) y devuelve un exit code no-zero si la imagen no pasa el umbral de eficiencia. Útil para impedir que imágenes mal optimizadas lleguen a producción por accidente.
+
+## Optimización de capas
+
+Elegir la base correcta es la mitad del trabajo. La otra mitad es cómo escribes las instrucciones `RUN`.
+
+### Limpiar en la misma capa
+
+Cada instrucción `RUN` crea una capa nueva. Si añades ficheros en un `RUN` y los eliminas en el siguiente, **los ficheros siguen en la imagen** — están marcados como eliminados en la capa nueva, pero la capa original con los ficheros sigue ahí intacta:
+
+```dockerfile
+# ❌ Los ficheros de apt están en la imagen — la capa anterior los guarda
+RUN apt update && apt install -y curl
+RUN rm -rf /var/lib/apt/lists/*
+
+# ✅ La limpieza ocurre en la misma capa, no queda rastro
+RUN apt update && apt install -y curl \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+El mismo principio aplica a cualquier instalación que descargue ficheros temporales: hazlo todo en la misma instrucción.
+
+### npm prune --production
+
+Si tu Dockerfile instala todas las dependencias (incluyendo dev) para compilar y luego copia `node_modules` al stage final sin filtrar, llevas bundlers, linters, tipos de TypeScript y probablemente varios frameworks de testing a producción:
+
+```dockerfile
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci                     # Instala todo: dev + producción
+COPY . .
+RUN npm run build
+RUN npm prune --production     # Elimina dev dependencies antes de copiar
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+CMD ["node", "dist/index.js"]
+```
+
+### .dockerignore
+
+Lo más fácil de olvidar y lo que más impacto tiene en el contexto de build. Sin `.dockerignore`, estás enviando `node_modules`, `.git`, logs y cualquier fichero del directorio al daemon antes de que empiece el build. Ralentiza la construcción y puede terminar en la imagen si tienes algún `COPY .` poco preciso.
+
+Un `.dockerignore` mínimo para proyectos Node.js:
+
+```
+node_modules
+.git
+.env
+*.log
+dist
+coverage
+.DS_Store
+```
+
+## Antes y después: el Dockerfile completo
+
+Juntando todo lo visto en este módulo — [multi-stage builds](/es/tutoriales/multi-stage-builds-docker), [BuildKit](/es/tutoriales/buildkit-docker), usuario no-root de la [lección de seguridad](/es/tutoriales/buenas-practicas-dockerfiles-seguridad) y la optimización de esta lección:
+
+```dockerfile
+# ❌ ANTES: 1.2 GB
+FROM node:20
+WORKDIR /app
+COPY . .
+RUN npm install
+CMD ["node", "index.js"]
+```
+
+```dockerfile
+# ✅ DESPUÉS: ~85 MB (93% de reducción)
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
+COPY src/ ./src/
+COPY tsconfig.json ./
+RUN npm run build && npm prune --production
+
+FROM node:20-alpine
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -u 1001 -S appuser -G appgroup
+WORKDIR /app
+COPY --from=builder --chown=appuser:appgroup /app/node_modules ./node_modules
+COPY --from=builder --chown=appuser:appgroup /app/dist ./dist
+USER appuser
+EXPOSE 3000
+CMD ["node", "dist/index.js"]
+```
+
+La diferencia en números: alpine en vez de debian completo, multi-stage para aislar el entorno de build, prune para dejar solo dependencias de producción, usuario no-root. Ninguno de estos cambios lleva más de dos minutos de trabajo — y el resultado es una imagen que tarda 10 veces menos en transferirse y tiene una fracción de la superficie de ataque.
+
+---
+
+Con esto cerramos el módulo de imágenes. Hemos pasado de saber qué es un Dockerfile a construir imágenes eficientes, seguras y optimizadas para producción. En la próxima lección arrancamos el módulo de Docker Compose: cómo orquestar varios contenedores que necesitan trabajar juntos — base de datos, backend, frontend — con un único fichero de configuración y un solo comando.
+
+¡Nunca dejes de programar!
+
+---
+
+**💡 Reto**: Analiza con `dive` cualquier imagen que tengas con más de 500 MB. Localiza las tres capas que más pesan e identifica cuál de las técnicas de esta lección reduciría más el tamaño. Si consigues bajarla de 100 MB, lo has conseguido.


### PR DESCRIPTION
## What

Adds the Docker image optimization tutorial (lesson 12, final lesson of the images module) in both Spanish and English.

## Content

- **Base image pyramid**: Alpine, scratch, distroless — comparing sizes from 1.1 GB to 0 MB
- **Distroless images**: Google's minimal runtime images (Node.js, Python, Go, Java) without shell or package manager
- **Analyzing with dive**: Interactive layer inspection, finding wasted space, CI mode for automated checks
- **Layer optimization**: Cleaning up in the same layer, `npm prune --production`, `.dockerignore`
- **Before and after**: Complete Dockerfile from 1.2 GB to ~85 MB (93% reduction)

## Files

- `src/content/tutorials/docker-image-optimization.mdx` (EN)
- `src/content/tutorials/optimizacion-imagenes-docker.mdx` (ES)