### PR TITLE
fix: run Astro dev-server regression guard in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,9 +23,14 @@ updates:
       - "automated"
     # No groups - individual PRs per dependency for easier debugging
     # and selective merging when some updates break tests
-    # Ignore major updates for these packages (manual review recommended)
+    # Astro 6.4.x currently breaks the dev server for catch-all getStaticPaths
+    # routes in this project. Keep Astro on 6.3.x until upstream fixes:
+    # https://github.com/withastro/astro/issues/16949
+    # @astrojs/mdx 6.x requires newer Astro internals, so it is blocked too.
     ignore:
       - dependency-name: "astro"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      - dependency-name: "@astrojs/mdx"
         update-types: ["version-update:semver-major"]
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,9 @@ jobs:
         run: bun x playwright install --with-deps chromium
 
       - name: Run E2E tests
-        run: bun run test:e2e --project=chromium
+        run: |
+          bun run test:e2e --project=chromium
+          bun run test:e2e:dev-server
 
       - name: Upload test results
         uses: actions/upload-artifact@v7

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@astrojs/mdx": "5.0.6",
         "@astrojs/rss": "4.0.18",
         "@astrojs/sitemap": "3.7.3",
-        "astro": "6.4.6",
+        "astro": "6.3.8",
         "fast-xml-parser": "5.9.0",
         "get-tsconfig": "5.0.0-beta.5",
         "marked": "^18.0.5",
@@ -69,7 +69,7 @@
 
     "@astrojs/compiler": ["@astrojs/compiler@2.11.0", "", {}, "sha512-zZOO7i+JhojO8qmlyR/URui6LyfHJY6m+L9nwyX5GiKD78YoRaZ5tzz6X0fkl+5bD3uwlDHayf6Oe8Fu36RKNg=="],
 
-    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.0", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.1.1", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw=="],
+    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.9.1", "", { "dependencies": { "picomatch": "^4.0.4" } }, "sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ=="],
 
     "@astrojs/language-server": ["@astrojs/language-server@2.16.7", "", { "dependencies": { "@astrojs/compiler": "^2.13.1", "@astrojs/yaml2ts": "^0.2.3", "@jridgewell/sourcemap-codec": "^1.5.5", "@volar/kit": "~2.4.28", "@volar/language-core": "~2.4.28", "@volar/language-server": "~2.4.28", "@volar/language-service": "~2.4.28", "muggle-string": "^0.4.1", "tinyglobby": "^0.2.16", "volar-service-css": "0.0.70", "volar-service-emmet": "0.0.70", "volar-service-html": "0.0.70", "volar-service-prettier": "0.0.70", "volar-service-typescript": "0.0.70", "volar-service-typescript-twoslash-queries": "0.0.70", "volar-service-yaml": "0.0.70", "vscode-html-languageservice": "^5.6.2", "vscode-uri": "^3.1.0" }, "peerDependencies": { "prettier": "^3.0.0", "prettier-plugin-astro": ">=0.11.0" }, "optionalPeers": ["prettier", "prettier-plugin-astro"], "bin": { "astro-ls": "bin/nodeServer.js" } }, "sha512-b64bWT74Vq/ORcSqW7TdIjjpB6hcl+Ei/lMANIUaAGlLPiYNtPTRI/j2tzvugT+LoVwfJtE2Ukq/t2OGCyEtfQ=="],
 
@@ -667,7 +667,7 @@
 
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
 
