### PR TITLE
feat(content): add Git in CI/CD pipelines tutorial with shallow clones, caching, and automated deploy

### DIFF
--- a/src/content/tutorials/git-ci-cd-pipelines.mdx
+++ b/src/content/tutorials/git-ci-cd-pipelines.mdx
@@ -1,0 +1,236 @@
+---
+title: "Git in CI/CD pipelines: from commit to automated deploy"
+post_slug: "git-ci-cd-pipelines"
+date: "2026-06-25"
+excerpt: "A CI/CD pipeline starts with a git push. This lesson covers how to configure Git correctly in GitHub Actions and GitLab CI: shallow clones, caching, permissions, and the practices that actually make a difference."
+language: "en"
+categories: ["git"]
+course: "mastering-git-from-scratch"
+order: 40
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "git-pipelines-ci-cd"
+---
+
+The CI runner is the most disoriented machine on the team. It arrives at each run knowing nothing about you: no `.gitconfig`, no custom pager, no commit graph precomputed overnight by `git maintenance`. An empty container that clones the repository, runs what you tell it, and disappears. Like assembling an IKEA shelf from scratch every time you need to put a book on it — the box arrives complete, no memory of the last time, no leftover screw you set aside just in case. If you know what you're doing, you can pre-stage the pieces for the next build. That's what caching is.
+
+This is the final lesson in the course. What we'll cover here is how Git fits inside an automated pipeline: what changes compared to local use, how to configure GitHub Actions and GitLab CI so that Git doesn't become the bottleneck, and which practices keep the integration between code and deployment free of surprises.
+
+## Git in a pipeline: what changes
+
+On your machine, Git has context: your global config, your local history, packed objects, configured remotes. On a CI runner, none of that exists. Each run starts from zero and needs to:
+
+1. Authenticate to clone the repository
+2. Clone (or restore from cache)
+3. Execute what it needs to execute
+4. Optionally push or deploy something
+
+Authentication is what differs most from local use. Locally you use SSH or HTTPS with saved credentials. In CI, platforms inject a temporary token — `GITHUB_TOKEN` in GitHub Actions, `CI_JOB_TOKEN` in GitLab — that has read permissions (and write if you configure it) only for that run. You don't manage credentials manually: the platform handles it.
+
+The clone is where there's usually room for improvement.
+
+## Shallow clones: the first adjustment to make
+
+By default, `git clone` downloads the full repository history. In a project with five years of commits, that can be hundreds of megabytes of objects that the runner will completely ignore — it'll run the tests, generate the build, and forget they ever existed.
+
+The solution is a shallow clone:
+
+```bash
+# Only fetch the last commit
+git clone --depth=1 <url>
+```
+
+In GitHub Actions, the `actions/checkout` action does this by default (`fetch-depth: 1`). In GitLab CI, you configure the `GIT_DEPTH` variable:
+
+```yaml
+# GitHub Actions — default behavior (shallow)
+- uses: actions/checkout@v4
+
+# GitHub Actions — full history when you need it
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+
+# GitLab CI — shallow clone
+variables:
+  GIT_DEPTH: "1"
+
+# GitLab CI — full history
+variables:
+  GIT_DEPTH: "0"
+```
+
+⚠️ Shallow clones have a limitation you'll discover at exactly the wrong moment: if your build runs `git log`, `git describe`, or any comparison with older commits — for version number generation, changelog calculation, or comparing against a base commit in a PR — Git will tell you it doesn't have those commits. The fix is `fetch-depth: 0`. Now you know this before learning it in production.
+
+## Caching: pre-staging the pieces
+
+A pipeline that takes four minutes and runs eighty times a day adds up to over five hours of distributed waiting across the team. Of those five hours, twenty minutes might be `npm install` downloading `node_modules` from scratch on every single run. With caching, that disappears.
+
+CI platforms have built-in caching systems that persist directories between runs — not the container itself, but specific folders you save and restore. The cache key typically includes a hash of the dependency lockfile, so it automatically invalidates when you change a dependency.
+
+### GitHub Actions
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+```
+
+The `key` is built from the hash of `package-lock.json`. If the lockfile hasn't changed, the cache is exactly what the previous build left behind and `npm ci` takes seconds instead of minutes. If it changed — new dependency, updated version — the cache invalidates and rebuilds.
+
+### GitLab CI
+
+```yaml
+stages:
+  - test
+  - deploy
+
+variables:
+  GIT_DEPTH: "1"
+
+test:
+  stage: test
+  image: node:20-slim
+  cache:
+    key: $CI_COMMIT_REF_SLUG
+    paths:
+      - node_modules/
+  script:
+    - npm ci
+    - npm test
+
+deploy:
+  stage: deploy
+  script:
+    - ./deploy.sh
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+```
+
+GitLab CI uses `cache.key` to identify the cache. `$CI_COMMIT_REF_SLUG` is the branch name in a filesystem-safe format — each branch gets its own cache, which prevents one branch from corrupting another's.
+
+## Automated tests on every commit
+
+The whole point of connecting Git to a pipeline is this: every commit gets verified automatically before it reaches main. The standard flow:
+
+1. Developer pushes to a feature branch
+2. The pipeline clones, installs, and runs tests
+3. If tests fail, the PR/MR can't be merged
+4. If they pass, the code can be reviewed and merged with confidence
+
+```yaml
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci
+      - run: npm test
+      - run: npm run lint
+```
+
+Branch protection in GitHub (`Settings → Branches → Require status checks`) makes the pipeline a mandatory condition for merging. Without green tests, the merge button is disabled. Simple in theory, career-saving in practice.
+
+## Automated deploy on merge
+
+The next step is connecting the merge to main with deployment. The most common pattern:
+
+```yaml
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to production
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        run: ./scripts/deploy.sh
+```
+
+The deploy only runs on pushes to `main` — not on PRs, not on feature branches. Secrets (`DEPLOY_KEY`, cloud credentials, access tokens) live in the platform's secrets configuration and get injected as environment variables at runtime. Never in the repository. Never in the code. If you ever see a hardcoded key in a deploy script, that repository has a problem that isn't a CI problem.
+
+## Best practices for Git in CI
+
+Things most people learn the hard way:
+
+**Use `fetch-depth: 0` only when you need it.** Shallow clone is the right default. If a specific step needs full history, add `fetch-depth: 0` to that job only, not everywhere.
+
+**`git fetch --tags` if your build depends on tags.** Shallow clones don't fetch tags by default. If you use `git describe` or generate version numbers from tags, you need an explicit fetch:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+    fetch-tags: true
+```
+
+**Minimum permissions for the token.** `GITHUB_TOKEN` defaults to write permissions on the repository. If your workflow only reads, reduce them:
+
+```yaml
+permissions:
+  contents: read
+```
+
+**Don't cache the `.git` directory.** It might seem like a good idea to skip the clone entirely, but `.git` changes on every run and the cache is almost never valid. What makes sense to cache is your dependencies: `node_modules`, `.pip`, `~/.gradle`.
+
+**The pipeline that works locally and fails in CI has a cause.** Always. It might be an environment variable you assumed was present, a system dependency installed globally on your machine, or — if the runner is `windows-latest` — mixed line endings because `core.autocrlf` isn't consistently configured across the team (the exact setting from the Git configuration lesson). The runner doesn't lie: it runs exactly what you tell it. If it fails there and works locally, local has something implicit that isn't in the repository.
+
+## Key concepts from this lesson
+
+- In CI, each run starts from zero: no local configuration, no previous history, authentication injected by the platform.
+- `fetch-depth: 1` (shallow clone) is the right default; use `fetch-depth: 0` only when you need full history.
+- Cache dependencies by lockfile hash — not the `.git` directory.
+- Secrets go in the platform's secrets configuration, never in the repository.
+- Branch protection + required status checks = merges only happen when tests pass.
+- If the pipeline fails and local works, local has something implicit you haven't declared.
+
+---
+
+Forty lessons. From `git init` in an empty folder to signed commits, worktrees, automated hooks, LFS, submodules, and now pipelines that deploy code without anyone pressing a button. Git is the same tool it was in lesson one. What changed is the size of what you can do with it.
+
+A closing note on who makes it here:
+
+**Arch Linux users** probably had `delta`, `rerere`, and `fsmonitor` configured before this course mentioned them, installed `lazygit` from the AUR before we got to the productivity section, and have been running split panes in the terminal the entire time. They don't need the acknowledgment, but they've earned it.
+
+**Windows users**: same ground covered, with the minor detail that somewhere in these forty lessons there was an unexpected `\r\n` in the history, Git Bash and WSL2 coexist on the same machine, and the question of which one to use is technically still open. Spoiler: WSL2.
+
+**And those who made it here with VS Code, the Source Control panel, and a mouse**: Git is exactly the same underneath the buttons. You now know what happens when you click "Sync." That counts.
+
+What comes next — if the curiosity doesn't stop — is the infrastructure that gives context to all of this. The same `git push` you've just learned to connect to a pipeline can end up updating a Kubernetes cluster, applying a Terraform plan, or notifying a monitoring system that a new version is live. That's exactly what the **DevOps and Platform Engineering** course — coming soon — is about: Linux, networking, CI with Jenkins, Docker, Kubernetes, Terraform, observability, and everything between the code and the server. Git is the mother tool. Now you know how to use it.
+
+Never stop coding!

