### PR TITLE
feat(content): add Vim marks and jumps tutorial with jump list, changelist, and special jumps

### DIFF
--- a/src/content/tutorials/marks-and-jumps-vim.mdx
+++ b/src/content/tutorials/marks-and-jumps-vim.mdx
@@ -1,0 +1,200 @@
+---
+title: "Marks and jumps in Vim: navigate without losing the thread"
+post_slug: "marks-and-jumps-vim"
+date: "2026-06-30"
+excerpt: "Learn how to use marks, the jump list, and the changelist in Vim to move between positions without losing your place, and how to get real mileage out of gf, gd, and %."
+language: "en"
+categories: ["vim"]
+course: "mastering-vim-from-scratch"
+order: 8
+cover: "/images/tutorials/cabecera-vim-curso.jpg"
+i18n: "marks-y-saltos-vim"
+---
+
+You're editing a function at line 347. Before finishing, you need to check how another function works. You jump with `/`, get there, read it, realize you also need to see a constant you defined near the top. You head up there. When you try to get back to line 347 — you can't find it. You search for the function name, land close, move around a bit. You pick up the thread again. Now you need to check one more thing in another file.
+
+This isn't editing anymore. This is sightseeing.
+
+Vim has a full system for remembering where you've been: marks for manually saving positions, a jump list for the automatic history of your movements, and a changelist for the spots where you made edits. Once you work these into your flow, "where was I?" stops being a question.
+
+## Marks: leaving a signal before you go
+
+A mark is a saved position. To create one, use `m` followed by a letter:
+
+```vim
+ma
+```
+
+That saves your current position under the key `a`. You can use any lowercase letter (a-z). Now move wherever you need to — another function, another section, another file. To return exactly where you were, use backtick followed by the letter:
+
+```vim
+`a
+```
+
+Cursor back to that exact line and column.
+
+There's also the apostrophe version:
+
+```vim
+'a
+```
+
+The difference: `` `a `` (backtick) jumps to the exact position — line **and** column. `'a` (apostrophe) jumps to the line, but to the first non-blank character. It's the difference between remembering "it was in the third drawer, under the old batteries, in the right corner" versus just "the third drawer." Both work. One is more precise.
+
+Which one to use? Backtick. Almost always. Unless you specifically need the first character of the line, backtick puts you back exactly where you left the cursor.
+
+Marks are movements too, which means they compose with [Normal mode grammar](/en/tutorials/normal-mode-power-of-vim):
+
+```vim
+d`a    " delete from cursor to mark a
+y'b    " yank from cursor to the line of mark b
+```
+
+Vim gives you 26 local marks (a-z) and 26 global ones (A-Z) — fifty-two total. Exactly the number that makes you think you need a naming convention and maybe a spreadsheet to track them all. What you'll actually use is two or three: `ma` to mark where you jumped from, `mb` for something you need to check later, and `ms` for that other thing you've been putting off. Always the same two or three.
+
+## Global marks: across files
+
+Uppercase letters (A-Z) are **global** marks: they work across files and persist between Vim sessions.
+
+```vim
+mA
+```
+
+That saves the current position under `A`. Tomorrow, after closing and reopening Vim, `` `A `` takes you right back there — opening the file if needed.
+
+Useful when you're constantly jumping between two or three files: `mA` in the config file, `mB` in the routes file, `mC` in the main entry point. You jump between them without searching for anything.
+
+Honest limitation: only one slot per letter. If you use `mA` in a different file, the previous `A` is gone. Fine with three files; not the right tool if you're trying to build a full project index with 26 active entries. For navigating many files, Vim has better tools you'll see later in the course.
+
+## Automatic marks: the ones Vim sets for you
+
+Vim also saves certain positions automatically. You don't have to do anything — they're already there when you need them.
+
+| Mark | What it stores |
+| ---- | -------------- |
+| `` `. `` | Position of the last change in the file |
+| `` `^ `` | Position where you left Insert mode last time |
+| `` `[ `` | Start of the last yanked or changed text |
+| `` `] `` | End of the last yanked or changed text |
+| `` `< `` | Start of the last visual selection |
+| `` `> `` | End of the last visual selection |
+
+The most useful one day-to-day: `` `. `` jumps to the last place you made a change. No setup, no thinking. `` `. `` and you're there.
+
+Then there's `''` (two apostrophes), or ` `` ` (two backticks) for the exact-position version. Both store where you were **before your last big jump** — a search, `gg`, `G`, jumping to a mark. It's the retroactive "take me back to the start" command. You don't activate it in advance; Vim records it automatically on every large jump.
+
+To see all active marks at any point:
+
+```vim
+:marks
+```
+
+It shows a table with name, line, column, and the text at that line. Useful when you've been working for a while and can't remember which mark points where — which is exactly when you need it.
+
+## The jump list: the editor's history
+
+Beyond manual marks, Vim keeps an automatic position history called the **jump list**. Every large jump — searching with `/`, going to a mark, `gg`, `G`, jumping to a definition — gets recorded.
+
+To navigate that history:
+
+```vim
+Ctrl+o    " go back (older jump)
+Ctrl+i    " go forward (newer jump)
+```
+
+`Ctrl+o` is your browser's back button, but for positions inside the editor. If you've made four jumps from where you started, four `Ctrl+o` presses bring you back one step at a time. `Ctrl+i` goes the other way.
+
+To see the full list:
+
+```vim
+:jumps
+```
+
+The jump list holds 100 positions. A hundred. Just enough to make it look like something you need to actively manage — you don't. When it fills up, the oldest entry quietly disappears. Vim doesn't send a notification. You keep editing.
+
+A note about [searches with `/` and `?`](/en/tutorials/search-and-find-vim): every jump to a result registers in the jump list. If you move through six matches with `n`, you have six entries. `Ctrl+o` undoes the trail.
+
+## The changelist: where you edited
+
+The jump list tracks positions. The **changelist** tracks specifically the spots where you made a change in the file.
+
+```vim
+g;    " go to older change
+g,    " go to newer change
+```
+
+To see the full list:
+
+```vim
+:changes
+```
+
+The common case: you edited something, jumped to another spot to check a variable, and now you want to get back exactly to where you were typing. `g;` and you're there.
+
+The changelist stores the last 100 changes with exact positions — a detailed audit trail of everything you've touched in the file since you opened it. In practice, you'll use `g;` once, to get back to the last place you typed something. That's what it's there for.
+
+## Special jumps
+
+### `%`: the matching pair
+
+Place the cursor on a parenthesis, brace, or bracket, and press `%`:
+
+```vim
+%
+```
+
+It jumps to the matching character. On `(` → jumps to `)`. On `}` → jumps to the `{` that opens it. You can bounce back and forth with repeated `%`.
+
+Useful in heavily nested code: instead of visually counting where a block ends, `%` takes you there directly.
+
+### `gd` and `gD`: go to definition
+
+```vim
+gd    " go to local definition (within the current scope)
+gD    " go to global definition (from the top of the file)
+```
+
+`gd` finds the first occurrence of the word under the cursor within the local scope — useful for jumping to where a variable is declared. `gD` does the same but searches from the beginning of the file.
+
+Not the same as LSP, which you'll see later in the course and which jumps with actual semantic context. `gd` and `gD` are text searches. In files without LSP, or for local variables with clear names, they work without any configuration.
+
+### `gf`: open the file under the cursor
+
+The most underrated command in this lesson.
+
+Place your cursor over a file path in the text:
+
+```
+import { config } from '../config/app'
+require('./utils/format')
+```
+
+And press:
+
+```vim
+gf
+```
+
+Vim opens the file. No extra commands, no file explorer, no copying the path and pasting it into `:e`. If it exists, `gf` goes there. To come back, use `Ctrl+o` — the jump was already recorded in the jump list.
+
+One caveat: `gf` works with the literal text under the cursor. Paths using bundler aliases (`@/components`) or implicit extensions might need extra configuration to resolve. On explicit paths, it works out of the box.
+
+## Key concepts from this lesson
+
+- `m{a-z}` creates a local mark; `` `{letter} `` jumps to the exact line and column; `'{letter}` jumps to the line
+- `m{A-Z}` creates a global mark that persists across sessions and works across files
+- `` `. `` jumps to the last change; `''` jumps to the position before the last big jump
+- `:marks` lists all active marks
+- `Ctrl+o` / `Ctrl+i` move backward and forward through the jump list
+- `g;` / `g,` move through the changelist (edit history)
+- `%` jumps between matching open and close characters
+- `gd` / `gD` jump to the local or global first occurrence of the word under the cursor
+- `gf` opens the file whose path is under the cursor
+
+---
+
+**💡 Challenge**: Open a large file from a real project. Set `ma` where you are, jump to another section with `/`, come back with `` `a ``. Make a small edit, jump with `gg`, come back with `g;`. If there's any file path referenced in the code, place your cursor on it and try `gf`. Then run `:marks` and `:jumps` to see both lists — everything you just did is recorded there.
+
+Marks and jumps close out Vim's core navigation system. You now have the tools to move through any codebase without losing the thread. In the next tutorial, we'll cover **text objects** — what many consider Vim's actual superpower: the ability to operate on "the content inside these quotes," "the block within these braces," or "this whole word" with a single two-key command.
+
+Never stop coding!

