### PR TITLE
feat(content): add retrospective post on building the Mastering Git from Scratch course

### DIFF
--- a/src/content/posts/lo-que-he-aprendido-curso-git.mdx
+++ b/src/content/posts/lo-que-he-aprendido-curso-git.mdx
@@ -1,0 +1,84 @@
+---
+title: "Lo que he aprendido creando el curso 'Domina Git desde cero'"
+post_slug: "lo-que-he-aprendido-curso-git"
+date: "2026-06-25"
+excerpt: "Nueve años de migraciones, un método que no sabía que tenía, y un curso de Git que empecé sin saber suficiente de Git. Todo tiene sentido visto en perspectiva."
+language: "es"
+categories: ["programacion"]
+cover: ""
+i18n: "what-i-learned-building-a-git-course"
+---
+
+Año 2017. Decidí crear un curso de Git.
+
+No tenía guión. No tenía el temario cerrado. Tenía conocimientos de Git —suficientes para trabajar con él a diario, no necesariamente suficientes para enseñarlo— y unas ganas enormes de devolver a internet lo que internet había hecho por mí. Esa combinación de vocación y carencia pedagógica es la que inicia la mayoría de proyectos interesantes. Y también bastantes desastres. En este caso tardé nueve años en saber en cuál de las dos categorías estaba.
+
+## El método
+
+Para entender cómo llegué a un curso de Git hace falta algo de contexto. Antes del curso estaba el proyecto. Antes del proyecto estaba el problema. Y el problema era simple: quería un sitio desde el cual compartir lo que sabía sobre programación.
+
+Aquí es donde, sin saberlo entonces, empezó a tomar forma lo que con el tiempo he bautizado como el **método de aprendizaje por migración**. La idea es simple: en lugar de crear algo desde cero para aprender algo nuevo, usas un proyecto real que ya existe como excusa. El diseño ya está resuelto, los requisitos son conocidos, lo único que cambia es el stack. No tienes que invertir energía en definir qué construir — solo en cómo construirlo en el nuevo contexto. En el peor de los casos, terminas sabiendo lo mismo que ya sabías pero en otro lenguaje. En el mejor, descubres algo que cambia cómo trabajas.
+
+Lo que no sabía en 2017 es que iba a aplicar ese método unas cuantas veces más.
+
+### Los hitos
+
+**25 de marzo de 2017.** Primer commit. El stack era PHP y MySQL: lo que más dominaba entonces, todo construido desde cero, todo personalizado. Reinventando la rueda con el entusiasmo intacto de quien todavía no sabe el coste de reinventar la rueda.
+
+**8 de julio de 2017.** Me doy cuenta de que para lo que estoy construyendo existe Symfony. Y Symfony resuelve en diez minutos lo que yo llevo semanas construyendo a mano. Primera aplicación del método: paro, migro, aprendo cómo se hacen las cosas con un framework que millones de personas ya han probado.
+
+**18 de octubre de 2017.** El proyecto sale a producción con el nombre de SargantanaCode. Primer post publicado.
+
+**27 de octubre de 2017.** Nace el curso "Domina Git desde cero". ¿Carencia pedagógica? Toda la del mundo. ¿Guión? Ninguno. ¿Conocimiento de Git suficiente para enseñarlo? Esa es la pregunta correcta, y la respuesta honesta es que la sabré años después, cuando mire todo esto en perspectiva. En ese momento solo había ganas, y las ganas a veces son suficiente para empezar.
+
+**2 de mayo de 2018.** SargantanaCode se para. El curso de Git se queda a medias. La idea del curso de programación desde cero tampoco llega a arrancar. El blog personal también frena. Dejé de escribir. Dejé de leer.
+
+*(Spoiler: esto volverá a ocurrir. Más de una vez.)*
+
+**Julio de 2018.** Descubro Ruby gracias a unas katas de código. Y digo descubrir en el sentido literal: Ruby on Rails de fondo, y algo que hacía tiempo que no sentía. Hay lenguajes que aprendes porque los necesitas en el trabajo. Y hay lenguajes que te cambian la forma de ver las cosas.
+
+Ruby fue lo segundo.
+
+Sé que es un lenguaje de nicho. Sé que profesionalmente no he podido usarlo tanto como hubiera querido. Pero si alguna vez tengo que explicar por qué me gusta programar, la respuesta tiene algo de Ruby dentro: su sencillez, su sintaxis que parece escrita para personas, su comunidad, su filosofía. El lenguaje que te hace entender que el código se escribe para que lo lean humanos, no máquinas. Hay lenguajes con los que trabajas. Ruby es uno con el que piensas. Siempre habrá un rinconcito especial ahí.
+
+Hora del método, segunda iteración: migración a Ruby on Rails.
+
+**26 de agosto de 2018.** La migración termina. Primer post del nuevo blog con fuerzas renovadas. Vuelvo con la idea del curso de programación desde cero: ¿con Ruby? ¿con Java? ¿con Python y Java combinados? La respuesta fue ninguna. Por falta de tiempo, por falta de foco, por esa mezcla de motivación y perfeccionismo que tan bien conocemos quienes hemos empezado proyectos que no llegaron a ningún sitio: el curso de programación se quedó en el limbo. El blog se paró. El blog personal también.
+
+*(Sí. Otra vez.)*
+
+El método siguió funcionando para aprender otras cosas: Django, Angular, React, Nuxt, NestJS. Frameworks que han pasado por esta web en distintos momentos. Pero los dos blogs —SargantanaCode y el personal— seguían parados y acumulando deuda técnica. Base de datos que mantener, dependencias que actualizar. Un blog personal con conexión a base de datos es sobreingeniería. Llegué a esa conclusión bastante tarde.
+
+**30 de marzo de 2020.** La solución obvia lleva un tiempo siendo obvia: un Static Site Generator. Sin base de datos, HTML estático, sin nada que mantener. El método, tercera iteración. Pruebo Jekyll (mi Ruby, era obligado), Hugo, Next y Gatsby. Me quedo con Gatsby: comunidad grande, plugins para todo, GraphQL en profundidad, base en React. El proyecto arrancó como CV en código —hasta entonces lo tenía en una herramienta de diseño gráfico, exportando PDFs a mano cada vez que cambiaba algo, que es una forma muy elegante de hacerse daño— y más tarde se extendió al blog.
+
+Con este cambio tomo otra decisión: discontinuar SargantanaCode y migrar todo su contenido aquí. Si me cuesta mantener una web, imagínate dos.
+
+**Diciembre de 2025.** Aparece Astro. TypeScript nativo, componentes sencillos, sin la complejidad que Gatsby fue acumulando con los años. Lo que terminó de convencerme no fue la promesa de Astro — fue el estado en que había quedado Gatsby: una actualización de versión mayor que rompía la compatibilidad con todo lo que tenía escrito. La rama del blog, entera en TypeScript, tenía que migrar a JavaScript para seguir. La parte del CV ya la había pasado a JavaScript a toda prisa por lo mismo. Tirar TypeScript en 2025 para no tener que migrar código es un poco como apagar el antivirus porque ralentiza el ordenador. El método, cuarta iteración.
+
+**Febrero de 2026.** La migración a Astro termina. Es la más limpia de todas. SargantanaCode desaparece —ahora redirige aquí—, el contenido que no valía la pena no se migra, y todo lo que había en SargantanaCode acaba donde tenía que acabar: en esta web. Stack actual: cómodo, rápido, fácil de mantener.
+
+Y sí, he pensado "esta vez me quedo" en todas las iteraciones anteriores. Eso lo sé.
+
+## Lo que no aparece en los commits
+
+Releer los tutoriales de 2017 da un poco de vergüenza ajena. No mucha —están bien, se entienden, son válidos— pero la diferencia entre cómo contaba las cosas entonces y cómo las cuento ahora es tan visible que resulta casi cómica. Y eso, en el fondo, es exactamente lo que tiene que ocurrir.
+
+Desde entonces he mentorizado personas en el trabajo, he seguido aprendiendo, he seguido leyendo. Todo eso cambia cómo explicas algo. Explicas con más criterio sobre qué merece estar y qué no. Con más paciencia para la parte difícil y más brevedad para la parte obvia. Y, sobre todo: dejas de escribir lo que sabes y empiezas a escribir lo que el que no sabe necesita entender. El salto entre esas dos cosas no es pequeño.
+
+Cuando empecé el curso de Git no sabía en qué orden iban a ir las lecciones. Escribía de lo que conocía, en el orden en que me venía. Ahora los cursos existen completos antes de que se publique la primera lección: tienen estructura, tienen dependencias entre temas, tienen una progresión pensada. La diferencia entre los dos enfoques es la diferencia entre compartir y enseñar. Las dos cosas están bien. Solo una escala.
+
+Hay algo que este proceso me enseñó y que no me esperaba: la mejor forma de aprender algo de verdad es tener que explicárselo a otra persona. No lo digo como filosofía de vida —lo digo como observación técnica. Los conceptos que mejor entiendo son los que he tenido que hacer comprensibles para alguien que no los conocía. Ese proceso me ha enseñado más sobre Git que años de usarlo a diario. Y me ha dejado algo más: la certeza de que compartir conocimiento no es opcional cuando sabes que hay alguien al otro lado que lo necesita. Le debo a la comunidad lo que la comunidad me dio cuando empecé. Esta web es parte de esa deuda.
+
+El curso de programación que llevaba en mi cabeza desde 2017 también está aquí ya. Con Python en lugar de Ruby —Ruby es un lenguaje que quiero, pero Python es el que está en los ciclos formativos, en los grados y en los trabajos— y con la estructura que debería haber tenido desde el principio.
+
+¿Que dentro de unos años miraré lo que estoy escribiendo ahora con la misma incredulidad con que miro lo de 2017? Ojalá. Eso significará que sigue habiendo evolución.
+
+---
+
+Lo que he aprendido con este curso va mucho más allá del propio Git: va del método, de cómo contar las cosas para que se entiendan, y de tener que consultar la documentación oficial para explicar bien algo que creía que ya sabía. Esa última parte es la más útil. Siempre hay algo que no sabías que no sabías.
+
+Y no puedo terminar sin nombrar lo que está en el centro de todo esto ahora mismo: la inteligencia artificial. Hay quien dice que esto hace que aprender a programar sea menos necesario. Yo pienso lo contrario. La velocidad no es el problema. El problema es no tener el criterio para saber si la respuesta que te da la IA es correcta, si la arquitectura que propone tiene sentido para tu caso, si el código que te están generando va a ser un problema en seis meses. Eso la IA no lo sabe. Si tú tampoco, tenemos un problema.
+
+Las bases siempre van a estar ahí. Y son más importantes ahora que antes, precisamente porque la herramienta es más potente.
+
+¡Nunca dejes de programar!

