### PR TITLE
feat(content): add Git worktrees tutorial with multiple working directories and real-world use cases

### DIFF
--- a/src/content/tutorials/git-worktrees-multiple-directorios.mdx
+++ b/src/content/tutorials/git-worktrees-multiple-directorios.mdx
@@ -1,0 +1,179 @@
+---
+title: "Git Worktrees: múltiples directorios de trabajo desde un mismo repositorio"
+post_slug: "git-worktrees-multiple-directorios"
+date: "2026-06-15"
+excerpt: "Trabaja en varias ramas simultáneamente sin cambiar de directorio ni hacer stash. Git worktree te permite tener tantos entornos de trabajo como necesites, todos conectados al mismo repositorio."
+language: "es"
+categories: ["git"]
+course: "domina-git-desde-cero"
+order: 34
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "git-worktrees-multiple-working-directories"
+---
+
+Tienes una carpeta que se llama `mi-proyecto-2`. O `mi-proyecto-copia`. O, si llevas suficiente tiempo en esto, `mi-proyecto-definitivo-real-ahora-sí`. No la mencionas en la daily. No vive dentro del repo, así que tampoco está en el `.gitignore`. Existe, en silencio, en algún punto del sistema de archivos, haciendo lo que se supone que hacía el primer clon que creaste cuando no sabías cómo cambiar de contexto con Git.
+
+O haces el baile del [stash](/es/tutoriales/guardando-cambios-temporalmente-git-stash): `git stash`, cambias de rama, haces lo que toca, `git stash pop`, resuelves lo que ha dejado el pop — que siempre es algo — y vuelves a donde estabas, ya no tan seguro de dónde estabas exactamente. Funciona. Como funciona tener un tornillo de sobra al montar un mueble de IKEA: la estantería está en pie, pero con una sensación vaga de que algo no encaja del todo.
+
+`git worktree` no es una curiosidad académica de los que leen la documentación de Git por placer. Es la respuesta oficial al problema, la que Git tenía preparada mientras todos hacíamos clones manuales y fingíamos que era una práctica razonable.
+
+## Qué es un worktree y por qué existe
+
+¿Un clone? ¿Un symlink? ¿Una copia del repositorio con otro nombre? Nada de eso.
+
+Un **worktree** es un directorio de trabajo vinculado a un repositorio Git existente. Cada worktree tiene su propia rama activa, su propio working tree y staging area — pero comparten el mismo historial, los mismos objetos y las mismas refs. Versión técnica: varios entornos de trabajo conectados al mismo `.git` subyacente. Versión del martes por la mañana: puedes tener `mi-proyecto-hotfix/` y `mi-proyecto-feature/` abiertas en tu editor al mismo tiempo, cada una en su propia rama, y cuando commiteas en una, la otra lo sabe.
+
+Piénsalo como escritorios de trabajo. En uno tienes la feature a medias. En otro el hotfix urgente. En otro la rama del compañero que hay que revisar. Ninguno interfiere con los demás. Cuando terminas con uno, lo cierras y desaparece.
+
+```
+mi-proyecto/           ← directorio principal, branch feature/login
+├── .git/              ← aquí está todo el historial
+└── src/
+
+mi-proyecto-hotfix/    ← worktree, branch hotfix/critical-bug
+├── .git               ← archivo, no carpeta
+└── src/
+
+mi-proyecto-review/    ← worktree, branch fix/auth-issue
+├── .git               ← archivo, no carpeta
+└── src/
+```
+
+Los worktrees secundarios tienen un archivo `.git` — no una carpeta, un archivo de texto plano con una ruta al repositorio principal. Git gestiona todo internamente. No tienes que abrirlo ni entenderlo; solo saber que es lo que diferencia un worktree de un clone. Los tres directorios comparten el espacio en disco del historial de Git. El único requisito: dos worktrees no pueden estar en la misma rama al mismo tiempo.
+
+## Crear tu primer worktree
+
+El comando básico:
+
+```bash
+git worktree add ../mi-proyecto-review fix/auth-issue
+```
+
+Esto crea el directorio `../mi-proyecto-review` y hace checkout de la rama `fix/auth-issue` en él. Si la rama no existe todavía, créala en el mismo paso:
+
+```bash
+git worktree add -b feature/nueva-funcionalidad ../mi-proyecto-feature main
+```
+
+`-b feature/nueva-funcionalidad` crea la rama a partir de `main`. El directorio existe, la rama existe, puedes trabajar — sin mover nada en tu directorio actual.
+
+## Ver todos los worktrees activos
+
+```bash
+git worktree list
+```
+
+```
+/home/fjpalacios/projects/mi-proyecto          9f3c2a1 [feature/login]
+/home/fjpalacios/projects/mi-proyecto-hotfix   3b7d9e2 [hotfix/critical-bug]
+/home/fjpalacios/projects/mi-proyecto-review   8c1f4d3 [fix/auth-issue]
+```
+
+Ruta, commit actual, rama activa. Git mantiene el registro de todos los worktrees del repositorio y los muestra aquí. Si intentas hacer checkout de una rama que ya está activa en otro worktree, Git te lo impide — no porque sea malo, sino porque sería confuso.
+
+## Eliminar un worktree
+
+Cuando terminas:
+
+```bash
+git worktree remove ../mi-proyecto-review
+```
+
+Esto elimina el directorio y limpia la referencia interna. Si hay cambios sin commitear, Git se niega:
+
+```
+error: '../mi-proyecto-review' contains modified or untracked files, use --force to override
+```
+
+Si quieres eliminarlo de todas formas:
+
+```bash
+git worktree remove --force ../mi-proyecto-review
+```
+
+Con `--force` le dices a Git "ya sé lo que hago, borra sin preguntar". Git siempre te cree — eso es el problema. Úsalo cuando estés absolutamente seguro de que no hay nada que perder: no bastante seguro, no creo que sí, sino seguro.
+
+## Casos de uso reales
+
+### Revisar un PR sin abandonar tu trabajo
+
+Estás en `feature/dashboard`, horas de trabajo en curso. Llega un PR para revisar. Sin worktrees: stash, cambia de rama, revisa, vuelve, pop, resuelve conflictos. Con worktrees:
+
+```bash
+git worktree add ../review-pr-234 origin/feature/pr-a-revisar
+cd ../review-pr-234
+# Revisas el código, ejecutas los tests, escribes comentarios
+cd ../mi-proyecto
+# Todo sigue exactamente donde lo dejaste
+```
+
+### Hotfix urgente en producción
+
+Estás en `feature/complex-refactor`, dos horas sin commitear. Producción reporta un bug crítico:
+
+```bash
+# Creas el worktree directamente desde main
+git worktree add -b hotfix/critical-login ../hotfix-urgent main
+
+# Arreglas, testas, commiteas y haces push desde ahí
+cd ../hotfix-urgent
+# ...fix, commit, push...
+git push origin hotfix/critical-login
+
+# Tu rama de feature no ha movido un píxel
+cd ../mi-proyecto
+```
+
+Sin stash, sin cambio de rama, sin contexto perdido. El directorio principal sigue en `feature/complex-refactor` exactamente donde lo dejaste.
+
+### Comparar ramas lado a lado
+
+Quieres ver las diferencias entre `main` y `feature/nueva-rama` directamente en el editor:
+
+```bash
+git worktree add ../mi-proyecto-main main
+```
+
+Abre los dos directorios en paralelo. Dos paneles de terminal, o si usas [Neovim](/es/cursos/domina-vim-desde-cero), puedes compararlos directamente con `vimdiff`:
+
+```bash
+vimdiff ../mi-proyecto/src/auth.ts ../mi-proyecto-main/src/auth.ts
+```
+
+Para quien prefiera el ratón y no le importe esperar a que cargue el Electron, `code --diff` hace lo mismo.
+
+## Limpiando worktrees huérfanos
+
+A veces un worktree queda en estado fantasma: borraste el directorio a mano, o eliminaste el branch antes de quitar el worktree. Git no recoge lo que no entiende — se queda con la referencia registrada y te da este error la próxima vez que intentas crear algo con el mismo nombre:
+
+```
+fatal: '/home/fjpalacios/projects/mi-proyecto-old' already exists
+```
+
+Para ver todos los worktrees con detalle, incluidos los problemáticos:
+
+```bash
+git worktree list --porcelain
+```
+
+Para limpiar referencias a worktrees que ya no existen en disco:
+
+```bash
+git worktree prune
+```
+
+## Cuándo no usar worktrees
+
+Los worktrees no reemplazan al stash, no reemplazan a los branches y no son la herramienta para cada cambio de contexto:
+
+- **Si cambias de rama constantemente en el mismo directorio**: los worktrees funcionan mejor cuando cada uno tiene una misión clara y una vida relativamente larga. Para cambios de contexto rápidos y frecuentes, el stash sigue siendo más directo.
+- **Si el repositorio tiene archivos grandes**: cada worktree necesita su propio working tree. El historial se comparte, pero los archivos del directorio no — si el repo pesa, multiplica.
+- **Si solo necesitas ver el estado de otra rama sin trabajar en ella**: `git show branch:ruta/al/fichero` o `git diff main..feature` es suficiente. No necesitas un directorio entero para eso.
+
+---
+
+Los worktrees hacen explícito algo que antes hacíamos de forma implícita y caótica: que a veces necesitas estar en más de un sitio a la vez. `mi-proyecto-2` puede jubilarse. El baile del stash puede jubilarse. Git tenía la infraestructura para esto desde hace tiempo — solo faltaba usarla.
+
+En el siguiente tutorial vemos **Git LFS**: cómo gestionar archivos grandes — binarios, assets, datasets — que no deberían vivir en el historial normal de Git.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/git-worktrees-multiple-working-directories.mdx
+++ b/src/content/tutorials/git-worktrees-multiple-working-directories.mdx
@@ -1,0 +1,179 @@
+---
+title: "Git Worktrees: multiple working directories from a single repository"
+post_slug: "git-worktrees-multiple-working-directories"
+date: "2026-06-15"
+excerpt: "Work on multiple branches simultaneously without switching directories or stashing. Git worktree lets you have as many working environments as you need, all connected to the same repository."
+language: "en"
+categories: ["git"]
+course: "mastering-git-from-scratch"
+order: 34
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "git-worktrees-multiple-directorios"
+---
+
+Somewhere on your machine there's a folder called `my-project-2`. Or `my-project-backup`. Or, if you've been at this long enough, `my-project-FINAL-no-really-this-one`. You don't bring it up in standups. It doesn't live inside the repo, so it's not in `.gitignore` either. It just exists, quietly, at some undisclosed path in your filesystem, doing the job your first manual clone was supposed to handle.
+
+Or you do the [stash](/en/tutorials/stashing-changes-git-stash) dance: `git stash`, switch branch, do the thing, `git stash pop`, untangle whatever the pop left behind — and there's always something — then get back to where you were, slightly less sure of exactly where that was. Every time. It works. Like leaving one screw out of an IKEA shelf works: the thing is standing, but you're not entirely confident it should be.
+
+`git worktree` isn't some obscure command for people who read Git documentation for fun. It's the official answer Git had prepared while everyone was making manual clones and calling it a workflow.
+
+## What a worktree is and why it exists
+
+A clone? A symlink? A renamed copy of the repository? None of those.
+
+A **worktree** is a working directory linked to an existing Git repository. Each worktree has its own active branch, its own working tree and staging area — but they share the same history, the same objects, the same refs. Technical version: multiple working environments connected to the same underlying `.git`. Tuesday morning version: you can have `my-project-hotfix/` and `my-project-feature/` open in your editor at the same time, each on its own branch, and when you commit in one, the other knows.
+
+Think of it as multiple workbenches. One has the feature in progress. One has the urgent hotfix. One has the teammate's branch you need to review. None of them interfere with the others. When you're done with one, you close it and it's gone.
+
+```
+my-project/             ← main directory, branch feature/login
+├── .git/               ← the real .git folder lives here
+└── src/
+
+my-project-hotfix/      ← worktree, branch hotfix/critical-bug
+├── .git                ← file, not folder
+└── src/
+
+my-project-review/      ← worktree, branch fix/auth-issue
+├── .git                ← file, not folder
+└── src/
+```
+
+Secondary worktrees have a `.git` file — not a folder, a plain text file pointing to the main repository. Git handles all the internal plumbing. You don't need to open it, understand it, or think about it; just know that it's what separates a worktree from a clone. All three directories share the disk space for Git history. The only rule: two worktrees can't be on the same branch at the same time.
+
+## Creating your first worktree
+
+The basic command:
+
+```bash
+git worktree add ../my-project-review fix/auth-issue
+```
+
+This creates `../my-project-review` and checks out `fix/auth-issue` there. If the branch doesn't exist yet, create it in the same step:
+
+```bash
+git worktree add -b feature/new-feature ../my-project-feature main
+```
+
+`-b feature/new-feature` creates the branch from `main`. The directory exists, the branch exists, you can work — without touching anything in your current directory.
+
+## Listing all active worktrees
+
+```bash
+git worktree list
+```
+
+```
+/home/fjpalacios/projects/my-project          9f3c2a1 [feature/login]
+/home/fjpalacios/projects/my-project-hotfix   3b7d9e2 [hotfix/critical-bug]
+/home/fjpalacios/projects/my-project-review   8c1f4d3 [fix/auth-issue]
+```
+
+Path, current commit, active branch. Git keeps a record of all worktrees in the repository and shows them here. If you try to check out a branch that's already active in another worktree, Git stops you — not because it's forbidden, but because having the same branch in two places is just confusing.
+
+## Removing a worktree
+
+When you're done:
+
+```bash
+git worktree remove ../my-project-review
+```
+
+This removes the directory and cleans up the internal reference. If there are uncommitted changes, Git refuses:
+
+```
+error: '../my-project-review' contains modified or untracked files, use --force to override
+```
+
+To force it:
+
+```bash
+git worktree remove --force ../my-project-review
+```
+
+`--force` tells Git: "I know what I'm doing, delete without asking." Git always believes you — that's the issue. Use it when you're certain nothing will be lost. Not pretty sure. Not I think so. Certain.
+
+## Real use cases
+
+### Reviewing a PR without leaving your work
+
+You're on `feature/dashboard`, hours in with no commits. A PR comes in for review. Without worktrees: stash, switch, review, come back, pop, untangle. With worktrees:
+
+```bash
+git worktree add ../review-pr-234 origin/feature/pr-to-review
+cd ../review-pr-234
+# Review the code, run the tests, leave comments
+cd ../my-project
+# Everything is exactly where you left it
+```
+
+### Urgent production hotfix
+
+You're on `feature/complex-refactor`, two hours in without committing. Production reports a critical bug:
+
+```bash
+# Create the worktree directly from main
+git worktree add -b hotfix/critical-login ../hotfix-urgent main
+
+# Fix, test, commit, and push from there
+cd ../hotfix-urgent
+# ...fix, commit, push...
+git push origin hotfix/critical-login
+
+# Your feature branch hasn't moved
+cd ../my-project
+```
+
+No stash, no branch switch, no lost context. The main directory stays on `feature/complex-refactor` exactly where you left it.
+
+### Comparing branches side by side
+
+You want to see the differences between `main` and `feature/new-branch` directly in your editor:
+
+```bash
+git worktree add ../my-project-main main
+```
+
+Open both directories in parallel — two terminal panes, or if you're on [Neovim](/en/courses/mastering-vim-from-scratch), diff them directly with `vimdiff`:
+
+```bash
+vimdiff ../my-project/src/auth.ts ../my-project-main/src/auth.ts
+```
+
+For those who prefer a mouse and don't mind the Electron startup tax, `code --diff` does the same.
+
+## Cleaning up orphaned worktrees
+
+Sometimes a worktree ends up in ghost state: you deleted the directory by hand, or removed the branch before the worktree. Git doesn't clean up what it doesn't understand — it keeps the reference registered indefinitely, and throws this error the next time you try to create something with the same name:
+
+```
+fatal: '/home/fjpalacios/projects/my-project-old' already exists
+```
+
+To see all worktrees in detail, including the problematic ones:
+
+```bash
+git worktree list --porcelain
+```
+
+To clean up references to worktrees no longer on disk:
+
+```bash
+git worktree prune
+```
+
+## When not to use worktrees
+
+Worktrees don't replace stash, they don't replace branches, and they're not the tool for every context switch:
+
+- **If you switch branches constantly in the same directory**: worktrees work best when each one has a clear mission and a relatively long life. For fast, frequent context switches, stash is still more direct.
+- **If the repository has large files**: each worktree needs its own working tree. History is shared, but directory contents aren't — if the repo is heavy, multiply accordingly.
+- **If you only need to look at another branch without working on it**: `git show branch:path/to/file` or `git diff main..feature` is enough. You don't need a full directory for that.
+
+---
+
+Worktrees make explicit something that was already happening — chaotically — through manual clones and the stash dance: sometimes you need to be in more than one place at once. `my-project-2` can finally retire. Git had the infrastructure for this all along; it was just waiting for you to use it.
+
+Next tutorial: **Git LFS** — how to manage large files (binaries, assets, datasets) that shouldn't live in your normal Git history.
+
+Never stop coding!


### PR DESCRIPTION
## What

Adds the Git worktrees tutorial in both Spanish and English.

## Content

- **What a worktree is**: Multiple working directories sharing the same `.git` history — no manual clones needed
- **Creating worktrees**: `git worktree add`, creating branches on the fly with `-b`
- **Listing and removing**: `git worktree list`, `git worktree remove`, and `--force` precautions
- **Real use cases**: Reviewing a PR without interrupting current work, urgent hotfixes without stash, comparing branches side by side
- **Orphaned worktrees**: Cleaning references with `git worktree prune`
- **When not to use worktrees**: Practical boundaries and alternatives

## Files

- `src/content/tutorials/git-worktrees-multiple-working-directories.mdx` (EN)
- `src/content/tutorials/git-worktrees-multiple-directorios.mdx` (ES)