--- a/src/content/tutorials/git-pipelines-ci-cd.mdx
+++ b/src/content/tutorials/git-pipelines-ci-cd.mdx
@@ -1,0 +1,237 @@
+---
+title: "Git en pipelines de CI/CD: del commit al deploy automático"
+post_slug: "git-pipelines-ci-cd"
+date: "2026-06-25"
+excerpt: "Un pipeline de CI/CD empieza con un git push. Esta lección cubre cómo configurar Git correctamente en GitHub Actions y GitLab CI: shallow clones, caché, permisos y las prácticas que marcan la diferencia."
+language: "es"
+categories: ["git"]
+course: "domina-git-desde-cero"
+order: 40
+cover: "/images/tutorials/cabecera-git.jpg"
+i18n: "git-ci-cd-pipelines"
+---
+
+El runner de CI es la máquina más desorientada del equipo. Llega a cada ejecución sin saber quién eres: sin tu `.gitconfig`, sin el pager que configuraste, sin el grafo de commits que `git maintenance` precalculó durante la noche. Un contenedor vacío que clona el repositorio, ejecuta lo que le pides y desaparece. Como montar la estantería de IKEA de nuevo cada vez que necesitas poner un libro — la caja llega completa, sin memoria de la vez anterior, sin el tornillo extra que guardaste. Si sabes lo que haces, puedes dejar las piezas precolocadas para el siguiente build. A eso se le llama caché.
+
+Esta es la última lección del curso. Lo que veremos aquí es cómo Git encaja dentro de un pipeline automatizado: qué cambia respecto al uso local, cómo configurar GitHub Actions y GitLab CI para que Git no se convierta en el cuello de botella, y qué prácticas hacen que la integración entre código y despliegue funcione sin sorpresas.
+
+## Git en un pipeline: qué cambia
+
+En tu máquina, Git tiene contexto: tu configuración global, tu historial local, los objetos empaquetados, los remotos configurados. En un runner de CI, nada de eso existe. Cada ejecución empieza de cero y necesita:
+
+1. Autenticarse para clonar el repositorio
+2. Clonar (o restaurar desde caché)
+3. Ejecutar lo que tenga que ejecutar
+4. Opcionalmente, hacer `push` o desplegar algo
+
+La autenticación es lo que más difiere. En local usas SSH o HTTPS con credenciales guardadas. En CI, las plataformas inyectan un token temporal — `GITHUB_TOKEN` en GitHub Actions, `CI_JOB_TOKEN` en GitLab — que tiene permisos de lectura (y escritura si la tienes configurada) solo para esa ejecución. No necesitas gestionar credenciales manualmente: la plataforma lo hace.
+
+El clon es donde suele haber margen de mejora.
+
+## Shallow clones: el primer ajuste
+
+Por defecto, `git clone` descarga todo el historial del repositorio. En un proyecto con cinco años de commits, eso puede ser cientos de megas de objetos que el runner va a ignorar completamente — ejecutará los tests, generará el build y se olvidará de ellos para siempre.
+
+La solución es el shallow clone:
+
+```bash
+# Only fetch the last commit
+git clone --depth=1 <url>
+```
+
+En GitHub Actions, la action `actions/checkout` hace esto por defecto (`fetch-depth: 1`). En GitLab CI, configuras la variable `GIT_DEPTH`:
+
+```yaml
+# GitHub Actions — default behavior (shallow)
+- uses: actions/checkout@v4
+
+# GitHub Actions — full history when you need it
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+
+# GitLab CI — shallow clone
+variables:
+  GIT_DEPTH: "1"
+
+# GitLab CI — full history
+variables:
+  GIT_DEPTH: "0"
+```
+
+⚠️ El shallow clone tiene una limitación que descubrirás exactamente cuando no te conviene: si tu build necesita ejecutar `git log`, `git describe`, o cualquier comparación con commits anteriores — para generar números de versión, calcular un changelog, o comparar con un commit base en un PR — Git te dirá que no tiene esos commits. La solución es `fetch-depth: 0`. Ahora lo sabes antes de aprenderlo en producción.
+
+## Caché: dejar las piezas precolocadas
+
+Un pipeline que tarda cuatro minutos y se ejecuta ochenta veces al día suma más de cinco horas de espera distribuidas entre el equipo. De esas cinco horas, veinte minutos pueden ser `npm install` descargando `node_modules` desde cero en cada ejecución. Con caché, eso desaparece.
+
+Las plataformas de CI tienen sistemas de caché integrados que persisten directorios entre ejecuciones — no el contenedor, sino carpetas específicas que guardas y restauras. La clave de la caché suele incluir un hash del fichero de dependencias, para que se invalide automáticamente cuando cambias una dependencia.
+
+### GitHub Actions
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+```
+
+La `key` se construye con el hash del `package-lock.json`. Si el fichero de lock no ha cambiado, la caché es exactamente la del build anterior y `npm ci` tarda segundos en lugar de minutos. Si ha cambiado — nueva dependencia, versión actualizada — la caché se invalida y se reconstruye.
+
+### GitLab CI
+
+```yaml
+stages:
+  - test
+  - deploy
+
+variables:
+  GIT_DEPTH: "1"
+
+test:
+  stage: test
+  image: node:20-slim
+  cache:
+    key: $CI_COMMIT_REF_SLUG
+    paths:
+      - node_modules/
+  script:
+    - npm ci
+    - npm test
+
+deploy:
+  stage: deploy
+  script:
+    - ./deploy.sh
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+```
+
+GitLab CI usa `cache.key` para identificar la caché. `$CI_COMMIT_REF_SLUG` es el nombre de la rama en formato seguro para ficheros — cada rama tiene su propia caché, lo que evita que una rama rompa la de otra.
+
+## Tests automáticos en cada commit
+
+La razón de conectar Git a un pipeline es precisamente esta: que cada commit sea verificado automáticamente antes de llegar a main. El flujo habitual:
+
+1. Developer hace `git push` a una rama de feature
+2. El pipeline clona, instala dependencias y ejecuta tests
+3. Si los tests fallan, el PR/MR no se puede fusionar
+4. Si pasan, el código puede revisarse y mergearse con confianza
+
+```yaml
+# GitHub Actions: block merges when tests fail
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci
+      - run: npm test
+      - run: npm run lint
+```
+
+La branch protection en GitHub (`Settings → Branches → Require status checks`) hace que el pipeline sea condición obligatoria para mergear. Sin tests en verde, el botón de merge está desactivado. Sencillo en teoría, salvavidas en la práctica.
+
+## Deploy automático al fusionar
+
+El paso siguiente es conectar el merge a main con el despliegue. El patrón más habitual:
+
+```yaml
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to production
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        run: ./scripts/deploy.sh
+```
+
+El deploy solo se ejecuta en pushes a `main` — no en PRs, no en ramas de feature. Los secretos (`DEPLOY_KEY`, credenciales de nube, tokens de acceso) se guardan en la configuración de secretos de la plataforma y se inyectan como variables de entorno en tiempo de ejecución. Nunca en el repositorio. Nunca en el código. Si alguna vez ves una clave hardcodeada en un script de deploy, ese repositorio tiene un problema que no es de CI.
+
+## Buenas prácticas de Git en CI
+
+Algunas cosas que la mayoría aprende de la peor manera posible:
+
+**Usa `fetch-depth: 0` solo cuando lo necesitas.** El clone superficial es la opción correcta por defecto. Si tienes un paso que necesita historia completa, añade `fetch-depth: 0` solo en ese job, no en todos.
+
+**`git fetch --tags` si tu build necesita tags.** El shallow clone no descarga tags por defecto. Si usas `git describe` o generas versiones a partir de tags, necesitas un fetch explícito:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0  # or use fetch-tags: true
+    fetch-tags: true
+```
+
+**Permisos mínimos para el token.** `GITHUB_TOKEN` tiene por defecto permisos de escritura en el repositorio. Si tu workflow solo necesita leer, redúcelos:
+
+```yaml
+permissions:
+  contents: read
+```
+
+**No cachés el directorio `.git`.** Puede parecer una buena idea para evitar el clone, pero el directorio `.git` cambia en cada ejecución y la caché casi nunca es válida. Lo que sí tiene sentido cachear son las dependencias (`node_modules`, `.pip`, `~/.gradle`).
+
+**El pipeline que funciona en tu máquina y falla en CI tiene una causa.** Siempre. Puede ser una variable de entorno que asumiste presente, una dependencia de sistema que tienes instalada globalmente, o — si el runner es `windows-latest` — que alguien del equipo usa Linux y el `core.autocrlf` no está configurado de forma consistente y hay saltos de línea mezclados por el repositorio (los que vimos en la lección de configuración de Git). El runner no miente: ejecuta exactamente lo que le dices. Si falla ahí y funciona local, el entorno local tiene algo que no está en el repositorio.
+
+## Conceptos clave de esta lección
+
+- En CI, cada ejecución empieza desde cero: sin configuración local, sin historial previo, con autenticación inyectada por la plataforma.
+- `fetch-depth: 1` (shallow clone) es la opción correcta por defecto; usa `fetch-depth: 0` solo cuando necesitas historia completa.
+- Cachea las dependencias por hash del fichero de lock — no el directorio `.git`.
+- Los secretos van en la configuración de la plataforma, nunca en el repositorio.
+- Branch protection + status checks = el merge solo ocurre cuando los tests pasan.
+- Si el pipeline falla y local funciona, el entorno local tiene algo implícito que no has declarado.
+
+---
+
+Cuarenta lecciones. Desde `git init` en una carpeta vacía hasta commits firmados, worktrees, hooks automatizados, LFS, submódulos y ahora pipelines que despliegan código sin que nadie pulse un botón. Git es la misma herramienta desde el primer tutorial. Lo que cambió es el tamaño de lo que puedes hacer con ella.
+
+Un apunte de salida sobre quién llega hasta aquí:
+
+Los usuarios de **Arch Linux** probablemente ya tenían `delta`, `rerere` y `fsmonitor` configurados antes de que este curso lo sugiriera, instalaron `lazygit` desde el AUR antes de que llegáramos a la sección de productividad, y han estado abriendo splits en el terminal mientras leían. No necesitan el guiño, pero se lo merecen.
+
+Los usuarios de **Windows**: llevan el mismo camino cubierto, con la diferencia de que en algún punto de estas cuarenta lecciones hubo un `\r\n` inesperado en el historial, Git Bash y WSL2 coexisten en el mismo sistema, y la pregunta de cuál usar sigue técnicamente abierta. Spoiler: WSL2.
+
+Y los que llegaron hasta aquí con **VS Code, el panel de Source Control y el ratón**: Git es exactamente el mismo debajo de los botones. Ahora saben lo que ocurre cuando hacen clic en "Sync". Eso cuenta.
+
+Lo que viene después — si la curiosidad no para — es la infraestructura que da contexto a todo esto. El mismo `git push` que acabas de aprender a conectar a un pipeline puede llegar a actualizar un clúster de Kubernetes, aplicar un plan de Terraform o notificar a un sistema de monitorización de que hay una nueva versión en producción. Eso es exactamente de lo que va el curso de **DevOps y Platform Engineering** que arrancará próximamente: Linux, networking, CI con Jenkins, Docker, Kubernetes, Terraform, observabilidad y todo lo que hay entre el código y el servidor. Git es la herramienta madre. Ahora sabes usarla.
+
+¡Nunca dejes de programar!


### PR DESCRIPTION
## What

Adds the Git in CI/CD pipelines tutorial (lesson 40, final lesson of the mastering Git course) in both Spanish and English.

## Content

- **Git in a pipeline**: How CI differs from local use — authentication, tokens, ephemeral runners
- **Shallow clones**: `fetch-depth: 1` as default, when to use `fetch-depth: 0` for full history
- **Caching**: GitHub Actions and GitLab CI examples, lockfile-based cache keys, dependency caching
- **Automated tests**: Branch protection with required status checks on every commit
- **Automated deploy**: Deploy on merge to main, secrets injection, minimum token permissions
- **Best practices**: fetch-tags, permission scoping, not caching `.git`, diagnosing CI/local divergence

## Files

- `src/content/tutorials/git-ci-cd-pipelines.mdx` (EN)
- `src/content/tutorials/git-pipelines-ci-cd.mdx` (ES)
