### PR TITLE
feat(content): add git switch and restore tutorial with sparse-checkout and maintenance commands

### DIFF
--- a/src/content/tutorials/git-switch-restore-comandos-modernos.mdx
+++ b/src/content/tutorials/git-switch-restore-comandos-modernos.mdx
@@ -1,0 +1,166 @@
+---
+title: "git switch y git restore: el fin del checkout multipropósito"
+post_slug: "git-switch-restore-comandos-modernos"
+date: "2026-06-23"
+excerpt: "git checkout lleva décadas haciendo demasiadas cosas. git switch y git restore llegaron en 2019 para arreglar ese diseño. Ya llevan años siendo estables: es hora de usarlos."
+language: "es"
+categories: ["git"]
+course: "domina-git-desde-cero"
+order: 39
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "git-switch-restore-modern-git-commands"
+---
+
+`git checkout` es la navaja suiza de Git: lleva cinco herramientas distintas dobladas una encima de la otra, y cuando quieres las tijeras, sacas el descorchador. Cambia de rama, crea una rama nueva, restaura un archivo a su última versión, restaura ese mismo archivo a la versión de un commit específico, o va al modo "detached HEAD" si le pasas un hash directamente. Todo eso, dependiendo de los flags que uses. Todos válidos. Todos el mismo comando. Ninguno especialmente obvio sobre lo que hace el otro.
+
+Si alguna vez sentiste que `git checkout` era confuso — que no tenía sentido que la misma palabra sirviera para navegar el historial y para recuperar un archivo que te habías cargado — no era cosa tuya. Era cosa del diseño. Lo suficiente como para que en 2019, con Git 2.23, llegaran dos comandos nuevos para dividirlo: `git switch` para lo de las ramas, `git restore` para lo de los archivos. Llevan años siendo estables. Este tutorial es para entenderlos y empezar a usarlos.
+
+## git switch: cambiar de rama sin ambigüedad
+
+`git switch` hace una cosa: mover el HEAD a otra rama. Sin más. La sintaxis es directa:
+
+```bash
+# Switch to an existing branch
+git switch main
+
+# Create a new branch and switch to it
+git switch -c feature/nueva-funcionalidad
+
+# Create from a specific base
+git switch -c feature/mi-rama origin/develop
+
+# Return to the previous branch
+git switch -
+```
+
+Si eres como yo cuando llevaba años trabajando con Git, tienes `git checkout -b` grabado en la memoria muscular y `git switch -c` te va a parecer redundante las primeras semanas. Pasa. La diferencia no está en lo que hace — está en lo que se niega a hacer: `git switch` no restaura archivos, no va a un commit concreto, no se pone en detached HEAD a menos que se lo pidas explícitamente. Solo cambia de rama. Eso lo hace predecible.
+
+¿Qué pasa si intentas `git switch abc123` para ir a un commit específico? Git no infiere nada: te da un error y te dice que si quieres detached HEAD tienes que pedirlo con `--detach`. Tienes que ser intencional:
+
+```bash
+# You have to mean this
+git switch --detach abc123
+```
+
+Con `git checkout`, llegar al detached HEAD era demasiado fácil — escribías un hash sin pensar y de repente el repositorio estaba en un estado que requería explicar qué era HEAD y por qué estaba flotando sola en el espacio. Con `git switch`, eso no ocurre por accidente.
+
+## git restore: recuperar archivos sin el doble guión misterioso
+
+La forma clásica de descartar cambios en un archivo era `git checkout -- archivo.txt`. El `--` ahí viene de una convención de Unix para separar flags de argumentos — sin él, Git no sabe si le estás pasando una rama o un path. Técnicamente necesario. Prácticamente, uno de esos detalles que llevas años escribiendo sin saber qué está haciendo ahí ese doble guión, y que tampoco nadie para a explicar porque ya lo tiene en el músculo y no se acuerda de que alguna vez no lo tuvo.
+
+`git restore` lo hace explícito:
+
+```bash
+# Discard working directory changes (restore to last committed version)
+git restore archivo.txt
+
+# Restore multiple paths at once
+git restore src/ tests/
+
+# Discard all tracked changes in working directory
+git restore .
+
+# Restore a file to its state at a specific commit
+git restore --source=abc123 archivo.txt
+
+# Unstage a file (move it back from index to working directory)
+git restore --staged archivo.txt
+
+# Unstage and discard working directory changes in one shot
+git restore --staged --worktree archivo.txt
+```
+
+El `--staged` es el que más diferencia hace en el día a día. Antes, sacar un archivo del staging area se hacía con `git reset HEAD archivo.txt` — que funciona, pero que usa la palabra "reset" para una operación que no es un reset, lo cual generaba ese momento de duda antes de ejecutarlo. `git restore --staged` hace lo mismo y dice exactamente lo que hace. Sin momento de duda.
+
+⚠️ `git restore` sin `--staged` descarta los cambios del working directory sin posibilidad de recuperación. No van al reflog porque nunca fueron un commit — simplemente se sobreescriben. Si hay alguna duda, `git stash` antes de `git restore`.
+
+## La tabla de conversión
+
+Para tenerla a mano cuando el músculo aún recuerda el comando viejo:
+
+| Operación | Antes | Ahora |
+|-----------|-------|-------|
+| Cambiar de rama | `git checkout main` | `git switch main` |
+| Crear rama y cambiar | `git checkout -b nueva` | `git switch -c nueva` |
+| Restaurar archivo | `git checkout -- archivo.txt` | `git restore archivo.txt` |
+| Restaurar desde commit | `git checkout abc123 -- archivo` | `git restore --source=abc123 archivo` |
+| Sacar del staging | `git reset HEAD archivo.txt` | `git restore --staged archivo.txt` |
+| Detached HEAD | `git checkout abc123` | `git switch --detach abc123` |
+
+`git checkout` no va a desaparecer — hay demasiados scripts, demasiados tutoriales, demasiada memoria muscular en el mundo como para eliminarlo. Pero si incorporas a alguien nuevo al equipo o empiezas un proyecto, `git switch` y `git restore` son los comandos con los que tiene sentido arrancar. No porque sean modernos, sino porque cada uno hace una sola cosa.
+
+## git sparse-checkout: cuando no necesitas el repositorio completo
+
+En un monorepo con cincuenta packages, lo habitual es trabajar en dos o tres. Descargar los otros cuarenta y siete cada vez no aporta nada excepto tiempo y espacio en disco.
+
+`git sparse-checkout` resuelve eso: permite hacer checkout de solo las carpetas que necesitas, ignorando el resto:
+
+```bash
+# Initialize sparse-checkout (cone mode is the standard)
+git sparse-checkout init --cone
+
+# Specify which directories to include
+git sparse-checkout set packages/mi-app src/shared
+
+# Check what's currently configured
+git sparse-checkout list
+
+# Add more directories without replacing the current set
+git sparse-checkout add packages/otra-lib
+
+# Disable and restore full checkout
+git sparse-checkout disable
+```
+
+El modo `--cone` (Git 2.26) trabaja con directorios completos en lugar de globs arbitrarios, lo que lo hace significativamente más eficiente y predecible. En la práctica es el modo que siempre querrás usar.
+
+Combinado con `--filter` al clonar, añade un nivel más:
+
+```bash
+# Only download metadata; file contents are fetched on demand
+git clone --filter=blob:none --sparse https://github.com/org/monorepo
+cd monorepo
+git sparse-checkout set packages/mi-app
+```
+
+Con `--filter=blob:none`, Git descarga commits y árboles pero no los contenidos de los archivos hasta que los necesita. En un monorepo con años de historia, la diferencia entre esto y un clone completo puede ser de varios minutos. En un pipeline de CI que se ejecuta cien veces al día, esos minutos se convierten en horas.
+
+## git maintenance: el mantenimiento que ocurre mientras trabajas
+
+A medida que crece un repositorio, las operaciones internas de Git se vuelven más lentas: el grafo de commits se recalcula cada vez, los objetos sueltos se acumulan, el índice crece. `git gc` existía para limpiar todo eso, pero requería acordarse de ejecutarlo — o confiar en que Git lo lanzara automáticamente en el momento menos conveniente.
+
+`git maintenance` (Git 2.31) registra tareas periódicas en el scheduler del sistema operativo para mantener el repositorio en buen estado sin interrumpir el trabajo:
+
+```bash
+# Register this repo for background maintenance
+git maintenance start
+
+# Run all maintenance tasks manually
+git maintenance run
+
+# Stop background maintenance for this repo
+git maintenance stop
+```
+
+Con `git maintenance start`, Git registra una tarea en cron (Linux/macOS) o en el Task Scheduler de Windows que ejecuta periódicamente cuatro tareas:
+
+- **commit-graph**: precompila el grafo de commits para que `git log` y `git merge-base` sean más rápidos.
+- **loose-objects**: empaqueta objetos sueltos acumulados desde el último pack.
+- **incremental-repack**: reorganiza los packs de objetos incrementalmente, sin el coste de un `git gc` completo.
+- **prefetch**: descarga objetos del remoto en segundo plano para que el siguiente `git fetch` sea más rápido.
+
+En un repositorio de tamaño normal, el efecto es imperceptible. En uno con varios años de historia y decenas de miles de commits, puede hacer que `git log` y `git status` respondan notablemente mejor sin que hayas cambiado nada en tu flujo de trabajo. Que es, básicamente, la mejor versión de cualquier optimización.
+
+## Conceptos clave de esta lección
+
+- `git switch` reemplaza `git checkout` para cambiar de rama: hace solo eso, y el detached HEAD requiere `--detach` explícito.
+- `git restore` reemplaza `git checkout -- archivo` y `git reset HEAD archivo`: `--staged` saca del index, sin flag descarta cambios del working directory.
+- `git checkout` seguirá funcionando, pero `git switch` y `git restore` son lo que tiene sentido usar y enseñar en proyectos nuevos.
+- `git sparse-checkout --cone` permite hacer checkout de solo parte del repositorio: fundamental en monorepos o repos con mucha historia.
+- `git maintenance start` registra mantenimiento en segundo plano sin coste para el flujo habitual.
+
+---
+
+Con esto cerramos la penúltima lección del curso. En la siguiente — la última — veremos cómo Git encaja dentro de un pipeline de CI/CD: shallow clones para que los builds no descarguen el historial completo, caché de objetos entre ejecuciones, y las operaciones concretas que hacen que Git se comporte bien cuando quien lo ejecuta no es una persona sino un servidor automatizado.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/git-switch-restore-modern-git-commands.mdx
+++ b/src/content/tutorials/git-switch-restore-modern-git-commands.mdx
@@ -1,0 +1,166 @@
+---
+title: "git switch and git restore: the end of the all-purpose checkout"
+post_slug: "git-switch-restore-modern-git-commands"
+date: "2026-06-23"
+excerpt: "git checkout has been doing too many things for too long. git switch and git restore arrived in 2019 to fix that design. They've been stable for years — time to use them."
+language: "en"
+categories: ["git"]
+course: "mastering-git-from-scratch"
+order: 39
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "git-switch-restore-comandos-modernos"
+---
+
+`git checkout` is Git's Swiss Army knife: five different tools folded on top of each other, and when you need the scissors, you pull out the corkscrew. It switches branches, creates new branches, restores files, restores files to a specific commit's version, and drops you into a detached HEAD state if you give it a hash. All valid. All the same command. None of them particularly obvious about what the others do.
+
+If you've ever felt that `git checkout` was confusing — that it made no sense for the same command to handle branch navigation and file recovery — you were right. It wasn't just you. It was the design. Enough so that in 2019, with Git 2.23, two new commands arrived to split it apart: `git switch` for branches, `git restore` for files. They've been stable for years. This tutorial is about understanding them and making the switch.
+
+## git switch: changing branches without ambiguity
+
+`git switch` does one thing: move HEAD to another branch. That's it. The syntax is straightforward:
+
+```bash
+# Switch to an existing branch
+git switch main
+
+# Create a new branch and switch to it
+git switch -c feature/new-functionality
+
+# Create from a specific base
+git switch -c feature/my-branch origin/develop
+
+# Return to the previous branch
+git switch -
+```
+
+If you're like me after years of muscle memory, `git checkout -b` is wired into your left hand and `git switch -c` will feel redundant for the first few weeks. That's normal. The difference isn't in what it does — it's in what it refuses to do: `git switch` can't restore files, can't go to a specific commit, can't enter detached HEAD unless you explicitly ask for it. It switches branches. That's what makes it predictable.
+
+What happens if you try `git switch abc123` to inspect a specific commit? Git doesn't guess: it gives you an error and tells you to use `--detach` if that's what you want. You have to be intentional:
+
+```bash
+# You have to mean this
+git switch --detach abc123
+```
+
+With `git checkout`, ending up in a detached HEAD was too easy — you'd type a hash without thinking and suddenly be in a repository state that required explaining what HEAD was and why it was floating alone in space. With `git switch`, that doesn't happen by accident.
+
+## git restore: recovering files without the mysterious double dash
+
+The classic way to discard changes in a file was `git checkout -- file.txt`. The `--` there comes from a Unix convention for separating flags from arguments — without it, Git can't tell if you're passing a branch name or a path. Technically necessary. Practically, one of those details you've spent years typing without knowing what that double dash is doing there, because nobody stopped to explain it and you already had it in your muscle memory before you thought to ask.
+
+`git restore` makes it explicit:
+
+```bash
+# Discard working directory changes (restore to last committed version)
+git restore file.txt
+
+# Restore multiple paths at once
+git restore src/ tests/
+
+# Discard all tracked changes in working directory
+git restore .
+
+# Restore a file to its state at a specific commit
+git restore --source=abc123 file.txt
+
+# Unstage a file (move it back from index to working directory)
+git restore --staged file.txt
+
+# Unstage and discard working directory changes in one shot
+git restore --staged --worktree file.txt
+```
+
+The `--staged` flag is the one that makes the biggest difference day-to-day. Before, removing a file from the staging area meant `git reset HEAD file.txt` — which works, but uses the word "reset" for something that isn't a reset, which caused that brief hesitation before hitting Enter. `git restore --staged` does the same thing and says exactly what it does. No hesitation required.
+
+⚠️ `git restore` without `--staged` discards working directory changes permanently. They don't go to the reflog because they were never committed — they're just overwritten. If you're not sure, `git stash` before `git restore`.
+
+## The conversion table
+
+For when muscle memory still reaches for the old command:
+
+| Operation | Before | Now |
+|-----------|--------|-----|
+| Switch branch | `git checkout main` | `git switch main` |
+| Create and switch | `git checkout -b new` | `git switch -c new` |
+| Restore file | `git checkout -- file.txt` | `git restore file.txt` |
+| Restore from commit | `git checkout abc123 -- file` | `git restore --source=abc123 file` |
+| Unstage file | `git reset HEAD file.txt` | `git restore --staged file.txt` |
+| Detached HEAD | `git checkout abc123` | `git switch --detach abc123` |
+
+`git checkout` isn't going anywhere — there's too much code, too many scripts, too much muscle memory in the world to remove it. But if you're onboarding someone new or starting a fresh project, `git switch` and `git restore` are the commands worth teaching first. Not because they're modern, but because each one does exactly one thing.
+
+## git sparse-checkout: when you don't need the whole repository
+
+In a monorepo with fifty packages, you're usually working on two or three of them. Downloading the other forty-seven every time gives you nothing except slower clones and wasted disk space.
+
+`git sparse-checkout` solves that: it lets you check out only the directories you need:
+
+```bash
+# Initialize sparse-checkout (cone mode is the standard)
+git sparse-checkout init --cone
+
+# Specify which directories to include
+git sparse-checkout set packages/my-app src/shared
+
+# Check what's currently configured
+git sparse-checkout list
+
+# Add more directories without replacing the current set
+git sparse-checkout add packages/another-lib
+
+# Disable and restore full checkout
+git sparse-checkout disable
+```
+
+Cone mode (Git 2.26) works with whole directories instead of arbitrary globs, which makes it significantly faster and more predictable. It's the mode you'll want to use in practice.
+
+Combined with `--filter` at clone time, it goes even further:
+
+```bash
+# Only download metadata; file contents are fetched on demand
+git clone --filter=blob:none --sparse https://github.com/org/monorepo
+cd monorepo
+git sparse-checkout set packages/my-app
+```
+
+With `--filter=blob:none`, Git downloads commits and trees but defers file contents until they're actually needed. In a monorepo with years of history, the difference between this and a full clone can be several minutes. In a CI pipeline that runs a hundred times a day, those minutes add up fast.
+
+## git maintenance: the work Git does while you're not looking
+
+As a repository grows, Git's internal operations get slower: the commit graph gets recalculated from scratch, loose objects accumulate, the index grows. `git gc` existed to clean all of that up, but it required either remembering to run it manually or trusting Git to trigger it automatically at the most inconvenient moment.
+
+`git maintenance` (Git 2.31) registers periodic background tasks with the operating system's scheduler to keep the repository healthy without interrupting your work:
+
+```bash
+# Register this repo for background maintenance
+git maintenance start
+
+# Run all maintenance tasks manually
+git maintenance run
+
+# Stop background maintenance for this repo
+git maintenance stop
+```
+
+With `git maintenance start`, Git registers a task in cron (Linux/macOS) or Task Scheduler (Windows) that periodically runs four tasks:
+
+- **commit-graph**: precomputes the commit graph so `git log` and `git merge-base` run faster.
+- **loose-objects**: packs loose objects accumulated since the last pack.
+- **incremental-repack**: reorganizes object packs incrementally, without the cost of a full `git gc`.
+- **prefetch**: downloads objects from the remote in the background so the next `git fetch` is faster.
+
+On a normal-sized repository, the effect is imperceptible. On a repository with years of history and tens of thousands of commits, it can make `git log` and `git status` noticeably faster without changing anything about how you work. Which is, essentially, the best version of any optimization.
+
+## Key concepts from this lesson
+
+- `git switch` replaces `git checkout` for changing branches: it does only that, and detached HEAD requires explicit `--detach`.
+- `git restore` replaces `git checkout -- file` and `git reset HEAD file`: `--staged` moves files out of the index, without the flag it discards working directory changes.
+- `git checkout` will keep working, but `git switch` and `git restore` are what makes sense to use and teach in new projects.
+- `git sparse-checkout --cone` lets you check out only part of the repository: essential in monorepos or repos with large histories.
+- `git maintenance start` registers background maintenance with no cost to your normal workflow.
+
+---
+
+This is the second-to-last lesson in the course. In the final tutorial, we'll look at how Git fits into CI/CD pipelines: shallow clones so builds don't download the full commit history, object caching between runs, and the specific operations that make Git behave well when it's being run by an automated server instead of a developer at a terminal.
+
+Never stop coding!


### PR DESCRIPTION
## What

Adds the git switch and restore tutorial (lesson 39 of the Git course) in both Spanish and English.

## Content

- **git switch**: Replaces `git checkout` for branch operations, requires explicit `--detach` for detached HEAD
- **git restore**: Replaces `git checkout -- file` and `git reset HEAD file` with `--staged` and `--worktree` flags
- **Conversion table**: Side-by-side mapping of old vs new commands
- **git sparse-checkout**: Partial checkout of monorepos with `--cone` mode, combined with `--filter=blob:none` for partial clones
- **git maintenance**: Background repository optimization with commit-graph, loose-objects, incremental-repack, and prefetch tasks

## Files

- `src/content/tutorials/git-switch-restore-modern-git-commands.mdx` (EN)
- `src/content/tutorials/git-switch-restore-comandos-modernos.mdx` (ES)