--- a/src/content/tutorials/marks-y-saltos-vim.mdx
+++ b/src/content/tutorials/marks-y-saltos-vim.mdx
@@ -1,0 +1,200 @@
+---
+title: "Marks y saltos en Vim: navega sin perder el hilo"
+post_slug: "marks-y-saltos-vim"
+date: "2026-06-30"
+excerpt: "Aprende a usar marks, el jump list y el changelist de Vim para moverte entre posiciones sin perder el hilo, y a sacarle partido a gf, gd y % en el trabajo diario."
+language: "es"
+categories: ["vim"]
+course: "domina-vim-desde-cero"
+order: 8
+cover: "/images/tutorials/cabecera-vim-curso.jpg"
+i18n: "marks-and-jumps-vim"
+---
+
+Estás editando una función en la línea 347. Necesitas revisar cómo funciona otra función antes de terminar. Saltas con `/`, llegas, lees, te das cuenta de que también necesitas ver la constante que definiste al principio del archivo. Vas allá. Cuando quieres volver a la línea 347, no la encuentras. Buscas el nombre de la función, llegas cerca, te mueves un poco. Retomas el hilo. Necesitas revisar una última cosa en otro archivo.
+
+Esto ya no es editar código. Esto es turismo.
+
+Vim tiene un sistema para recordar dónde has estado: marks para guardar posiciones manualmente, un jump list para el historial automático de tus movimientos, y un changelist para los sitios donde hiciste cambios. Una vez que los integras en el flujo de trabajo, el "¿dónde estaba?" desaparece.
+
+## Marks: dejar una señal antes de irte
+
+Una mark es una posición guardada. Para crear una, usa `m` seguido de una letra:
+
+```vim
+ma
+```
+
+Eso guarda la posición actual bajo la clave `a`. Puedes usar cualquier letra minúscula (a-z). Ahora muévete a donde necesites — a otra función, a otra sección, a otro archivo. Para volver exactamente a donde estabas, usa el backtick seguido de la letra:
+
+```vim
+`a
+```
+
+Cursor de vuelta a línea y columna exactas.
+
+Existe también la versión con apóstrofe:
+
+```vim
+'a
+```
+
+La diferencia: `` `a `` (backtick) salta a la posición exacta — línea **y** columna. `'a` (apóstrofe) salta a la línea, pero al primer carácter no en blanco. Es la diferencia entre recordar "estaba en el tercer cajón, debajo de las baterías viejas, en la esquina derecha" y recordar simplemente "estaba en el tercer cajón". El segundo también funciona. El primero es más preciso.
+
+¿Cuál usar? El backtick. Casi siempre. A menos que necesites explícitamente el primer carácter de la línea, el backtick te lleva exactamente a donde dejaste el cursor.
+
+Las marks también son movimientos, lo que significa que se componen con la [gramática del modo Normal](/es/tutoriales/modo-normal-el-poder-de-vim):
+
+```vim
+d`a    " borra desde el cursor hasta la mark a
+y'b    " copia desde el cursor hasta la línea de la mark b
+```
+
+Vim te da 26 marks locales (a-z) y 26 globales (A-Z) — cincuenta y dos en total. La cantidad exacta para convencerte de que necesitas organizarlas por módulo o proyecto, quizás con un sistema de nombres coherente. Lo que vas a usar en la práctica son dos o tres: `ma` para marcar el sitio desde donde sales, `mb` para algo que necesitas revisar luego, y `ms` para esa otra cosa que llevas días posponiendo. Siempre las mismas dos o tres.
+
+## Marks globales: entre archivos
+
+Las letras mayúsculas (A-Z) son marks **globales**: funcionan entre archivos y persisten entre sesiones de Vim.
+
+```vim
+mA
+```
+
+Eso guarda la posición actual bajo `A`. Mañana, con Vim cerrado y abierto de nuevo, `` `A `` te lleva exactamente a ese punto, abriendo el archivo si es necesario.
+
+Útil cuando tienes dos o tres archivos que consultas constantemente: `mA` en el archivo de configuración, `mB` en el de rutas, `mC` en el principal. Saltas entre ellos sin buscar nada.
+
+La limitación honesta: solo tienes un slot por letra. Si usas `mA` en otro archivo, la `A` anterior desaparece. No es problema con tres archivos; sí lo es si intentas construir un índice completo del proyecto con 26 entradas. Para navegación entre muchos archivos, Vim tiene herramientas mejores que veremos más adelante en el curso.
+
+## Marks automáticas: las que Vim pone solo
+
+Vim también guarda ciertas posiciones de forma automática. No tienes que hacer nada — ya están ahí cuando las necesitas.
+
+| Mark | Qué guarda |
+| ---- | ---------- |
+| `` `. `` | Posición del último cambio en el archivo |
+| `` `^ `` | Posición donde saliste del modo Insert la última vez |
+| `` `[ `` | Inicio del último texto copiado o cambiado |
+| `` `] `` | Final del último texto copiado o cambiado |
+| `` `< `` | Inicio de la última selección visual |
+| `` `> `` | Final de la última selección visual |
+
+La más útil del día a día: `` `. `` lleva al último punto donde hiciste un cambio. Sin pensar, sin buscar. Un `` `. `` y estás ahí.
+
+Y luego está `''` (dos apóstrofes), o su equivalente con backtick, ` `` ` (dos backticks). Guardan la posición donde estabas **antes del último salto grande** — una búsqueda, `gg`, `G`, saltar a una mark. Es el comando de "llévame al punto de partida" retroactivo. No hace falta activarlo antes de saltar: Vim lo registra automáticamente.
+
+Para ver todas las marks activas en cualquier momento:
+
+```vim
+:marks
+```
+
+Muestra una tabla con nombre, línea, columna y el texto de la línea. Útil cuando llevas un rato trabajando y ya no recuerdas qué pusiste dónde, que es justo cuando más falta hace.
+
+## El jump list: el historial del editor
+
+Además de las marks manuales, Vim lleva un historial automático de posiciones llamado **jump list**. Cada salto grande — buscar con `/`, ir a una mark, `gg`, `G`, saltar a una definición — queda registrado.
+
+Para navegar por ese historial:
+
+```vim
+Ctrl+o    " volver al salto anterior (older)
+Ctrl+i    " avanzar al salto siguiente (newer)
+```
+
+`Ctrl+o` es el botón de atrás del navegador, pero para posiciones dentro del editor. Si llevas cuatro saltos, cuatro `Ctrl+o` te llevan de vuelta al punto de partida, uno a uno. `Ctrl+i` va en la dirección contraria.
+
+Para ver la lista completa:
+
+```vim
+:jumps
+```
+
+El jump list tiene capacidad para 100 posiciones. Cien. El número justo para hacer que parezca un recurso que necesitas gestionar — no hace falta. Cuando se llena, la entrada más antigua desaparece sin aviso. Vim no te manda ninguna notificación. Tú sigues editando.
+
+Nota sobre las [búsquedas con `/` y `?`](/es/tutoriales/busqueda-en-vim): cada salto a un resultado entra en el jump list. Si recorres seis resultados con `n`, tienes seis entradas. `Ctrl+o` deshace el camino.
+
+## El changelist: donde editaste
+
+El jump list recuerda posiciones. El **changelist** recuerda específicamente los sitios donde hiciste un cambio en el archivo.
+
+```vim
+g;    " ir al cambio anterior (older change)
+g,    " ir al cambio siguiente (newer change)
+```
+
+Para ver la lista completa:
+
+```vim
+:changes
+```
+
+El caso de uso habitual: editaste algo, saltaste a otro sitio a revisar una variable, y ahora quieres volver exactamente a donde estabas escribiendo. `g;` y estás ahí.
+
+El changelist guarda los últimos 100 cambios con posición exacta. Como un cuaderno de auditoría de todo lo que has tocado en el archivo desde que lo abriste. El 95% de las veces usarás `g;` una sola vez para volver al último sitio donde escribiste algo. Para eso existe.
+
+## Saltos especiales
+
+### `%`: los pares que se buscan
+
+Coloca el cursor sobre un paréntesis, llave o corchete, y pulsa `%`:
+
+```vim
+%
+```
+
+Salta al carácter correspondiente. Sobre `(` → al `)`. Sobre `}` → al `{` que lo abre. Puedes rebotar entre los dos con `%` repetido.
+
+Útil en código con varios niveles de anidamiento: en vez de contar visualmente dónde termina un bloque, `%` te lleva ahí directamente.
+
+### `gd` y `gD`: ir a la definición
+
+```vim
+gd    " go to local definition (dentro del scope actual)
+gD    " go to global definition (desde el principio del archivo)
+```
+
+`gd` busca la primera aparición de la palabra bajo el cursor dentro del scope local — útil para saltar a donde se declara una variable. `gD` hace lo mismo pero buscando desde el inicio del archivo.
+
+No es lo mismo que el LSP, que veremos más adelante en el curso y que salta con contexto semántico real. `gd` y `gD` son búsquedas de texto. En archivos sin LSP, o para variables locales con nombre claro, funcionan sin fricción y sin configuración.
+
+### `gf`: abrir el archivo bajo el cursor
+
+El comando más subestimado de esta lección.
+
+Coloca el cursor sobre un path en el texto:
+
+```
+import { config } from '../config/app'
+require('./utils/format')
+```
+
+Y pulsa:
+
+```vim
+gf
+```
+
+Vim abre el archivo. Sin comandos extra, sin explorador lateral, sin copiar el path y pegarlo en `:e`. Si existe, `gf` va ahí. Para volver, `Ctrl+o` — el salto ya quedó registrado en el jump list.
+
+La única pega: `gf` trabaja con el texto literal del cursor. Paths con aliases de bundler (`@/components`) o extensiones implícitas pueden necesitar configuración adicional. En paths explícitos, funciona sin nada más.
+
+## Conceptos clave de esta lección
+
+- `m{a-z}` crea una mark local; `` `{letra} `` salta a línea y columna exactas; `'{letra}` salta a la línea
+- `m{A-Z}` crea una mark global que persiste entre sesiones y funciona entre archivos
+- `` `. `` lleva al último cambio; `''` lleva a la posición antes del último salto grande
+- `:marks` muestra todas las marks activas
+- `Ctrl+o` / `Ctrl+i` recorren el jump list hacia atrás y hacia delante
+- `g;` / `g,` recorren el changelist (historial de ediciones)
+- `%` salta entre el carácter de apertura y cierre correspondiente
+- `gd` / `gD` saltan a la primera aparición local o global de la palabra bajo el cursor
+- `gf` abre el archivo cuyo path está bajo el cursor
+
+---
+
+**💡 Reto**: Abre un archivo grande de un proyecto real. Pon `ma` donde estás, salta a otra sección con `/`, vuelve con `` `a ``. Haz un cambio pequeño, salta con `gg`, vuelve con `g;`. Si hay algún path referenciado en el código, coloca el cursor encima y prueba `gf`. Escribe `:marks` y `:jumps` para ver el estado de las listas — todo lo que hiciste está registrado ahí.
+
+Las marks y los saltos cierran el sistema de navegación básica de Vim. Ya tienes las herramientas para moverte por cualquier codebase sin perder el hilo. En el próximo tutorial llega algo que muchos consideran el auténtico superpoder de Vim: los **text objects**, que permiten operar sobre "el contenido entre comillas", "el bloque entre llaves" o "la palabra entera" con dos teclas.
+
+¡Nunca dejes de programar!


### PR DESCRIPTION
## What

Adds the Vim marks and jumps tutorial (lesson 8 of the Vim course) in both Spanish and English.

## Content

- **Marks**: Local marks `m{a-z}` with backtick (exact position) vs apostrophe (line only), global marks `m{A-Z}` across files and sessions
- **Automatic marks**: `.` (last change), `[`/`]` (last yank), `<`/`>` (last visual selection)
- **Jump list**: `Ctrl+o`/`Ctrl+i` for backward/forward navigation, `:jumps` to view history
- **Changelist**: `g;`/`g,` to navigate through edit locations, `:changes` to view edit history
- **Special jumps**: `%` for matching pairs, `gd`/`gD` for definition lookup, `gf` for opening files under cursor

## Files

- `src/content/tutorials/marks-and-jumps-vim.mdx` (EN)
- `src/content/tutorials/marks-y-saltos-vim.mdx` (ES)
