### PR TITLE
chore(deps): allow Astro minor updates again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,13 +23,12 @@ updates:
       - "automated"
     # No groups - individual PRs per dependency for easier debugging
     # and selective merging when some updates break tests
-    # Astro 6.4.x currently breaks the dev server for catch-all getStaticPaths
-    # routes in this project. Keep Astro on 6.3.x until upstream fixes:
-    # https://github.com/withastro/astro/issues/16949
-    # @astrojs/mdx 6.x requires newer Astro internals, so it is blocked too.
+    # Keep major updates manual for high-impact tooling.
+    # @astrojs/mdx 6.x requires newer Astro internals and should be validated
+    # separately from Astro core upgrades.
     ignore:
       - dependency-name: "astro"
-        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@astrojs/mdx"
         update-types: ["version-update:semver-major"]
       - dependency-name: "typescript"


### PR DESCRIPTION
## Description

Allows Dependabot to open Astro minor updates again now that `astro@6.4.6` has been validated with the dedicated dev-server E2E guard added in #423.

Major Astro updates remain manual.

`@astrojs/mdx` major updates remain blocked because MDX 6.x should be validated separately from Astro core upgrades.

## Type of Change

- [x] 🔧 Configuration/Build update

## Related Issues

- Follows #423 (dev-server E2E guard)
- Follows #429 (`astro@6.4.6` validation)
- Related to https://github.com/withastro/astro/issues/16949

## Changes Made

- Changed Astro Dependabot ignore rule from:

```yaml
update-types: ["version-update:semver-minor", "version-update:semver-major"]
```

  to:

```yaml
update-types: ["version-update:semver-major"]
```

- Kept `@astrojs/mdx` major updates blocked.
- Updated comments to reflect the new validation status.

## Testing

- [x] `.github/dependabot.yml` passes Prettier check:

```bash
bun x prettier --check .github/dependabot.yml
```
