### PR TITLE
feat(content): add Docker Compose introduction tutorial with YAML configuration and essential commands

### DIFF
--- a/src/content/tutorials/docker-compose-introduction.mdx
+++ b/src/content/tutorials/docker-compose-introduction.mdx
@@ -1,0 +1,205 @@
+---
+title: "Introduction to Docker Compose: one file, one command"
+post_slug: "docker-compose-introduction"
+date: "2026-06-26"
+excerpt: "Docker Compose turns four `docker run` commands you run from memory into a single declarative file and one command. This is where Docker starts feeling useful on a daily basis."
+language: "en"
+categories: ["docker"]
+course: "mastering-docker-from-scratch"
+order: 13
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "introduccion-docker-compose"
+---
+
+There's a moment where managing Docker manually stops scaling. Not when you add the second container — that one you can keep in your head. It's when you add the third, and the startup order starts to matter, and the API tries to connect to the database before it's ready, and you have four terminal tabs open, and you're running the same four commands from memory in a slightly different order every time.
+
+That moment is when Docker Compose starts making sense.
+
+Instead of remembering which flags you passed to Postgres last week, you describe the entire stack in a single `docker-compose.yml` and run one command. The file lives in your repository. The next person who clones it runs `docker compose up -d` and gets the same environment you have. No terminal history, no sticky notes, no "I have the command somewhere".
+
+## What is Docker Compose?
+
+Docker Compose is a tool for defining and running multi-container applications. You describe your services, their relationships, and their configuration in a YAML file. Compose handles creating the network, starting services in the right order, and managing their lifecycle together.
+
+The approach is declarative: you describe _what_ your stack looks like, not the step-by-step _how_ of starting it.
+
+Here's what running a database, a cache, and an API looked like before Compose:
+
+```bash
+docker network create myapp-network
+
+docker run -d --name db --network myapp-network \
+  -e POSTGRES_PASSWORD=secret postgres
+
+docker run -d --name redis --network myapp-network redis
+
+docker run -d --name api --network myapp-network \
+  -p 3000:3000 -e DATABASE_URL=postgresql://db:5432 myapp-api
+```
+
+Four commands. In the right order. With the exact flags. On the right network. And that's three services — not the twelve you'll have in production.
+
+With Compose:
+
+```yaml
+# docker-compose.yml
+services:
+  db:
+    image: postgres
+    environment:
+      POSTGRES_PASSWORD: secret
+
+  redis:
+    image: redis
+
+  api:
+    image: myapp-api
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: postgresql://db:5432
+    depends_on:
+      - db
+      - redis
+```
+
+```bash
+docker compose up -d
+```
+
+One file. One command.
+
+## Installation
+
+Docker Compose v2 ships with Docker Desktop on macOS and Windows. On Linux, it depends on how you installed Docker.
+
+Check if you already have it:
+
+```bash
+docker compose version
+```
+
+If that returns `Docker Compose version 5.1.4`, you're set. If it returns an error, or you have the old `docker-compose` binary (with a hyphen — the v1 Python tool), install the modern version:
+
+```bash
+# macOS and Linux (Homebrew)
+brew install docker-compose
+
+# Ubuntu / Debian
+apt install docker-compose-plugin
+
+# Arch Linux
+pacman -S docker-compose
+```
+
+The modern command is `docker compose` (space, no hyphen). v1 was a separate Python binary, v2 is an official plugin integrated into the Docker CLI. If you installed Docker in 2023 or later, you already have v2.
+
+## Your first docker-compose.yml
+
+The `docker-compose.yml` has three top-level sections:
+
+```yaml
+services: # The containers that make up your application
+volumes: # Named persistent storage
+networks: # Custom networks (optional if the default is enough)
+```
+
+A realistic example — a Node.js API with a Postgres database:
+
+```yaml
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: myapp
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: myapp
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+  api:
+    build: ./api # Build from the Dockerfile in ./api
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: postgresql://myapp:secret@db:5432/myapp
+    depends_on:
+      - db
+
+volumes:
+  db-data:
+```
+
+A few things worth noting:
+
+- `image: postgres:16-alpine` pulls a public image, same as `docker run`.
+- `build: ./api` builds the image from that directory's Dockerfile. No separate `docker build` step needed.
+- In `DATABASE_URL`, the host is `db` — the service name. Compose creates a default network where services resolve each other by name automatically.
+- `db-data` under `volumes:` declares a named volume that Docker manages. Postgres data persists across `docker compose down`. The volume stays until you explicitly remove it.
+
+The file belongs at the root of your project, versioned alongside your code. If you're using [Git](/en/courses/mastering-git-from-scratch), `docker-compose.yml` is just another configuration file — and it's exactly what eliminates the mental overhead of remembering how to start the project.
+
+## Essential commands
+
+These cover the vast majority of what you'll actually need:
+
+```bash
+# Start all services in the background
+docker compose up -d
+
+# Start and rebuild images that have a Dockerfile
+docker compose up -d --build
+
+# Stop containers without removing them
+docker compose stop
+
+# Stop and remove containers + networks (volumes intact)
+docker compose down
+
+# Stop and remove everything, including named volumes
+docker compose down -v
+
+# Show running services and their status
+docker compose ps
+
+# Show logs from all services
+docker compose logs
+
+# Follow logs from a specific service
+docker compose logs -f api
+
+# Run a command inside a running service
+docker compose exec api sh
+docker compose exec db psql -U myapp
+```
+
+The distinction between `stop` and `down`: `stop` halts containers but keeps them, `down` removes them. Named volumes survive `down` — they only get removed if you pass `-v`. Worth knowing before you accidentally wipe a local database.
+
+## depends_on: startup ordering
+
+Without `depends_on`, Compose starts all services roughly in parallel. That means your API can try to connect to Postgres while Postgres is still initializing — which, depending on how patient your connection retry logic is, will either work on the third attempt or fail immediately with a confusing error.
+
+```yaml
+services:
+  db:
+    image: postgres:16-alpine
+
+  api:
+    build: ./api
+    depends_on:
+      - db # Wait for db container to be running before starting api
+```
+
+Here's the nuance worth understanding upfront: `depends_on` waits for the _container_ to be running, not for the _service_ to be ready. The Postgres container can be up and running while Postgres itself is still writing its initial data directory. From Docker's perspective, started. From Postgres's perspective, not yet accepting connections.
+
+The proper solution — waiting until the service is genuinely healthy — uses health checks with `condition: service_healthy`. That's the topic for the next lesson, along with the full `docker-compose.yml` structure.
+
+---
+
+You now have everything needed to run a real development stack with Docker Compose: a declarative file, the commands to manage it, and the basic dependency model. The next lesson covers the complete `docker-compose.yml` structure — environment variables from files, health checks, restart policies, and how to split development and production configuration in the same project.
+
+Never stop coding!
+
+---
+
+**💡 Challenge**: Write a `docker-compose.yml` with three services: Postgres, Redis, and any image you're familiar with. Start the stack with `docker compose up -d`, verify all three services show `Up` in `docker compose ps`, then follow the combined logs with `docker compose logs -f`. When you're done, bring everything down with `docker compose down` and confirm `docker compose ps` shows nothing running.

