### PR TITLE
feat(content): add prompts for code generation AI tutorial with scaffold approach, TDD, and review prompts

### DIFF
--- a/src/content/tutorials/prompts-for-code-generation-ai.mdx
+++ b/src/content/tutorials/prompts-for-code-generation-ai.mdx
@@ -1,0 +1,187 @@
+---
+title: "Prompts for Code Generation with AI"
+post_slug: "prompts-for-code-generation-ai"
+date: "2026-06-22"
+excerpt: "Learn to specify before you ask: scaffold approach, TDD with AI, and how to review generated code before trusting it."
+language: "en"
+categories: ["ia"]
+course: "ai-for-developers"
+order: 10
+cover: "/images/tutorials/cabecera-ia-para-programadores-curso.jpg"
+i18n: "prompts-para-generar-codigo-ia"
+---
+
+You type "write a function to manage users" and hit Enter.
+
+The AI comes back with 847 lines. An entity, a repository, a service, a controller, a DTO, a mapper, a validation decorator, and a README explaining the architecture. You wanted to filter by name.
+
+This is what happens when you ask for code without specifying what you actually want: the AI doesn't fill gaps with nothing — it fills them with competence. Impressive, thorough, and completely wrong for your use case.
+
+The problem isn't the AI. It's that "manage users" isn't a specification — it's an open invitation. And without constraints, AI tends to show everything it knows. Like that coworker who, when you ask what time it is, also explains how atomic clocks work.
+
+In the [previous tutorial, you used AI as a learning tutor to understand programming concepts](/en/tutorials/using-ai-to-learn-programming-concepts). Now the goal shifts: instead of asking for explanations, you're asking for code you can actually use. That requires a different way of asking.
+
+## Specification first, code second
+
+The rule is straightforward: the better you describe what you want, the closer the result is to what you wanted.
+
+It sounds obvious. It is, until you see the difference in practice:
+
+```text
+❌ Vague specification:
+"Write a function to process orders"
+
+✅ Concrete specification:
+"Write a Python function process_order() that:
+- Accepts an Order object with fields: id, user_id, items (list
+  of dicts with product_id and quantity), and status
+- Calculates the total by summing price * quantity for each item
+- Returns the Order object with total calculated and status set to 'processed'
+- Raises ValueError if items is empty
+- Raises OrderAlreadyProcessedError if status is already 'processed'
+- Includes full type hints
+- Uses no external dependencies"
+```
+
+Why all the detail? Because "process orders" can mean forty different things depending on the system. The function generated from the vague prompt might work perfectly in a different context than yours.
+
+Isn't the AI supposed to be smart? It is. But smart isn't the same as psychic. Your most capable colleague would also ask three questions before touching the keyboard. The AI can't ask because you already told it to start.
+
+Elements that belong in a solid specification:
+
+- **Name and signature** of the function or module
+- **What it receives** (types, input constraints)
+- **What it returns** (return type, shape of the result)
+- **Error behavior** (which exceptions to raise, when)
+- **Technical constraints** (language version, available libraries, project conventions)
+- **What NOT to do** — sometimes more important than everything else
+
+That last one deserves its own example:
+
+```text
+"Implement without recursion.
+Don't introduce external dependencies.
+Don't use type syntax below Python 3.10.
+Don't generate test code yet — just the function."
+```
+
+Negative constraints save time. Without them, the AI makes decisions that are reasonable from its perspective but may not be from yours. Then you spend ten minutes wondering why there's a `functools.reduce` in a function you thought was simple.
+
+## The scaffold approach: structure first, code second
+
+Asking for code directly is like building a house by starting with the curtains. The curtains look great. Then you discover the windows aren't standard size, the frames don't fit, and someone designed a bathroom with no door.
+
+The scaffold approach works the other way: structure first, then implement piece by piece.
+
+```text
+Prompt 1:
+"Give me the complete file structure for a Flask REST API
+for a todo app. Just the structure: filenames and one line
+describing what each contains. No code yet."
+
+Prompt 2:
+"Now implement models.py with the models you described."
+
+Prompt 3:
+"Implement routes.py connecting to the models from the previous step."
+
+Prompt 4:
+"Write tests for routes.py."
+```
+
+Each step is verifiable before moving forward. If the structure doesn't work for you, you fix it at prompt 1, not at prompt 4 when you already have 200 lines of code that depend on a flawed decision.
+
+There's a non-obvious benefit here too: breaking work into short steps gives the AI more room to reason. A specific, focused prompt consistently outperforms "do everything at once."
+
+A useful variation is a **context block** — a chunk of project context you paste at the start of each important conversation. The AI doesn't remember previous sessions, but it does know everything in the current context. Use that:
+
+```text
+"Project context:
+- Django 5 backend with Django REST Framework
+- PostgreSQL 15, Redis for caching, Celery for async tasks
+- Python 3.12, strict typing with mypy
+- All models follow snake_case, tests with pytest
+- Domain separated into apps: orders/, products/, users/
+
+With this context, implement..."
+```
+
+Once per conversation, at the start. You don't need to repeat it every prompt.
+
+## TDD with AI: tests first
+
+The test-first approach with AI is, arguably, the most honest way to generate code. Not because it's more principled, but because it forces you to specify behavior before seeing the implementation.
+
+The logic: tests are easier to verify than code. You can read three lines of a test and know exactly what's expected. The 40 lines of implementation that make them pass are more opaque.
+
+```text
+Prompt 1:
+"Write failing pytest tests for a function add_user(name, email) that should:
+- Accept a non-empty name and a valid email
+- Raise ValueError if name is empty
+- Raise ValueError if email has invalid format
+- Return a dict with generated id, name, and email
+Don't implement the function yet."
+
+Prompt 2:
+"Now implement add_user() to make these tests pass."
+
+Prompt 3:
+"What edge cases are missing from my tests?"
+```
+
+The third prompt is the most valuable step in the process. The AI typically surfaces scenarios you didn't consider: emails with Unicode characters, names with 500 characters, `None` passed instead of a string, emails with leading spaces. Some will be irrelevant to your use case. Others will be the exact bug you'd have found in production two weeks later.
+
+If you're also working through the [Python from scratch course](/en/courses/learn-to-code-from-scratch-python), this pattern maps naturally to the functions lesson: define the signature, specify behavior through tests, let the implementation come after. It's a way to practice thinking in interfaces before thinking in code.
+
+## The problems with generated code
+
+Generated code works. It compiles, sometimes has tests, the variable names are reasonable. What it doesn't have is context about what happened the last time someone tried something similar in production.
+
+You do.
+
+The most common problems that slip through unnoticed:
+
+**Stale APIs.** The library changed eight months ago and the AI doesn't know. The generated code uses the previous version. It works in development because you have the old version pinned. It breaks on the production server because that one has the new version. The error shows up on a Friday afternoon.
+
+**Hardcoded values.** Database credentials, API tokens, internal service URLs — all in the source code. Like hiding your house key under the welcome mat with a note that says "emergency key." Everybody knows about the welcome mat. So does your git history on GitHub.
+
+**Partial error handling.** The AI handles the cases you described. The ones you didn't mention don't exist to it. If you didn't say what should happen when the external service doesn't respond, there's a silent timeout waiting for its moment in production.
+
+**Security issues.** SQL injection when inputs aren't sanitized correctly. Secrets leaking into logs. Validations that look complete but don't cover every execution path.
+
+**Performance that doesn't scale.** A query that works with 100 records and takes 45 seconds with 50,000. The N+1 that looks innocent until traffic grows and someone messages you at 3 AM.
+
+None of these are the AI's fault. They're a consequence of you having context it doesn't: the project's history, previous architectural decisions, bugs that already happened, the client's security requirements. That knowledge isn't transmitted in a prompt — it gets applied in review.
+
+## The review prompt
+
+Once you have generated code, this prompt catches most issues before they reach production:
+
+```text
+"Review the code you just generated, specifically looking for:
+1. Security vulnerabilities (injection, exposed secrets, input validation)
+2. Performance issues (inefficient queries, unnecessary memory load)
+3. Missing or incomplete error handling
+4. Hardcoded values that should be configurable
+5. Assumptions about the environment that might not hold
+
+For each issue found: describe the problem, explain why it matters,
+and propose the specific fix."
+```
+
+The AI runs through the same checks you'd do in a code review, before you do. And it sometimes catches things you'd have missed. Not always — especially problems that depend on your system's context. The review prompt reduces noise; your judgment as a developer is still the final filter.
+
+## Key concepts from this lesson
+
+- A concrete specification produces concrete code; a vague one produces architecture nobody asked for
+- The scaffold approach (structure → models → routes → tests) avoids rewriting from the middle
+- TDD with AI: write failing tests first, ask for an implementation that passes them, then ask what edge cases you missed
+- Generated code works for the cases you specified — the ones you didn't mention are your responsibility
+- The review prompt is a second pair of eyes before code review, not a replacement for it
+
+---
+
+There's a pattern in all of these approaches: the first response is rarely the final one. The scaffold takes multiple rounds, TDD has three prompts, the review adds another pass. That's not a problem with the process — it's how building code with AI actually works. In the next tutorial, we'll look at exactly that: how to manage the refinement dialogue without losing the thread or ending up with a function that no longer resembles what you asked for in the first place.
+
+Never stop coding!

