### PR TITLE
feat(content): add advanced Python function parameters tutorial with defaults, *args, and **kwargs

### DIFF
--- a/src/content/tutorials/advanced-function-parameters-python.mdx
+++ b/src/content/tutorials/advanced-function-parameters-python.mdx
@@ -1,0 +1,238 @@
+---
+title: "Advanced function parameters in Python: defaults, *args, and **kwargs"
+post_slug: "advanced-function-parameters-python"
+date: "2026-06-19"
+excerpt: "Default parameters, keyword arguments, *args, and **kwargs make your functions flexible. One of them has a trap Python doesn't warn you about before springing it."
+language: "en"
+categories: ["programming"]
+course: "learn-to-code-from-scratch-python"
+order: 12
+cover: "/images/tutorials/cabecera-python-curso.jpg"
+i18n: "parametros-avanzados-funciones-python"
+---
+
+The function you wrote in the previous tutorial had one or two parameters. The one you'll write in six months will have eight. Someone on the team added four without telling anyone, one has a name nobody remembers the origin of, the seventh is a boolean called `flag` whose behavior depends on the value of the parameter before it, and there's a `mode` that "makes sense in context." This isn't a prediction; it's just how software grows.
+
+Python has tools to keep this from becoming a disaster: default parameters, keyword arguments, `*args`, and `**kwargs`. This lesson covers all of them — including why one of them has a trap that's caught more programmers than will admit it.
+
+## Default parameters
+
+A default parameter has a value Python uses when you don't pass an argument for it:
+
+```python
+def greet(name, greeting="Hello"):
+    print(f"{greeting}, {name}")
+
+greet("Alice")               # Hello, Alice
+greet("Bob", "Hey")          # Hey, Bob
+```
+
+`greeting` is optional. If you don't pass it, Python uses `"Hello"`. If you do, Python uses what you send.
+
+**The rule**: default parameters always come after non-default ones. Python needs to know what's required and what's optional, and it figures that out by position.
+
+```python
+def calculate(price, discount=0, tax=0.21):   # ✅
+    base = price - discount
+    return base + (base * tax)
+
+def calculate(discount=0, price, tax=0.21):   # ❌ SyntaxError
+    ...
+```
+
+If you put the default parameter first, Python can't tell whether the first argument you pass is `discount` or `price`. The question makes sense; the answer is a syntax error.
+
+### The trap nobody warns you about
+
+Default values are evaluated **once**, when Python defines the function — not each time you call it. For strings, numbers, and booleans that's fine because they're immutable. For lists and dictionaries, it matters a lot.
+
+```python
+def add_item(item, items=[]):
+    items.append(item)
+    return items
+
+print(add_item("a"))   # ['a']
+print(add_item("b"))   # ['a', 'b']  ← wait
+print(add_item("c"))   # ['a', 'b', 'c']  ← this wasn't the plan
+```
+
+The `[]` in the definition is created once. Every call that doesn't pass `items` shares the exact same object. You're accumulating items across calls even though it looks like you're starting fresh each time.
+
+Like a shared whiteboard in a meeting room: you walk in expecting a blank surface, but the diagrams from the previous meeting are still there. The whiteboard is the list; the diagrams are the elements from previous calls; and "I thought it started fresh" is wrong every time.
+
+The fix:
+
+```python
+def add_item(item, items=None):
+    if items is None:
+        items = []  # New list for each call without an explicit list
+    items.append(item)
+    return items
+```
+
+The rule: **never use a mutable object as a default value** — list, dict, or set. Use `None` and create the object inside the function. No exceptions.
+
+## Positional and keyword arguments
+
+So far you've been passing arguments in order — those are **positional** arguments. Python assigns them by position: first to the first parameter, second to the second, and so on.
+
+With two or three parameters, that's fine:
+
+```python
+def show_user(name, age, city):
+    print(f"{name}, {age}, {city}")
+
+show_user("Alice", 34, "London")
+```
+
+With six:
+
+```python
+create_report(True, "pdf", "en", None, False, "full")
+```
+
+What does that `True` do? And the `False`? Is `None` intentional or did someone forget to pass something? You can't know without reading the function definition. And reading the function definition every time you call something isn't development — it's archaeology.
+
+**Keyword arguments** solve this:
+
+```python
+show_user(name="Alice", age=34, city="London")
+```
+
+Now each value carries its label. You can also change the order:
+
+```python
+show_user(city="London", name="Alice", age=34)
+```
+
+And mix positional and keyword — always with positional first:
+
+```python
+show_user("Alice", city="London", age=34)   # ✅
+show_user(name="Alice", 34, "London")       # ❌ SyntaxError
+```
+
+Why bother? For the day your function has four boolean parameters and the person reading the code six months from now isn't you. `include_signature=True` says what it does. `True` in position four says nothing.
+
+## *args: variable number of positional arguments
+
+What if you need a function that accepts any number of arguments? The `*` before the parameter name tells Python to pack all the extra positional arguments into a **tuple**:
+
+```python
+def add(*args):
+    return sum(args)
+
+print(add(1, 2))              # 3
+print(add(1, 2, 3, 4, 5))    # 15
+print(add())                  # 0
+```
+
+Inside the function, `args` is just a tuple with everything that arrived. The name `args` is convention — the `*` does the work. You could call it `*numbers` or `*values`. In practice, `*args` is what everyone expects to see.
+
+```python
+def inspect(*args):
+    print(type(args))   # <class 'tuple'>
+    print(args)
+
+inspect(10, 20, "hello")
+# <class 'tuple'>
+# (10, 20, 'hello')
+```
+
+You can combine regular parameters with `*args`, as long as `*args` comes after the positional ones:
+
+```python
+def show_list(title, *items):
+    print(f"{title}:")
+    for item in items:
+        print(f"  - {item}")
+
+show_list("Fruits", "apple", "orange", "banana")
+```
+
+```
+Fruits:
+  - apple
+  - orange
+  - banana
+```
+
+Think of `*args` like a function that takes however many pizza toppings you want — you don't hardcode three slots for `topping_1`, `topping_2`, `topping_3`. Whatever shows up goes in.
+
+## **kwargs: variable keyword arguments
+
+`**kwargs` does the same thing as `*args`, but for keyword arguments. Instead of a tuple, Python packs everything into a **dictionary**:
+
+```python
+def configure(**kwargs):
+    for key, value in kwargs.items():
+        print(f"{key}: {value}")
+
+configure(color="blue", size="large", border=True)
+```
+
+```
+color: blue
+size: large
+border: True
+```
+
+Same as `*args`, the name `kwargs` is convention. The `**` is what counts.
+
+`**kwargs` shows up a lot in code that builds or configures objects, in function wrappers, and in generic utilities that don't know in advance what options they'll receive.
+
+Honest warning: `**kwargs` can make your function very flexible or completely opaque. If someone calls `configure(name="test", temperature=37, pizza=True)` and the function accepts it without complaint, there's no way to know from the outside which parameters are actually valid. Use it when the flexibility makes real sense; not as a substitute for thinking through your function's interface. The warning sign: if you're calling `kwargs.get()` in eight different places inside the same function, that function is probably doing too many things.
+
+## Combining everything
+
+You can combine regular parameters, `*args`, and `**kwargs` in one function. The order is always:
+
+1. Regular positional parameters
+2. `*args`
+3. Keyword-only parameters (come after `*args` and can **only** be passed by name)
+4. `**kwargs`
+
+```python
+def log(level, *messages, timestamp=True, **extra):
+    print(f"[{level}] timestamp={timestamp}")
+    for msg in messages:
+        print(f"  {msg}")
+    if extra:
+        print(f"  extra: {extra}")
+
+log("INFO", "Connection established", "Database ready",
+    timestamp=False, user="admin", ip="192.168.1.1")
+```
+
+```
+[INFO] timestamp=False
+  Connection established
+  Database ready
+  extra: {'user': 'admin', 'ip': '192.168.1.1'}
+```
+
+`timestamp` isn't a regular positional parameter or part of `**kwargs` — it sits between `*args` and `**kwargs`, which makes it **keyword-only**: it can only be passed by name, never by position.
+
+## When to use what
+
+- **Default parameters**: when a reasonable value works for most cases. Don't put a default on everything "just in case" — a function where everything is optional has no clear contract.
+- **Keyword arguments**: when the signature has more than three parameters or when the argument types don't make their purpose obvious.
+- ***args**: when you genuinely don't know how many positional arguments will arrive. If you know, list them explicitly — an explicit signature always communicates more than `*args`.
+- ****kwargs**: for wrappers, decorators, and generic configuration utilities. Not as a substitute for thinking through the interface.
+
+## Key concepts from this lesson
+
+- Default parameters always go after required ones.
+- Default values are evaluated once: **never use a mutable object as a default value**.
+- Keyword arguments make code more readable when functions have many parameters.
+- `*args` packs positional arguments into a tuple; `**kwargs` packs keyword arguments into a dictionary.
+- Parameters after `*args` are keyword-only: they cannot be passed by position.
+- The order is: positional → `*args` → keyword-only → `**kwargs`.
+
+---
+
+**💡 Challenge**: Create a function `log(message, level="INFO", *tags, timestamp=True, **extra)`. Call it in several ways: just with `message`, adding `level`, passing extra tags, with `timestamp=False`, and with extra keyword arguments like `user="admin"`. What does it print each time? What happens if you try to pass `timestamp` by position?
+
+Next up: **scope** — how Python decides which variable is visible from where, what happens when a function defines a variable with the same name as one outside it, and why `global` exists even though most of the time you're better off not using it.
+
+Never stop coding!