--- a/src/content/posts/what-i-learned-building-a-git-course.mdx
+++ b/src/content/posts/what-i-learned-building-a-git-course.mdx
@@ -1,0 +1,84 @@
+---
+title: "What I learned building the 'Mastering Git from Scratch' course"
+post_slug: "what-i-learned-building-a-git-course"
+date: "2026-06-25"
+excerpt: "Nine years of migrations, a method I didn't know I had, and a Git course I started without knowing enough Git. It all makes sense in hindsight."
+language: "en"
+categories: ["programacion"]
+cover: ""
+i18n: "lo-que-he-aprendido-curso-git"
+---
+
+In 2017 I decided to build a Git course.
+
+No outline. No syllabus. I had Git knowledge — enough to use it daily, not necessarily enough to teach it — and a strong urge to give back to the internet that had taught me everything I knew. That combination of genuine motivation and complete pedagogical unpreparedness is what starts most interesting projects. And also most disasters. It took me nine years to figure out which one this was.
+
+## The method
+
+To understand how I ended up with a Git course, some context is needed. Before the course came the project. Before the project came the problem. The problem was simple: I wanted a place to share what I knew about programming.
+
+This is where, without realizing it at the time, something took shape that I've since called the **learning-by-migration method**. The idea is straightforward: instead of building something from scratch to learn something new, you use an existing real project as your excuse. The design is already solved, the requirements are known — the only thing that changes is the stack. You don't need to spend creative energy figuring out what to build, just how to build it in the new context. Worst case: you end up knowing the same things you already knew, just in a different language. Best case: you discover something that changes how you work.
+
+What I didn't know in 2017 is that I'd apply that method several more times.
+
+### The milestones
+
+**March 25, 2017.** First commit. Stack: PHP and MySQL, built entirely from scratch. Reinventing the wheel with the unchecked enthusiasm of someone who hasn't yet learned the cost of reinventing the wheel.
+
+**July 8, 2017.** I discover that Symfony exists. And that Symfony solves in ten minutes what I've been building by hand for weeks. First application of the method: stop, migrate, learn how things are done with a framework that millions of people have already battle-tested.
+
+**October 18, 2017.** The project goes live under the name SargantanaCode. First post published.
+
+**October 27, 2017.** The "Mastering Git from Scratch" course is born. Pedagogical preparation? Zero. Outline? None. Enough Git knowledge to actually teach it? That's the right question, and the honest answer is I'll only know years later, looking back. At the time there were just intentions, and intentions are sometimes enough to get started.
+
+**May 2, 2018.** SargantanaCode goes on pause. The Git course stalls halfway through. The idea for a learn-to-code course from scratch never gets off the ground either. The personal blog also stops. I stopped writing. I stopped reading.
+
+_(Spoiler: this will happen again. More than once.)_
+
+**July 2018.** I discover Ruby through some coding katas. And I mean discover in the real sense — Ruby on Rails in the background, and something I hadn't felt in a while. There are languages you learn because the job requires them. And there are languages that change how you think about code.
+
+Ruby was the second kind.
+
+I know it's a niche language. I know I haven't been able to use it as much professionally as I would have liked. But if I ever have to explain why I enjoy programming, the answer has something of Ruby in it: its simplicity, its syntax that reads like it was written for humans, its community, its philosophy. The language that makes you understand that code is written to be read by people, not machines. Some languages are tools you use. Ruby is one you think in. There will always be a special place for it.
+
+Time for the method, second iteration: migrate everything to Ruby on Rails.
+
+**August 26, 2018.** Migration done. First post on the new blog, energy restored. Back to the learn-to-code course idea: with Ruby? With Java? With Python and Java combined for "the best of both worlds"? The answer was none of the above. Between lack of time, lack of focus, and that particular mix of motivation and perfectionism that keeps projects in permanent draft mode — the course went nowhere. The blog went quiet. The personal blog too.
+
+_(Yeah. Again.)_
+
+The method kept working for learning other things: Django, Angular, React, Nuxt, NestJS. Frameworks that have passed through this site at various points. But both blogs — SargantanaCode and the personal one — were stalled and accumulating technical debt. Database to maintain, dependencies to update. A personal blog with a database connection is overengineering. I arrived at that conclusion somewhat late.
+
+**March 30, 2020.** The obvious solution had been obvious for a while: a Static Site Generator. No database, static HTML, nothing to maintain. The method, third iteration. I tried Jekyll (my Ruby, it was mandatory), Hugo, Next, and Gatsby. I went with Gatsby: large community, plugins for everything, GraphQL in depth, React underneath. The project started as a CV in code — until then I had it in a design tool, manually exporting PDFs every time something changed, which is a very elegant way to waste time — and later expanded to the blog.
+
+With this move came another decision: shut down SargantanaCode and migrate all its content here. If maintaining one site is hard enough, imagine two.
+
+**December 2025.** Astro appears. Native TypeScript, simple components, without the complexity Gatsby had been accumulating over the years. What finally pushed me wasn't Astro's promise — it was Gatsby's state: a major version upgrade that broke compatibility with everything I had written. The entire blog branch, in TypeScript, needed to migrate to JavaScript to keep working. The CV section I'd already rushed to JavaScript for the same reason. Dropping TypeScript in 2025 to avoid migrating code is a bit like turning off your antivirus because it slows your computer down. The method, fourth iteration.
+
+**February 2026.** The Astro migration is done. It's the cleanest one yet. SargantanaCode disappears — it now redirects here — the content that didn't hold up doesn't get migrated, and everything worth keeping from SargantanaCode ends up where it always should have been: this site. Current stack: comfortable, fast, easy to maintain.
+
+And yes, I've thought "this is the last migration" every single time. I know.
+
+## What doesn't show up in commits
+
+Reading the tutorials I wrote in 2017 makes me cringe a little. Not a lot — they're fine, they're clear, they still hold up — but the gap between how I explained things then and how I explain them now is wide enough to be almost funny. And that's exactly how it should be.
+
+Since then I've mentored people at work, kept learning, kept reading. All of that changes how you explain something. You explain with more judgment about what deserves to be there and what doesn't. More patience for the hard parts, more economy with the obvious ones. And, above all: you stop writing what you know and start writing what someone who doesn't know yet needs to understand. The gap between those two things isn't small.
+
+When I started the Git course I had no idea what order the lessons would go in. I wrote about what I knew, in whatever order it came to me. Now courses exist in their entirety before the first lesson is published: structure, topic dependencies, a planned progression. The difference between the two approaches is the difference between sharing and teaching. Both are valid. Only one scales.
+
+Something this process taught me that I didn't expect: the fastest way to genuinely learn something is to have to explain it to someone else. Not as life advice — as a technical observation. The concepts I understand best are the ones I've had to make clear for someone who didn't know them yet. That process has taught me more about Git than years of daily use. And it's left me with something else: the conviction that sharing knowledge isn't optional when you know there's someone on the other end who needs it. I owe the community what the community gave me when I was starting out. This site is part of that debt.
+
+The learn-to-code course that had been living in my head since 2017 is also here now. With Python instead of Ruby — Ruby is a language I love, but Python is the one in vocational training, in university programs, and in job listings — and with the structure it should have had from the beginning.
+
+Will I look back at what I'm writing now with the same bewilderment I feel looking at 2017? I hope so. That would mean the evolution is still happening.
+
+---
+
+What I've learned from building this course goes far beyond Git: it's about the method, about learning to explain things so they land, and about having to read the official docs to explain something well that I thought I already knew. That last one is the most useful. There's always something you didn't know you didn't know.
+
+And I can't wrap this up without addressing what's at the center of everything right now: artificial intelligence. Some people say this makes learning to code less necessary. I think the opposite. Speed isn't the problem. The problem is not having the judgment to know whether the answer the AI gives you is correct, whether the architecture it proposes makes sense for your specific case, whether the code being generated is going to be a problem in six months. The AI doesn't know that. If you don't either, we have a problem.
+
+The fundamentals will always be there. And they matter more now than before, precisely because the tool is more powerful.
+
+Never stop coding!


### PR DESCRIPTION
## What

Adds a retrospective blog post (ES/EN) reflecting on the 9-year journey of building the Mastering Git from Scratch course.

## Content

- **The learning-by-migration method**: Using real projects as excuses to learn new stacks — from PHP to Symfony, Ruby on Rails, Gatsby, and Astro
- **Course evolution**: From writing without a syllabus in 2017 to structured courses in 2026
- **Teaching insights**: The difference between sharing and teaching, explaining for understanding
- **Why fundamentals matter more with AI**: Speed without judgment is dangerous

## Files

- `src/content/posts/what-i-learned-building-a-git-course.mdx` (EN)
- `src/content/posts/lo-que-he-aprendido-curso-git.mdx` (ES)