--- a/src/content/tutorials/prompts-para-generar-codigo-ia.mdx
+++ b/src/content/tutorials/prompts-para-generar-codigo-ia.mdx
@@ -1,0 +1,186 @@
+---
+title: "Prompts para generar código con IA"
+post_slug: "prompts-para-generar-codigo-ia"
+date: "2026-06-22"
+excerpt: "Aprende a especificar antes de pedir: scaffold, TDD con IA y cómo revisar el código generado antes de confiar en él."
+language: "es"
+categories: ["ia"]
+course: "ia-para-programadores"
+order: 10
+cover: "/images/tutorials/cabecera-ia-para-programadores-curso.jpg"
+i18n: "prompts-for-code-generation-ai"
+---
+
+Escribes "escríbeme una función que gestione usuarios" y mandas el mensaje.
+
+La IA devuelve 847 líneas. Una entidad, un repositorio, un servicio, un controlador, un DTO, un mapper, un decorador de validación y un README con el diagrama de arquitectura. Tú querías filtrar por nombre.
+
+Bienvenido al código generado por especificación insuficiente: técnicamente correcto, prácticamente inútil.
+
+El problema no es la IA. Es que "gestione usuarios" no es una especificación: es una invitación abierta. Y la IA, cuando no tiene restricciones, tiende a demostrar todo lo que sabe. Como ese compañero de trabajo que cuando le preguntas la hora te explica también cómo funciona un reloj atómico.
+
+En el [tutorial anterior aprendiste a usar la IA como tutor para entender conceptos](/es/tutoriales/aprender-conceptos-programacion-ia). Ahora el objetivo cambia: ya no queremos que explique, queremos que escriba código que podamos usar. Y eso requiere una forma distinta de pedir.
+
+## La especificación antes del código
+
+La regla es brutalmente simple: cuanto mejor describes lo que quieres, más se parece el resultado a lo que querías.
+
+Suena obvio. Lo es, hasta que ves la diferencia en la práctica:
+
+```text
+❌ Especificación vaga:
+"Escríbeme una función para procesar pedidos"
+
+✅ Especificación concreta:
+"Escríbeme una función process_order() en Python que:
+- Reciba un objeto Order con los campos: id, user_id, items (lista
+  de dicts con product_id y quantity) y status
+- Calcule el total sumando price * quantity por cada item
+- Devuelva el objeto Order con total calculado y status a 'processed'
+- Lance ValueError si items está vacío
+- Lance OrderAlreadyProcessedError si el status ya es 'processed'
+- Incluya type hints completos
+- No use dependencias externas"
+```
+
+¿Por qué tanto detalle? Porque "procesar pedidos" puede significar cuarenta cosas distintas dependiendo del sistema. La función que genera el prompt vago puede funcionar perfectamente en un contexto diferente al tuyo.
+
+¿No se supone que la IA ya es lista? Sí. Pero lista no es lo mismo que telepática. Tu colega más capaz también te haría tres preguntas antes de ponerse a escribir. La IA no puede preguntarte porque ya le dijiste que empezara.
+
+Los elementos que no pueden faltar en una especificación:
+
+- **Nombre y firma** de la función o módulo
+- **Qué recibe** (tipos, restricciones de los inputs)
+- **Qué devuelve** (tipo de retorno, forma del resultado)
+- **Comportamiento en errores** (qué excepciones lanzar, cuándo)
+- **Restricciones técnicas** (versión del lenguaje, librerías disponibles, convenciones del proyecto)
+- **Qué NO hacer** — a veces más importante que todo lo anterior
+
+Ese último punto se merece un ejemplo propio:
+
+```text
+"Implementa sin usar recursión.
+No introduzcas dependencias externas.
+No uses sintaxis de tipos de Python < 3.10.
+No generes código de tests todavía — solo la función."
+```
+
+Las restricciones negativas ahorran tiempo. Si no las escribes, la IA toma decisiones razonables para ella que pueden no serlo para ti. Y luego pasas diez minutos preguntándote por qué hay un `functools.reduce` en una función que creías simple.
+
+## El enfoque scaffold: estructura primero, código después
+
+Pedir código directamente es como construir una casa empezando por las cortinas. Las cortinas quedan bien. Luego descubres que las ventanas no tienen el tamaño estándar, los marcos no coinciden y alguien ha diseñado un baño sin puerta.
+
+El scaffold approach funciona al revés: primero la estructura, luego vas implementando pieza a pieza.
+
+```text
+Prompt 1:
+"Dame la estructura completa de archivos para una API REST en Flask
+para una app de tareas pendientes. Solo la estructura: nombres de
+archivos y qué contiene cada uno en una línea. Sin código todavía."
+
+Prompt 2:
+"Ahora implementa models.py con los modelos que describiste."
+
+Prompt 3:
+"Implementa routes.py conectando con los modelos del paso anterior."
+
+Prompt 4:
+"Escribe los tests para routes.py."
+```
+
+Cada paso es verificable antes de avanzar. Si la estructura no te convence, corriges en el prompt 1 y no en el prompt 4, cuando ya tienes 200 líneas de código que dependen de una decisión equivocada.
+
+Hay un beneficio adicional que no es obvio: dividir el trabajo en pasos cortos le da a la IA más espacio para razonar. El modelo trabaja mejor con un prompt específico y concreto que cuando le pides que lo haga todo de golpe y esperas que salga bien.
+
+Una variación útil es el **context block**: un bloque de contexto del proyecto que pegas al inicio de cada conversación importante. Describe el stack, las convenciones, las restricciones. La IA no recuerda conversaciones anteriores, pero sí todo lo que hay en el contexto actual. Dáselo:
+
+```text
+"Contexto del proyecto:
+- API backend en Django 5 con Django REST Framework
+- PostgreSQL 15, Redis para caché, Celery para tareas async
+- Python 3.12, tipado estricto con mypy
+- Todos los modelos siguen snake_case, tests con pytest
+- Dominio separado en apps: orders/, products/, users/
+
+Con este contexto, implementa..."
+```
+
+Una sola vez al inicio de la conversación. No hace falta repetirlo en cada prompt.
+
+## TDD con IA: empieza por los tests
+
+El enfoque test-first con IA es, posiblemente, la forma más honesta de generar código. No porque sea más purista que el resto, sino porque obliga a especificar el comportamiento antes de ver la implementación.
+
+La lógica: los tests son más fáciles de verificar que el código. Puedes leer tres líneas de test y saber exactamente qué se espera. El código de 40 líneas que los pasa es más opaco.
+
+```text
+Prompt 1:
+"Escribe tests en pytest que fallen para una función add_user(name, email) que:
+- Acepta un nombre no vacío y un email válido
+- Lanza ValueError si el nombre está vacío
+- Lanza ValueError si el email no tiene formato válido
+- Devuelve un dict con id generado, name y email
+No implementes la función todavía."
+
+Prompt 2:
+"Ahora implementa add_user() para que pasen estos tests."
+
+Prompt 3:
+"¿Qué casos de borde faltan en mis tests?"
+```
+
+El tercer prompt es el más valioso del proceso. La IA suele señalar escenarios que no consideraste: emails con caracteres Unicode, nombres con 500 caracteres, inputs de tipo `None` en vez de string, emails con espacios al principio. Algunos serán irrelevantes para tu caso; otros serán el bug que habrías encontrado en producción dos semanas después.
+
+Si estás siguiendo también el [curso de Python desde cero](/es/cursos/aprende-a-programar-desde-cero-python), este patrón encaja muy bien con la lección de funciones: defines la firma, especificas el comportamiento con tests y dejas que la implementación venga después. Es una forma de aprender a pensar en interfaces antes que en código.
+
+## Los problemas del código generado
+
+El código que genera la IA funciona. Compila, a veces tiene tests, los nombres de las variables son razonables. Lo que no tiene es contexto de lo que ocurrió la última vez que alguien hizo algo parecido en producción.
+
+Tú sí.
+
+Los problemas más comunes que pasan desapercibidos:
+
+**APIs obsoletas.** La librería cambió hace ocho meses y la IA no lo sabe. El código generado usa la versión anterior. Funciona en desarrollo porque tienes la versión antigua. Rompe en el servidor de producción porque allí está la nueva. El error aparece un viernes por la tarde.
+
+**Valores hardcodeados.** Credenciales de base de datos, tokens de API, URLs de servicios internas. Todo en el código fuente. Como dejar la llave de casa debajo del felpudo con una nota que pone "llave de emergencia". Todo el mundo sabe lo del felpudo. El historial de commits de GitHub también.
+
+**Error handling parcial.** La IA maneja los casos que describiste. Los que no mencionaste no existen para ella. Si no dijiste qué hacer cuando el servicio externo no responde, hay un timeout silencioso esperando su momento en producción.
+
+**Problemas de seguridad.** SQL injection si los inputs no se sanitizan correctamente. Secrets expuestos en logs. Validaciones que parecen estar pero no cubren todos los paths de ejecución.
+
+**Performance que no escala.** Una query que funciona con 100 registros y tarda 45 segundos con 50.000. El N+1 que parece inocente hasta que el tráfico crece y alguien te escribe a las tres de la mañana.
+
+Ninguno de estos problemas es culpa de la IA. Son consecuencia de que tú tienes contexto que ella no tiene: el historial del proyecto, las decisiones de arquitectura anteriores, los bugs que ya pasaron, los requisitos de seguridad del cliente. Ese conocimiento no se transmite con un prompt; se aplica en la revisión.
+
+## El prompt de revisión
+
+Una vez que tienes el código generado, hay una técnica que atrapa la mayoría de problemas antes de que lleguen a producción:
+
+```text
+"Revisa el código que acabas de generar buscando específicamente:
+1. Vulnerabilidades de seguridad (inyección, secrets expuestos, validación de inputs)
+2. Problemas de rendimiento (queries ineficientes, carga innecesaria en memoria)
+3. Error handling ausente o incompleto
+4. Valores hardcodeados que deberían ser configurables
+5. Supuestos sobre el entorno que podrían no cumplirse
+
+Para cada problema: describe qué es, por qué importa y propón la corrección concreta."
+```
+
+La IA pasa por los mismos checks que harías en un code review, antes de que los hagas tú. Y a veces encuentra cosas que se te habrían pasado. No siempre, especialmente los problemas que dependen del contexto de tu sistema. El prompt de revisión reduce el ruido; tu criterio como desarrollador sigue siendo el filtro final.
+
+## Conceptos clave de esta lección
+
+- Una especificación concreta produce código concreto; una vaga produce arquitectura que nadie pidió
+- El scaffold approach (estructura → modelos → rutas → tests) evita reescribir desde la mitad
+- TDD con IA: escribe los tests primero, pide que los pase después, luego pregunta qué casos de borde faltan
+- El código generado funciona para los casos que especificaste — los que no mencionaste son responsabilidad tuya
+- El prompt de revisión es un segundo par de ojos antes del code review, no un sustituto de él
+
+---
+
+Hay un patrón que aparece en cada uno de estos enfoques: rara vez la primera respuesta es la definitiva. El scaffold pide varias rondas, el TDD tiene tres prompts, la revisión añade otra vuelta. Eso no es un problema del proceso; es cómo funciona construir código con IA. En el próximo tutorial veremos exactamente eso: cómo gestionar el diálogo de refinamiento sin perder el hilo ni acabar con una función que ya no se parece nada a lo que pediste al principio.
+
+¡Nunca dejes de programar!


### PR DESCRIPTION
## What

Adds the prompts for code generation with AI tutorial (lesson 10 of the AI for Developers course) in both Spanish and English.

## Content

- **Specification before code**: Vague vs concrete prompts, negative constraints, six elements of a solid spec
- **Scaffold approach**: Structure first, implement piece by piece, context blocks for project constraints
- **TDD with AI**: Write failing tests first, then ask for the implementation, then ask what edge cases are missing
- **Common problems with generated code**: Stale APIs, hardcoded values, partial error handling, security issues, performance that doesn't scale
- **The review prompt**: AI self-review for security, performance, error handling, and assumptions before human review

## Files

- `src/content/tutorials/prompts-for-code-generation-ai.mdx` (EN)
- `src/content/tutorials/prompts-para-generar-codigo-ia.mdx` (ES)