-    "astro": ["astro@6.4.6", "", { "dependencies": { "@astrojs/compiler": "^4.0.0", "@astrojs/internal-helpers": "0.10.0", "@astrojs/markdown-remark": "7.2.0", "@astrojs/telemetry": "3.3.2", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^7.3.2", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "./bin/astro.mjs" } }, "sha512-48OBTBKR9ctbf+DQxpOuxGl8ebfn59zTuNQMBzptmG/Mi/H8IdfMSbJgGuX1I/4U6g9yazG1p4BHlf4+2hWU4Q=="],
+    "astro": ["astro@6.3.8", "", { "dependencies": { "@astrojs/compiler": "^4.0.0", "@astrojs/internal-helpers": "0.9.1", "@astrojs/markdown-remark": "7.1.2", "@astrojs/telemetry": "3.3.2", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.6.3", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^7.3.2", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "./bin/astro.mjs" } }, "sha512-xH2UA8Z17IS+JaqSlSkBor7jO6gd7zXTLdmu06nKpfpDDJFbi/7KZEy3NDmWxmier+6XrCZ9Z4aitO8jhC9oiA=="],
 
     "astro-eslint-parser": ["astro-eslint-parser@1.3.0", "", { "dependencies": { "@astrojs/compiler": "^2.0.0", "@typescript-eslint/scope-manager": "^7.0.0 || ^8.0.0", "@typescript-eslint/types": "^7.0.0 || ^8.0.0", "astrojs-compiler-sync": "^1.0.0", "debug": "^4.3.4", "entities": "^6.0.0", "eslint-scope": "^8.0.1", "eslint-visitor-keys": "^4.0.0", "espree": "^10.0.0", "fast-glob": "^3.3.3", "is-glob": "^4.0.3", "semver": "^7.3.8" } }, "sha512-aOLc/aDR7lTWAHlytEefwn4Y6qs6uMr69DZvUx2A1AOAZsWhGB/paiRWPtVchh9wzMvLeqr+DkbENhVreVr9AQ=="],
 
@@ -2083,8 +2083,6 @@
 
     "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
-    "@astrojs/markdown-remark/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.9.1", "", { "dependencies": { "picomatch": "^4.0.4" } }, "sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ=="],
-
     "@astrojs/rss/fast-xml-parser": ["fast-xml-parser@5.5.8", "", { "dependencies": { "fast-xml-builder": "^1.1.4", "path-expression-matcher": "^1.2.0", "strnum": "^2.2.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ=="],
 
     "@astrojs/rss/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
@@ -2190,8 +2188,6 @@
     "ast-v8-to-istanbul/js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "astro/@astrojs/compiler": ["@astrojs/compiler@4.0.0", "", {}, "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA=="],
-
-    "astro/@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.2.0", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.0", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw=="],
 
     "astro/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 

--- a/e2e/dev-server-routing.spec.ts
+++ b/e2e/dev-server-routing.spec.ts
@@ -12,8 +12,7 @@
  *
  * `astro build` is unaffected by the bug, so the regular e2e suite (which runs
  * against `astro preview` / built output) does NOT catch this regression.
- * This spec runs against `astro dev` only — see the `dev-server` project in
- * playwright.config.ts.
+ * This spec runs against `astro dev` only — see playwright.dev-server.config.ts.
  *
  * If you see this test failing with "404 - Template Not Found" or empty
  * contentType / pageType, astro has likely been bumped to a broken version.

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@astrojs/mdx": "5.0.6",
     "@astrojs/rss": "4.0.18",
     "@astrojs/sitemap": "3.7.3",
-    "astro": "6.4.6",
+    "astro": "6.3.8",
     "fast-xml-parser": "5.9.0",
     "get-tsconfig": "5.0.0-beta.5",
     "marked": "^18.0.5",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:changed": "vitest run --changed src/__tests__",
     "test:related": "vitest run --related src/__tests__",
     "test:e2e": "bun run scripts/kill-dev-servers.ts && bun run build && playwright test",
+    "test:e2e:dev-server": "bun run scripts/kill-dev-servers.ts && playwright test --config=playwright.dev-server.config.ts",
     "test:e2e:ui": "bun run scripts/kill-dev-servers.ts && playwright test --ui",
     "test:e2e:debug": "bun run scripts/kill-dev-servers.ts && playwright test --debug",
     "test:e2e:update-snapshots": "bun run scripts/kill-dev-servers.ts && bun run build && playwright test --update-snapshots",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,21 +29,6 @@ export default defineConfig({
       testMatch: ["**/visual-regression.spec.ts", "**/bookshelf.spec.ts"],
     },
     {
-      // Regression guard for astro #16949: dev-server only empty-props bug
-      // in dynamic catch-all routes. Runs `astro dev` (not preview/build) so
-      // the actual dev server path is exercised. Build is unaffected by the
-      // bug, so the regular e2e suite cannot catch this regression.
-      name: "dev-server",
-      use: { ...devices["Desktop Chrome"] },
-      testMatch: ["**/dev-server-routing.spec.ts"],
-      webServer: {
-        command: "bun run dev",
-        url: "http://localhost:4321",
-        reuseExistingServer: !process.env.CI,
-        timeout: 120_000,
-      },
-    },
-    {
       name: "mobile-iphone12",
       use: { ...devices["iPhone 12"] },
       testMatch: "**/responsive.spec.ts",

--- a/playwright.dev-server.config.ts
+++ b/playwright.dev-server.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const DEV_SERVER_PORT = 4322;
+const DEV_SERVER_URL = `http://127.0.0.1:${DEV_SERVER_PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: ["**/dev-server-routing.spec.ts"],
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: DEV_SERVER_URL,
+    trace: "on-first-retry",
+  },
+
+  projects: [
+    {
+      name: "dev-server",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  webServer: {
+    command: `bun x astro dev --host 127.0.0.1 --port ${DEV_SERVER_PORT}`,
+    url: DEV_SERVER_URL,
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+});


### PR DESCRIPTION
## Description

Fixes the gap that allowed dependabot PR #420 to pass CI while the live `astro dev` server was still broken by the upstream Astro getStaticPaths props regression.

The previous regression test was correct, but CI never executed it: the workflow explicitly ran `bun run test:e2e --project=chromium`, and the `chromium` project ignored `e2e/dev-server-routing.spec.ts`. That meant CI only tested build/preview output, not the dev server path where the bug lives.

This PR:

- reverts `astro` from `6.4.6` back to `6.3.8`;
- moves the dev-server regression guard to a dedicated Playwright config that starts `astro dev` as a top-level `webServer`;
- adds `bun run test:e2e:dev-server`;
- runs that script from the existing E2E CI job after the current chromium suite;
- pauses dependabot updates for blocked Astro/MDX versions until upstream fixes the regression.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Test update
- [x] 🔧 Configuration/Build update

## Related Issues

- Blocks recurrence of dependabot PR #420 (`astro@6.4.6`)
- Related to upstream Astro issue: https://github.com/withastro/astro/issues/16949
- Related to previous guard PR #408

## Changes Made

- Reverted `astro` to `6.3.8` in `package.json` and `bun.lock`.
- Added `playwright.dev-server.config.ts` with a top-level `webServer` that runs:

  ```bash
  bun x astro dev --host 127.0.0.1 --port 4322
  ```

- Added `test:e2e:dev-server` script.
- Updated `.github/workflows/ci.yml` to run both:

  ```bash
  bun run test:e2e --project=chromium
  bun run test:e2e:dev-server
  ```

- Removed the misleading `dev-server` project from the regular `playwright.config.ts` because the CI command selected only `--project=chromium`.
- Updated the dev-server spec comment to point at the dedicated config.
- Updated dependabot ignore rules:
  - block `astro` minor/major updates while 6.4.x is broken for this project;
  - block `@astrojs/mdx` major updates because `@astrojs/mdx@6.x` requires newer Astro internals and is incompatible with the temporary `astro@6.3.8` pin.

## Testing

- [x] Dev-server regression test fails with broken Astro:

  ```bash
  # with astro@6.4.6
  bun run test:e2e:dev-server
  # 5 failed
  ```

- [x] Dev-server regression test passes after revert:

  ```bash
  # with astro@6.3.8
  bun run test:e2e:dev-server --reporter=line
  # 5 passed
  ```

- [x] Relevant files pass Prettier/ESLint:

  ```bash
  bun x prettier --check .github/workflows/ci.yml .github/dependabot.yml package.json playwright.config.ts playwright.dev-server.config.ts e2e/dev-server-routing.spec.ts
  bun x eslint playwright.config.ts playwright.dev-server.config.ts e2e/dev-server-routing.spec.ts
  ```

## Why PR #420 passed incorrectly

The E2E workflow ran:

```bash
bun run test:e2e --project=chromium
```

which expanded to:

```bash
bun run scripts/kill-dev-servers.ts && bun run build && playwright test "--project=chromium"
```

That command never ran the `dev-server` project. It only tested `astro preview` / built output, and the upstream bug is `astro dev` only.

This PR makes the dev-server check an explicit CI command, so future Astro bumps cannot silently pass without exercising the broken path.

