### PR TITLE
chore(deps): refresh MDX Dependabot comment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,8 +24,8 @@ updates:
     # No groups - individual PRs per dependency for easier debugging
     # and selective merging when some updates break tests
     # Keep major updates manual for high-impact tooling.
-    # @astrojs/mdx 6.x requires newer Astro internals and should be validated
-    # separately from Astro core upgrades.
+    # @astrojs/mdx 6.x is validated against Astro 6.4.x, so future major
+    # bumps should be evaluated together with Astro core upgrades.
     ignore:
       - dependency-name: "astro"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Refresh the inline comment in `.github/dependabot.yml` now that `@astrojs/mdx@6.x` has been validated against `astro@6.4.x` in #433. The ignore rule itself is unchanged; MDX major updates still stay manual.

## Changes

- Updated the comment above the `ignore` list to reflect the new validation status.

## Validation

- [x] `bun x prettier --check .github/dependabot.yml`