--- a/src/content/tutorials/introduccion-docker-compose.mdx
+++ b/src/content/tutorials/introduccion-docker-compose.mdx
@@ -1,0 +1,205 @@
+---
+title: "Introducción a Docker Compose: un solo `docker compose up`"
+post_slug: "introduccion-docker-compose"
+date: "2026-06-26"
+excerpt: "Docker Compose convierte cuatro `docker run` que ejecutas por memoria en un único fichero declarativo y un solo comando. Aquí empieza el módulo que hace que Docker sea realmente útil en el día a día."
+language: "es"
+categories: ["docker"]
+course: "domina-docker-desde-cero"
+order: 13
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "docker-compose-introduction"
+---
+
+En algún punto del viaje con Docker, la mayoría acaba con un fichero `commands.txt` en el escritorio. O con un bloque de comentarios al principio de un README que nadie más que tú va a leer. Dentro: cuatro `docker run` distintos, en el orden correcto, con las variables de entorno exactas, en la red adecuada, con los puertos bien mapeados.
+
+Funciona. Como funciona guardar los pasos de instalación en un mensaje de Slack que nadie más tiene: el proyecto arranca en tu máquina, pero con una sensación vaga de que en cuanto alguien nuevo pregunte «¿cómo lo levanto yo?», la respuesta va a ser «tengo el comando por ahí».
+
+Docker Compose es la solución a ese fichero. En lugar de recordar qué flags le pusiste a Postgres la semana pasada, describes todo el stack en un único `docker-compose.yml` y lo arrancas con un solo comando.
+
+## ¿Qué es Docker Compose?
+
+Docker Compose es una herramienta para definir y gestionar aplicaciones multi-contenedor. En lugar de lanzar cada contenedor por separado con sus redes, volúmenes y variables de entorno, describes todo en un fichero YAML y Compose se encarga del resto: crear las redes, arrancar los servicios en orden, gestionar el ciclo de vida conjunto.
+
+La idea es declarativa. No describes *cómo* arrancar los servicios paso a paso, sino *qué* servicios existen y cómo se relacionan.
+
+Antes de Compose, arrancar un stack de desarrollo con base de datos, caché y API requería algo así:
+
+```bash
+docker network create myapp-network
+
+docker run -d --name db --network myapp-network \
+  -e POSTGRES_PASSWORD=secret postgres
+
+docker run -d --name redis --network myapp-network redis
+
+docker run -d --name api --network myapp-network \
+  -p 3000:3000 -e DATABASE_URL=postgresql://db:5432 myapp-api
+```
+
+¿Y si el `db` tarda en inicializar? ¿Y si te olvidaste de añadir `--restart unless-stopped`? ¿Y si dentro de tres semanas no recuerdas en qué red lo pusiste?
+
+Con Compose:
+
+```yaml
+# docker-compose.yml
+services:
+  db:
+    image: postgres
+    environment:
+      POSTGRES_PASSWORD: secret
+
+  redis:
+    image: redis
+
+  api:
+    image: myapp-api
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: postgresql://db:5432
+    depends_on:
+      - db
+      - redis
+```
+
+```bash
+docker compose up -d
+```
+
+Un fichero. Un comando. El mismo stack.
+
+## Instalación
+
+Docker Compose v2 viene integrado con Docker Desktop en macOS y Windows. En Linux, depende de cómo hayas instalado Docker.
+
+Para verificar:
+
+```bash
+docker compose version
+```
+
+Si el comando existe y devuelve algo parecido a `Docker Compose version 5.1.4`, ya lo tienes. Si devuelve un error, o tienes instalado el antiguo `docker-compose` (con guión), instala la versión moderna:
+
+```bash
+# macOS y Linux (Homebrew)
+brew install docker-compose
+
+# Ubuntu / Debian
+apt install docker-compose-plugin
+
+# Arch Linux
+pacman -S docker-compose
+```
+
+Una aclaración que ahorra confusión: el comando moderno es `docker compose` (espacio, sin guión). El antiguo era `docker-compose` (con guión). No son lo mismo — v1 era un binario separado escrito en Python, v2 es un plugin oficial integrado en el CLI de Docker. Si tienes Docker instalado desde 2023, ya tienes v2. Úsalo.
+
+## Tu primer docker-compose.yml
+
+El corazón de Compose es el fichero `docker-compose.yml`. Tiene tres secciones principales:
+
+```yaml
+services:    # Los contenedores que forman tu aplicación
+volumes:     # Almacenamiento persistente con nombre
+networks:    # Redes personalizadas (opcionales si no necesitas aislamiento explícito)
+```
+
+Un ejemplo realista: una API de Node.js con Postgres.
+
+```yaml
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: myapp
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: myapp
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+  api:
+    build: ./api          # Construye desde el Dockerfile en ./api
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: postgresql://myapp:secret@db:5432/myapp
+    depends_on:
+      - db
+
+volumes:
+  db-data:
+```
+
+Algunas cosas que vale la pena señalar:
+
+- `image: postgres:16-alpine` usa una imagen pública, igual que en `docker run`.
+- `build: ./api` construye la imagen desde el Dockerfile de ese directorio. No necesitas hacer `docker build` por separado.
+- En `DATABASE_URL`, el host es `db` — el nombre del servicio. Compose crea una red por defecto y los servicios se resuelven entre sí por nombre automáticamente.
+- `db-data` en `volumes:` declara un volumen con nombre que Docker gestiona. Los datos de Postgres persisten aunque hagas `docker compose down`.
+
+El fichero va en la raíz del proyecto, junto al código. Si estás usando [Git](/es/cursos/domina-git-desde-cero), se versiona igual que cualquier otro fichero de configuración — y es exactamente lo que hace que el `commands.txt` del principio desaparezca para siempre.
+
+## Comandos esenciales
+
+Estos son los que vas a usar el 90% del tiempo:
+
+```bash
+# Arranca todos los servicios (en segundo plano)
+docker compose up -d
+
+# Arranca reconstruyendo las imágenes que tengan Dockerfile
+docker compose up -d --build
+
+# Para los contenedores (sin eliminarlos)
+docker compose stop
+
+# Para y elimina contenedores + redes (volúmenes intactos)
+docker compose down
+
+# Para, elimina contenedores, redes y volúmenes
+docker compose down -v
+
+# Estado de los servicios
+docker compose ps
+
+# Logs de todos los servicios
+docker compose logs
+
+# Seguir los logs de un servicio concreto
+docker compose logs -f api
+
+# Ejecutar un comando dentro de un servicio
+docker compose exec api sh
+docker compose exec db psql -U myapp
+```
+
+La diferencia entre `stop` y `down` importa: `stop` para los contenedores pero los conserva, `down` los elimina. Si no quieres perder datos, usa volúmenes con nombre como el `db-data` del ejemplo — `down` no los toca a menos que añadas `-v`. Con `-v` sí.
+
+## depends_on: el orden de arranque
+
+Por defecto, Docker Compose arranca todos los servicios más o menos a la vez. Sin `depends_on`, tu API puede intentar conectarse a Postgres mientras la base de datos todavía está inicializando su directorio de datos.
+
+```yaml
+services:
+  db:
+    image: postgres:16-alpine
+
+  api:
+    build: ./api
+    depends_on:
+      - db    # Espera a que el contenedor de db esté arrancado
+```
+
+Hay una distinción que conviene entender desde el principio: `depends_on` garantiza el *orden de arranque*, no que el servicio esté *listo*. El contenedor de Postgres puede estar corriendo y Docker Compose lo considerará "arrancado", pero Postgres puede seguir inicializando internamente y todavía no aceptar conexiones.
+
+Para esperar a que un servicio esté verdaderamente operativo se usan health checks con `condition: service_healthy`, que es el tema de la siguiente lección junto con el resto de las opciones del `docker-compose.yml`.
+
+---
+
+Con esto tienes lo esencial para arrancar cualquier stack de desarrollo: un fichero que describe los servicios, los comandos para gestionarlos, y la lógica básica de dependencias. La siguiente lección profundiza en la estructura completa del `docker-compose.yml`: variables de entorno desde fichero, health checks, políticas de restart, y cómo separar la configuración de desarrollo de la de producción en un mismo proyecto.
+
+¡Nunca dejes de programar!
+
+---
+
+**💡 Reto**: Escribe un `docker-compose.yml` con tres servicios: Postgres, Redis y cualquier imagen que conozcas. Arranca la stack con `docker compose up -d`, verifica que los tres servicios están en estado `Up` con `docker compose ps`, y prueba `docker compose logs -f` para ver la salida conjunta. Cuando hayas terminado, para todo con `docker compose down` y comprueba que `docker compose ps` no muestra nada.


### PR DESCRIPTION
## What

Adds the Docker Compose introduction tutorial (lesson 13, first lesson of the Docker Compose module) in both Spanish and English.

## Content

- **What is Docker Compose**: Multi-container applications with declarative YAML — replacing manual `docker run` commands
- **Installation**: v1 vs v2 (`docker-compose` vs `docker compose`), platform-specific instructions
- **Your first docker-compose.yml**: Three sections (`services`, `volumes`, `networks`), Node.js API + Postgres example
- **Essential commands**: `up -d`, `stop`, `down`, `ps`, `logs`, `exec` — and the difference between `stop` and `down -v`
- **depends_on**: Container startup ordering, the nuance between "container running" and "service ready"

## Files

- `src/content/tutorials/docker-compose-introduction.mdx` (EN)
- `src/content/tutorials/introduccion-docker-compose.mdx` (ES)