--- a/src/content/tutorials/parametros-avanzados-funciones-python.mdx
+++ b/src/content/tutorials/parametros-avanzados-funciones-python.mdx
@@ -1,0 +1,238 @@
+---
+title: "Parámetros avanzados en Python: defaults, *args y **kwargs"
+post_slug: "parametros-avanzados-funciones-python"
+date: "2026-06-19"
+excerpt: "Parámetros por defecto, argumentos con nombre, *args y **kwargs hacen tus funciones flexibles. Uno de ellos tiene una trampa que Python no anuncia antes de tenderla."
+language: "es"
+categories: ["programacion"]
+course: "aprende-a-programar-desde-cero-python"
+order: 12
+cover: "/images/tutorials/cabecera-python-curso.jpg"
+i18n: "advanced-function-parameters-python"
+---
+
+La función que escribiste en el tutorial anterior tenía uno o dos parámetros. La que escribirás en seis meses tendrá ocho. Alguien del equipo habrá añadido cuatro sin avisar, uno tiene un nombre que ya nadie recuerda de dónde salió, el séptimo es un booleano llamado `flag` cuyo efecto depende del valor del parámetro anterior, y hay un `mode` que "se entiende por el contexto". No es una predicción; es una ley de la naturaleza del software.
+
+Python ofrece herramientas para que esto no acabe en catástrofe: parámetros con valores por defecto, argumentos con nombre, `*args` y `**kwargs`. En esta lección los verás todos. Y aprenderás por qué uno de ellos tiene una trampa que ha pillado a más programadores de los que admiten.
+
+## Parámetros con valor por defecto
+
+Un parámetro por defecto tiene un valor que Python usa cuando no se le pasa argumento para ese parámetro:
+
+```python
+def saludar(nombre, saludo="Hola"):
+    print(f"{saludo}, {nombre}")
+
+saludar("Ana")               # Hola, Ana
+saludar("Luis", "Buenas")    # Buenas, Luis
+```
+
+El parámetro `saludo` es opcional. Si no lo pasas, Python usa `"Hola"`. Si lo pasas, usa lo que envías.
+
+**Regla de hierro**: los parámetros con valor por defecto siempre van después de los parámetros sin valor por defecto. Python necesita saber qué es obligatorio y qué es opcional, y lo determina por posición.
+
+```python
+def calcular(precio, descuento=0, impuesto=0.21):   # ✅
+    base = precio - descuento
+    return base + (base * impuesto)
+
+def calcular(descuento=0, precio, impuesto=0.21):   # ❌ SyntaxError
+    ...
+```
+
+Si pones el parámetro con default primero, Python no puede saber si el primer argumento que pasas es el `descuento` o el `precio`. La pregunta tiene sentido; la respuesta es un error de sintaxis.
+
+### La trampa que nadie avisa
+
+Los valores por defecto se evalúan **una sola vez**, cuando Python define la función, no cada vez que la llamas. Para `strings`, números y booleanos eso no importa porque son inmutables. Para listas y diccionarios, importa mucho.
+
+```python
+def agregar_elemento(elemento, lista=[]):
+    lista.append(elemento)
+    return lista
+
+print(agregar_elemento("a"))   # ['a']
+print(agregar_elemento("b"))   # ['a', 'b']  ← espera
+print(agregar_elemento("c"))   # ['a', 'b', 'c']  ← esto ya no estaba en el plan
+```
+
+La lista `[]` de la definición se crea una vez. Todas las llamadas que no pasan `lista` comparten exactamente el mismo objeto. Estás acumulando elementos entre llamadas, aunque cada vez parezca que empiezas de cero.
+
+Es como aquella impresora de la oficina que todos usaban y nadie mantenía: cuando llegabas, el papel del trabajo anterior seguía en la bandeja. La bandeja es la lista; los papeles son los elementos de llamadas anteriores; y la pregunta "¿pero yo no lo había dejado vacío?" no tiene respuesta satisfactoria.
+
+La solución correcta:
+
+```python
+def agregar_elemento(elemento, lista=None):
+    if lista is None:
+        lista = []  # New list for each call without an explicit list
+    lista.append(elemento)
+    return lista
+```
+
+La regla práctica: **nunca uses un objeto mutable como valor por defecto** — lista, diccionario o conjunto. Usa `None` y crea el objeto dentro de la función. Sin excepción.
+
+## Argumentos posicionales y con nombre
+
+Hasta ahora has pasado argumentos en orden — eso son argumentos **posicionales**. Python los asigna por posición: el primero al primer parámetro, el segundo al segundo.
+
+Con dos o tres parámetros, todo bien:
+
+```python
+def mostrar_usuario(nombre, edad, ciudad):
+    print(f"{nombre}, {edad} años, {ciudad}")
+
+mostrar_usuario("Ana", 34, "Madrid")
+```
+
+Con seis:
+
+```python
+crear_informe(True, "pdf", "es", None, False, "completo")
+```
+
+¿Qué hace ese `True`? ¿Y el `False`? ¿El `None` es intencional o alguien se olvidó de pasar algo? Sin leer la definición de la función no hay forma de saberlo. Y leer la definición de la función cada vez que llamas a algo no es desarrollo; es arqueología.
+
+Los **argumentos con nombre** resuelven esto:
+
+```python
+mostrar_usuario(nombre="Ana", edad=34, ciudad="Madrid")
+```
+
+Ahora cada valor lleva su etiqueta. Además, puedes cambiar el orden:
+
+```python
+mostrar_usuario(ciudad="Madrid", nombre="Ana", edad=34)
+```
+
+Y mezclar posicionales y con nombre — siempre con los posicionales primero:
+
+```python
+mostrar_usuario("Ana", ciudad="Madrid", edad=34)  # ✅
+mostrar_usuario(nombre="Ana", 34, "Madrid")        # ❌ SyntaxError
+```
+
+¿Por qué molestarse? Para el día en que tu función tenga cuatro parámetros booleanos y quien lea el código en seis meses no seas tú. `incluir_firma=True` dice qué hace. `True` en cuarta posición no dice nada.
+
+## *args: número variable de argumentos posicionales
+
+¿Y si necesitas una función que acepte cualquier cantidad de argumentos? El `*` antes del nombre del parámetro le dice a Python que empaquete todos los argumentos posicionales adicionales en una **tupla**:
+
+```python
+def sumar(*args):
+    return sum(args)
+
+print(sumar(1, 2))              # 3
+print(sumar(1, 2, 3, 4, 5))    # 15
+print(sumar())                  # 0
+```
+
+Dentro de la función, `args` es simplemente una tupla con todo lo que llegó. El nombre `args` es convención — el `*` es lo que hace el trabajo. Podrías llamarlo `*numeros` o `*valores`. En la práctica, `*args` es lo que todo el mundo espera ver.
+
+```python
+def inspeccionar(*args):
+    print(type(args))   # <class 'tuple'>
+    print(args)
+
+inspeccionar(10, 20, "hola")
+# <class 'tuple'>
+# (10, 20, 'hola')
+```
+
+Puedes combinar parámetros normales con `*args`, siempre que `*args` vaya después de los posicionales:
+
+```python
+def mostrar_lista(titulo, *elementos):
+    print(f"{titulo}:")
+    for elemento in elementos:
+        print(f"  - {elemento}")
+
+mostrar_lista("Frutas", "manzana", "naranja", "plátano")
+```
+
+```
+Frutas:
+  - manzana
+  - naranja
+  - plátano
+```
+
+Piensa en `*args` como el cajón de la cocina donde cabe todo lo que no tiene sitio fijo. No decides de antemano cuántas cosas van a entrar — simplemente entran.
+
+## **kwargs: argumentos con nombre variables
+
+`**kwargs` hace lo mismo que `*args`, pero para argumentos con nombre. En lugar de una tupla, Python lo empaqueta en un **diccionario**:
+
+```python
+def configurar(**kwargs):
+    for clave, valor in kwargs.items():
+        print(f"{clave}: {valor}")
+
+configurar(color="azul", tamaño="grande", borde=True)
+```
+
+```
+color: azul
+tamaño: grande
+borde: True
+```
+
+Igual que con `*args`, el nombre `kwargs` es convención. El `**` es lo que cuenta.
+
+`**kwargs` aparece mucho en código que construye o configura objetos, en wrappers de funciones, y en utilidades genéricas que no saben de antemano qué opciones van a recibir.
+
+Una advertencia honesta: `**kwargs` puede hacer tu función muy flexible o completamente opaca. Si alguien llama a `configurar(nombre="test", temperatura=37, pizza=True)` y la función acepta todo sin quejarse, no hay forma de saber desde fuera qué parámetros son realmente válidos. Úsalo cuando la flexibilidad tiene sentido real; no como atajo para no pensar qué acepta tu función. La señal de alarma: si usas `kwargs.get()` en ocho sitios distintos dentro de la misma función, probablemente esa función está haciendo demasiadas cosas.
+
+## Combinando todo
+
+Puedes combinar parámetros normales, `*args` y `**kwargs` en una misma función. El orden siempre es:
+
+1. Parámetros posicionales normales
+2. `*args`
+3. Parámetros solo-keyword (van después de `*args` y **solo** pueden pasarse con nombre)
+4. `**kwargs`
+
+```python
+def registrar(nivel, *mensajes, timestamp=True, **extra):
+    print(f"[{nivel}] timestamp={timestamp}")
+    for msg in mensajes:
+        print(f"  {msg}")
+    if extra:
+        print(f"  extra: {extra}")
+
+registrar("INFO", "Conexión establecida", "Base de datos lista",
+          timestamp=False, usuario="admin", ip="192.168.1.1")
+```
+
+```
+[INFO] timestamp=False
+  Conexión establecida
+  Base de datos lista
+  extra: {'usuario': 'admin', 'ip': '192.168.1.1'}
+```
+
+`timestamp` no es un argumento posicional normal ni parte de `**kwargs` — va entre `*args` y `**kwargs`, lo que lo convierte en **solo-keyword**: solo puede pasarse con nombre, nunca por posición.
+
+## Cuándo usar qué
+
+- **Parámetros por defecto**: cuando un valor razonable aplica en la mayoría de casos. No pongas default en todo "por si acaso" — una función donde todo es opcional es una función sin contrato claro.
+- **Argumentos con nombre**: cuando la firma tiene más de tres parámetros o cuando los tipos de los argumentos no dicen por sí solos qué hace cada uno.
+- ***args**: cuando realmente no sabes cuántos argumentos posicionales van a llegar. Si lo sabes, ponlos explícitamente — una firma explícita siempre comunica más que un `*args`.
+- ****kwargs**: para wrappers, decoradores o funciones de configuración genérica. No como sustituto de pensar la firma.
+
+## Conceptos clave de esta lección
+
+- Los parámetros con valor por defecto van siempre después de los sin valor por defecto.
+- Los valores por defecto se evalúan una sola vez: **nunca uses un objeto mutable como valor por defecto**.
+- Los argumentos con nombre hacen el código más legible cuando la función tiene muchos parámetros.
+- `*args` empaqueta argumentos posicionales en una tupla; `**kwargs` empaqueta argumentos con nombre en un diccionario.
+- Los parámetros que van después de `*args` son solo-keyword: no pueden pasarse por posición.
+- El orden es: posicionales normales → `*args` → solo-keyword → `**kwargs`.
+
+---
+
+**💡 Reto**: Crea una función `registrar(mensaje, nivel="INFO", *tags, timestamp=True, **extra)`. Prueba llamarla de distintas formas: solo con `mensaje`, añadiendo `nivel`, pasando tags extra, con `timestamp=False` y con parámetros adicionales como `usuario="admin"`. ¿Qué imprime en cada caso? ¿Qué pasa si intentas pasar `timestamp` por posición?
+
+En el próximo tutorial veremos el **scope**: cómo Python decide qué variable es visible desde dónde, qué pasa cuando defines una variable dentro de una función con el mismo nombre que una variable exterior, y por qué `global` existe aunque en la mayoría de casos sea mejor idea no usarlo.
+
+¡Nunca dejes de programar!


### PR DESCRIPTION
## What

Adds the advanced function parameters Python tutorial (lesson 12 of the Python course) in both Spanish and English.

## Content

- **Default parameters**: Required vs optional arguments, ordering rules
- **Mutable default trap**: Why `def f(x=[])` accumulates state across calls, how to fix with `None`
- **Positional vs keyword arguments**: Readability, ordering, mixing both
- **`*args`**: Variable positional arguments packed into a tuple, combining with regular parameters
- **`**kwargs`**: Variable keyword arguments packed into a dict, honest warnings about overuse
- **Combining everything**: Positional → `*args` → keyword-only → `**kwargs`
- **When to use what**: Practical guidelines for each parameter type

## Files

- `src/content/tutorials/advanced-function-parameters-python.mdx` (EN)
- `src/content/tutorials/parametros-avanzados-funciones-python.mdx` (ES)
