### PR TITLE
feat(content): add introduction to DevOps tutorial with culture, automation, and feedback fundamentals

### DIFF
--- a/src/content/tutorials/introduccion-mundo-devops.mdx
+++ b/src/content/tutorials/introduccion-mundo-devops.mdx
@@ -1,0 +1,277 @@
+---
+title: "Introducción al mundo DevOps: cultura, automatización y feedback"
+post_slug: "introduccion-mundo-devops"
+date: "2026-07-03"
+excerpt: "Empieza el curso de DevOps, SRE y Platform Engineering entendiendo qué problema resuelve DevOps, por qué no es solo un rol y cómo encaja todo el roadmap."
+language: "es"
+categories: ["devops"]
+course: "devops-sre-platform-engineering-desde-cero"
+order: 1
+cover: "/images/tutorials/cabecera-devops-curso.jpg"
+i18n: "introduction-devops-world"
+---
+
+Son las 17:43 de un jueves. Desarrollo acaba de terminar una feature. Operaciones tiene que desplegarla. La feature funciona en local, los tests pasan, el ticket está en Done y alguien ya está pensando en cerrar el portátil con dignidad.
+
+Entonces llega producción y dice: “qué bonito todo, pero no”.
+
+El servidor tiene otra versión de Node. La variable de entorno no existe. El script de deploy depende de un paso manual que solo conoce una persona. Los logs están en una máquina, la configuración en otra, y el documento que explica el proceso se llama `deploy-final-v2-bueno-ahora-si.md`.
+
+¿Quién tiene la culpa? ¿Dev? ¿Ops? ¿La VPN? ¿Ese `README` que nadie actualiza desde 2021? Si estás empezando, esta escena puede parecer exagerada. Si ya has trabajado en software, probablemente acabas de recordar una cara concreta. Lo siento.
+
+Bienvenido al mundo DevOps.
+
+## El problema antes de DevOps
+
+Durante mucho tiempo, el desarrollo de software se organizó con una separación muy clara:
+
+- **Development** escribía código.
+- **Operations** mantenía servidores, redes, despliegues y producción.
+
+Sobre el papel suena razonable. Como separar cocina y sala en un restaurante: unos preparan la comida, otros la sirven. El problema aparece cuando cocina no sabe cómo se sirve el plato, sala no sabe qué lleva el plato, y el cliente está mirando una lasaña que ha llegado congelada por dentro.
+
+En software, esa separación generaba varios síntomas conocidos:
+
+- “En mi máquina funciona.”
+- “El deploy lo hace Ops, pregúntales a ellos.”
+- “No podemos desplegar hasta el viernes porque hay ventana de cambios.”
+- “¿Dónde están los logs?”
+- “¿Quién tocó producción?”
+
+La frase “en mi máquina funciona” es casi patrimonio cultural del sector. Técnicamente no soluciona nada, pero permite ganar tres segundos de silencio incómodo. Como cuando montas un mueble de IKEA, te sobra una pieza metálica y decides que probablemente era decorativa. La estantería está en pie. De momento.
+
+El problema real no era que Dev fuese irresponsable ni que Ops fuese lento. Esa caricatura es cómoda, pero falsa. El problema era **el sistema de trabajo**: equipos separados, objetivos distintos, poca automatización, feedback tarde y despliegues tratados como eventos especiales en vez de parte normal del desarrollo.
+
+Ahí entra DevOps.
+
+## Qué es DevOps
+
+**DevOps** es una cultura y un conjunto de prácticas para entregar software de forma más rápida, segura y fiable mediante colaboración, automatización y feedback continuo.
+
+La frase importante es esta: **DevOps no es una herramienta**.
+
+No es Jenkins. No es Docker. No es Kubernetes. No es Terraform. No es tener un YAML con 400 líneas y la esperanza de que si lo miras con suficiente respeto no falle.
+
+Las herramientas ayudan, claro. Pero DevOps empieza antes: empieza cuando development y operations dejan de trabajar como dos departamentos que se pasan paquetes por encima de una valla y empiezan a compartir responsabilidad sobre todo el ciclo de vida del software.
+
+Ese ciclo completo se parece más a esto:
+
+```text
+Plan → Code → Build → Test → Release → Deploy → Operate → Monitor
+```
+
+DevOps intenta que ese ciclo sea:
+
+- **más rápido**, porque automatizas pasos repetitivos;
+- **más seguro**, porque reduces cambios manuales y sorpresas;
+- **más observable**, porque sabes qué ocurre cuando algo falla;
+- **más colaborativo**, porque el equipo comparte contexto y responsabilidad.
+
+La parte incómoda: DevOps no se “instala”. Se practica. Si una empresa dice “hemos comprado DevOps”, lo que ha comprado probablemente es una herramienta, una consultoría o una pegatina para el portátil. DevOps real cambia cómo se trabaja.
+
+Y para cambiar cómo se trabaja, necesitas tres ideas base.
+
+## Las tres ideas centrales: colaboración, automatización y feedback
+
+Podríamos hacer una lista enorme de principios, pero para empezar quédate con tres. Son el trípode. Si una pata falla, la cámara se cae y la foto sale movida. Metáfora humilde, pero precisa.
+
+### Colaboración
+
+Dev y Ops no deberían encontrarse por primera vez el día del deploy.
+
+La colaboración significa que quienes escriben el código entienden cómo se ejecuta en producción, y quienes operan el sistema entienden qué está cambiando en el producto. No para que todo el mundo haga todo siempre — eso acaba en caos con calendario compartido — sino para que no haya muros absurdos.
+
+Un developer no necesita convertirse en experto en redes BGP para desplegar una API. Pero sí debería entender qué variables necesita, qué puertos expone, qué logs genera y cómo se sabe si está sana.
+
+Un perfil de operaciones no necesita conocer cada detalle del dominio de negocio. Pero sí debería participar en decisiones que afectan despliegue, capacidad, observability y recuperación.
+
+DevOps elimina el “yo ya hice mi parte”. En sistemas reales, esa frase es una trampa. Tu parte no termina cuando haces `git push`; termina cuando el software aporta valor funcionando en un entorno real.
+
+### Automatización
+
+Cada paso manual repetido es una futura incidencia escribiendo su currículum.
+
+Compilar a mano, copiar archivos por SSH, reiniciar servicios “en el orden correcto”, editar configuración directamente en producción... todo eso puede funcionar una vez. También puedes cruzar una calle con los ojos cerrados una vez. No lo convierte en metodología.
+
+La automatización convierte procesos frágiles en pasos reproducibles:
+
+```text
+Código → pipeline → tests → build → deploy → monitorización
+```
+
+En vez de depender de que alguien recuerde el ritual exacto, el proceso vive en scripts, pipelines, repositorios e infraestructura como código.
+
+Aquí entran herramientas que veremos más adelante: Git, Jenkins, Docker, Kubernetes, Terraform, Prometheus, Grafana. Pero fíjate en el orden mental: **primero el problema, luego la herramienta**. Comprar Kubernetes antes de entender el deploy es como comprar una excavadora porque quieres colgar un cuadro.
+
+### Feedback
+
+El feedback rápido evita que los errores lleguen tarde, caros y vestidos de producción.
+
+Tests automáticos, pipelines, alertas, logs, métricas, dashboards, postmortems: todo eso existe para responder preguntas cuanto antes:
+
+- ¿El cambio funciona?
+- ¿El sistema sigue sano?
+- ¿El deploy rompió algo?
+- ¿Los usuarios están sufriendo?
+- ¿Podemos recuperar rápido?
+
+Sin feedback, trabajas a ciegas. Y trabajar a ciegas en infraestructura tiene un nombre técnico: viernes por la tarde.
+
+Con colaboración, automatización y feedback ya puedes entender por qué DevOps no es “poner a alguien a llevar Jenkins”. Es una forma de reducir distancia entre escribir software y operarlo.
+
+## Entonces, ¿DevOps es un rol?
+
+Aquí empieza la confusión divertida. Divertida en el sentido de “hay organigramas que parecen generados por una IA con sueño”.
+
+DevOps nació como cultura y prácticas, no como cargo. Pero la industria hizo lo que la industria hace: convirtió la idea en ofertas de trabajo.
+
+Hoy puedes ver títulos como:
+
+- DevOps Engineer
+- Site Reliability Engineer
+- Platform Engineer
+- Cloud Engineer
+- Infrastructure Engineer
+- Build and Release Engineer
+
+¿Son lo mismo? No. ¿Se solapan? Muchísimo. ¿Depende de la empresa? Sí. ¿Eso ayuda al principiante? En absoluto.
+
+Una forma práctica de verlo:
+
+| Enfoque              | Pregunta principal                                                                |
+| -------------------- | --------------------------------------------------------------------------------- |
+| DevOps               | ¿Cómo entregamos software mejor y con menos fricción?                             |
+| SRE                  | ¿Cómo hacemos que el sistema sea fiable de forma medible?                         |
+| Platform Engineering | ¿Cómo construimos una plataforma para que otros equipos entreguen software mejor? |
+
+DevOps suele enfocarse en colaboración, automatización, CI/CD e infraestructura. SRE toma muchas de esas ideas y las lleva a fiabilidad operativa: SLOs, error budgets, incident response, toil, postmortems. Platform Engineering sube otro nivel: construye herramientas internas, Golden Paths y self-service para que los equipos no tengan que reinventar el despliegue en cada repo.
+
+Si DevOps reduce el muro entre Dev y Ops, SRE pone números a la fiabilidad, y Platform Engineering construye la carretera por la que los equipos circulan. Si la carretera está bien hecha, nadie piensa en ella. Si está mal hecha, todos acaban en una rotonda infinita con un ticket de Jira en la mano.
+
+## Qué hace un DevOps Engineer tradicional
+
+En muchas empresas, el rol de DevOps Engineer mezcla varias responsabilidades:
+
+- Diseñar y mantener **pipelines de CI/CD**.
+- Automatizar **deployments**.
+- Gestionar **infraestructura como código**.
+- Mantener servidores, entornos y configuración.
+- Configurar monitorización básica.
+- Ayudar a los equipos a desplegar de forma más segura.
+
+Eso implica tocar muchas piezas. Algunas muy agradables. Otras con YAML.
+
+Las habilidades habituales son:
+
+- **Linux/Unix**, porque la mayoría de servidores viven ahí.
+- **Terminal y scripting**, sobre todo Bash y a veces Python.
+- **Git**, porque sin control de versiones no hay trazabilidad. Si Git todavía te parece una caja negra con ramas, el curso [Domina Git desde cero](/es/cursos/domina-git-desde-cero) te va a ahorrar sufrimiento real.
+- **Containers**, normalmente Docker. Si quieres entrar por ahí antes de Kubernetes, [Domina Docker desde cero](/es/cursos/domina-docker-desde-cero) es el camino natural.
+- **Cloud providers**, como AWS o GCP.
+- **Observability**, para saber qué está pasando cuando el sistema deja de sonreír.
+
+La clave no es saberlo todo desde el día uno. Nadie serio espera eso. La clave es entender el mapa: qué pieza resuelve qué problema y cómo se comunican entre sí.
+
+Porque si no tienes mapa, cada herramienta parece una solución universal. Y entonces acabas intentando arreglar un problema de DNS con Terraform. No preguntes cómo lo sé.
+
+## El ecosistema DevOps
+
+Una forma sencilla de entender el ecosistema es seguir el viaje de un cambio desde que nace hasta que se observa en producción:
+
+```text
+Development → Build → Test → Deploy → Monitor
+
+Git → Jenkins → Docker → Kubernetes → Prometheus
+      GitHub    Registry   Helm         Grafana
+      GitLab    Artifacts  ArgoCD       Alerts
+```
+
+No memorices todos los nombres ahora. En serio, no te agobies. La lista parece una tienda de herramientas donde alguien mezcló destornilladores, sierras, cables y una máquina de soldar en el mismo pasillo.
+
+Lo importante es entender las categorías:
+
+- **Version control**: dónde vive el código y la historia de cambios.
+- **CI/CD**: cómo automatizas build, tests y deploy.
+- **Packaging**: cómo empaquetas la aplicación para ejecutarla igual en distintos entornos.
+- **Orchestration**: cómo gestionas múltiples servicios y su ciclo de vida.
+- **Infrastructure as Code**: cómo describes infraestructura de forma versionada.
+- **Observability**: cómo ves qué ocurre dentro del sistema.
+
+Cada categoría responde a una pregunta distinta. Y esta distinción te salva de una trampa clásica: aprender herramientas sin entender el problema. Eso produce currículums largos y sistemas frágiles. Mucha tecnología, poco criterio. Como comprar una caja de herramientas profesional para apretar un tornillo y terminar desmontando la lavadora.
+
+## El roadmap del curso
+
+Este curso está diseñado para que el mapa aparezca poco a poco, no como una pared de siglas el primer día.
+
+Lo recorreremos en tres grandes fases.
+
+### Fase 1: DevOps tradicional
+
+Primero construiremos fundamentos:
+
+- Linux y terminal.
+- Procesos, servicios, logs y networking básico.
+- Bash scripting.
+- Git aplicado a infraestructura.
+- CI/CD con Jenkins.
+- Docker y contenedores.
+- Kubernetes.
+- Terraform.
+
+Esta fase responde a la pregunta: **¿cómo automatizo y opero el ciclo de entrega de software?**
+
+Aquí vas a ensuciarte las manos. Bien. DevOps sin tocar terminal es como aprender natación con una presentación de PowerPoint.
+
+### Fase 2: SRE
+
+Después entraremos en Site Reliability Engineering:
+
+- Observability avanzada.
+- SLOs y error budgets.
+- Incident management.
+- Postmortems sin culpa.
+- Chaos engineering.
+- Capacity planning.
+- On-call sostenible.
+
+Esta fase responde a otra pregunta: **¿cómo hago que el sistema sea fiable sin convertir al equipo en una guardia permanente de bomberos?**
+
+SRE introduce algo fundamental: fiabilidad con números. No “queremos que vaya bien”, sino “este servicio debe cumplir este SLO, y este es el margen de error aceptable”. Menos intuición heroica, más ingeniería.
+
+### Fase 3: Platform Engineering
+
+Finalmente llegamos a Platform Engineering:
+
+- Golden Paths.
+- Developer Experience.
+- Self-service.
+- Backstage.
+- Service catalog.
+- Internal Developer Platforms.
+- Tooling interno.
+
+Esta fase responde a la pregunta madura: **¿cómo construyo una plataforma para que otros equipos entreguen software mejor sin depender de mí para cada paso?**
+
+Ese cambio es enorme. Pasas de apagar fuegos a diseñar sistemas que evitan que el fuego empiece. O, siendo realistas, que al menos arda en una zona controlada, con alertas, runbook y extintor que no caducó en 2019.
+
+## Lo que debes llevarte de esta primera lección
+
+DevOps no va de herramientas. Va de reducir fricción entre construir software y operarlo en un entorno real.
+
+Las herramientas importan, pero son consecuencia. Git, Jenkins, Docker, Kubernetes, Terraform, Prometheus o Backstage tienen sentido cuando entiendes qué problema resuelven. Sin ese contexto, son solo nombres caros en una arquitectura que nadie quiere tocar.
+
+Quédate con estas ideas:
+
+- DevOps nace para romper silos entre Development y Operations.
+- La base es colaboración, automatización y feedback rápido.
+- DevOps no es un rol puro, aunque existan roles llamados DevOps Engineer.
+- SRE y Platform Engineering son evoluciones relacionadas, no palabras mágicas.
+- El curso irá de fundamentos reales a plataformas internas modernas, sin saltar directamente al YAML profundo.
+
+---
+
+**💡 Reto**: Piensa en un proyecto real o imaginario que conozcas. Escribe en una nota cómo se entrega hoy un cambio: quién escribe el código, cómo se prueba, cómo se despliega, dónde se ven los logs y cómo se sabe si funciona. Si en algún punto respondes “no lo sé” o “lo hace alguien manualmente”, perfecto: acabas de encontrar una futura lección de este curso.
+
+En el próximo tutorial prepararemos el entorno de trabajo. Veremos opciones como máquina virtual local, cloud y WSL2, y dejaremos una base Linux lista para empezar a tocar terminal sin depender de magia negra ni de “en mi ordenador ya venía configurado”.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/introduction-devops-world.mdx
+++ b/src/content/tutorials/introduction-devops-world.mdx
@@ -1,0 +1,277 @@
+---
+title: "Introduction to the DevOps world: culture, automation, and feedback"
+post_slug: "introduction-devops-world"
+date: "2026-07-03"
+excerpt: "Start the DevOps, SRE, and Platform Engineering course by understanding what problem DevOps solves, why it is not just a role, and how the roadmap fits together."
+language: "en"
+categories: ["devops"]
+course: "devops-sre-platform-engineering-from-scratch"
+order: 1
+cover: "/images/tutorials/cabecera-devops-curso.jpg"
+i18n: "introduccion-mundo-devops"
+---
+
+It's 5:43 PM on a Thursday. Development has just finished a feature. Operations needs to deploy it. The feature works locally, tests are green, the ticket is Done, and someone is already thinking about closing the laptop with dignity.
+
+Then production shows up and says: “adorable, but no.”
+
+The server has a different Node version. The environment variable is missing. The deploy script depends on a manual step known by exactly one person. Logs live on one machine, configuration on another, and the document explaining the process is called `deploy-final-v2-good-now-for-real.md`.
+
+Whose fault is it? Dev? Ops? The VPN? That `README` nobody has updated since 2021? If you're just starting out, this may sound exaggerated. If you've worked in software before, you probably just remembered a specific face. Sorry about that.
+
+Welcome to the DevOps world.
+
+## The problem before DevOps
+
+For a long time, software delivery was organized around a very clear separation:
+
+- **Development** wrote the code.
+- **Operations** managed servers, networks, deployments, and production.
+
+On paper, that sounds reasonable. Like separating kitchen and service in a restaurant: one team prepares the food, another serves it. The problem starts when the kitchen doesn't know how the dish is served, service doesn't know what's in the dish, and the customer is staring at lasagna that's still frozen in the middle.
+
+In software, that separation produced familiar symptoms:
+
+- “It works on my machine.”
+- “Ops handles deployments, ask them.”
+- “We can't deploy until Friday because there's a change window.”
+- “Where are the logs?”
+- “Who touched production?”
+
+“It works on my machine” is practically cultural heritage in this industry. It solves nothing technically, but it does buy three seconds of awkward silence. Like assembling IKEA furniture, finding one spare metal part, and deciding it was probably decorative. The shelf is standing. For now.
+
+The real problem wasn't that Dev was irresponsible or Ops was slow. That caricature is convenient, but wrong. The problem was **the system of work**: separated teams, different goals, little automation, late feedback, and deployments treated as special events instead of a normal part of development.
+
+That's where DevOps comes in.
+
+## What is DevOps?
+
+**DevOps** is a culture and a set of practices for delivering software faster, more safely, and more reliably through collaboration, automation, and continuous feedback.
+
+The important sentence is this: **DevOps is not a tool**.
+
+It is not Jenkins. It is not Docker. It is not Kubernetes. It is not Terraform. It is not having a 400-line YAML file and hoping that if you look at it respectfully enough, it won't fail.
+
+Tools help, of course. But DevOps starts earlier: it starts when development and operations stop working like two departments throwing packages over a fence and start sharing responsibility for the whole software lifecycle.
+
+That full lifecycle looks roughly like this:
+
+```text
+Plan → Code → Build → Test → Release → Deploy → Operate → Monitor
+```
+
+DevOps tries to make that cycle:
+
+- **faster**, because repetitive steps are automated;
+- **safer**, because manual changes and surprises are reduced;
+- **more observable**, because you know what is happening when something breaks;
+- **more collaborative**, because the team shares context and responsibility.
+
+The uncomfortable bit: DevOps cannot be “installed.” It has to be practiced. If a company says “we bought DevOps,” what it probably bought is a tool, consulting, or a laptop sticker. Real DevOps changes how work happens.
+
+And to change how work happens, you need three core ideas.
+
+## The three core ideas: collaboration, automation, and feedback
+
+We could build a giant list of principles, but for now keep three. They are the tripod. If one leg fails, the camera falls and the picture comes out blurry. Humble metaphor, accurate result.
+
+### Collaboration
+
+Dev and Ops should not meet for the first time on deployment day.
+
+Collaboration means that people writing the code understand how it runs in production, and people operating the system understand what is changing in the product. Not so everyone does everything all the time — that ends in calendar-shaped chaos — but so there are no absurd walls.
+
+A developer doesn't need to become a BGP networking expert to deploy an API. But they should understand what variables it needs, what ports it exposes, what logs it emits, and how to tell if it is healthy.
+
+An operations person doesn't need to know every detail of the business domain. But they should be involved in decisions that affect deployment, capacity, observability, and recovery.
+
+DevOps removes the “I already did my part” escape hatch. In real systems, that sentence is a trap. Your part does not end when you run `git push`; it ends when the software delivers value in a real environment.
+
+### Automation
+
+Every repeated manual step is a future incident updating its résumé.
+
+Building by hand, copying files over SSH, restarting services “in the correct order,” editing configuration directly in production... all of that can work once. You can also cross a road with your eyes closed once. That doesn't make it a methodology.
+
+Automation turns fragile rituals into repeatable steps:
+
+```text
+Code → pipeline → tests → build → deploy → monitoring
+```
+
+Instead of depending on someone remembering the exact ceremony, the process lives in scripts, pipelines, repositories, and infrastructure as code.
+
+This is where tools we'll cover later enter the picture: Git, Jenkins, Docker, Kubernetes, Terraform, Prometheus, Grafana. But notice the mental order: **problem first, tool second**. Buying Kubernetes before understanding deployment is like buying an excavator because you want to hang a picture frame.
+
+### Feedback
+
+Fast feedback prevents errors from arriving late, expensive, and dressed as production.
+
+Automated tests, pipelines, alerts, logs, metrics, dashboards, postmortems: all of this exists to answer questions as early as possible:
+
+- Does the change work?
+- Is the system still healthy?
+- Did the deploy break something?
+- Are users suffering?
+- Can we recover quickly?
+
+Without feedback, you work blind. And working blind in infrastructure has a technical name: Friday afternoon.
+
+With collaboration, automation, and feedback, you can already see why DevOps is not “put someone in charge of Jenkins.” It is a way to reduce distance between writing software and operating it.
+
+## So, is DevOps a role?
+
+Here is where the confusion gets fun. Fun in the sense of “some org charts look generated by a sleep-deprived AI.”
+
+DevOps started as culture and practices, not a job title. Then the industry did what the industry does: it turned the idea into job postings.
+
+Today you'll see titles like:
+
+- DevOps Engineer
+- Site Reliability Engineer
+- Platform Engineer
+- Cloud Engineer
+- Infrastructure Engineer
+- Build and Release Engineer
+
+Are they the same? No. Do they overlap? A lot. Does it depend on the company? Absolutely. Does that help beginners? Not even slightly.
+
+A practical way to frame it:
+
+| Focus                | Main question                                                      |
+| -------------------- | ------------------------------------------------------------------ |
+| DevOps               | How do we deliver software better and with less friction?          |
+| SRE                  | How do we make the system reliable in a measurable way?            |
+| Platform Engineering | How do we build a platform so other teams deliver software better? |
+
+DevOps usually focuses on collaboration, automation, CI/CD, and infrastructure. SRE takes many of those ideas into operational reliability: SLOs, error budgets, incident response, toil, postmortems. Platform Engineering climbs another level: internal tools, Golden Paths, and self-service so teams don't reinvent deployment in every repository.
+
+If DevOps reduces the wall between Dev and Ops, SRE puts numbers on reliability, and Platform Engineering builds the road teams drive on. If the road is well built, nobody thinks about it. If it isn't, everyone ends up in an infinite roundabout holding a Jira ticket.
+
+## What a traditional DevOps Engineer does
+
+In many companies, the DevOps Engineer role combines several responsibilities:
+
+- Designing and maintaining **CI/CD pipelines**.
+- Automating **deployments**.
+- Managing **infrastructure as code**.
+- Maintaining servers, environments, and configuration.
+- Setting up basic monitoring.
+- Helping teams deploy more safely.
+
+That means touching many moving parts. Some pleasant. Some YAML-shaped.
+
+The usual skills include:
+
+- **Linux/Unix**, because most servers live there.
+- **Terminal and scripting**, especially Bash and sometimes Python.
+- **Git**, because without version control there is no traceability. If Git still feels like a black box with branches, [Mastering Git from Scratch](/en/courses/mastering-git-from-scratch) will save you real pain.
+- **Containers**, usually Docker. If you want to enter there before Kubernetes, [Mastering Docker from Scratch](/en/courses/mastering-docker-from-scratch) is the natural path.
+- **Cloud providers**, like AWS or GCP.
+- **Observability**, so you can see what is happening when the system stops smiling.
+
+The key is not knowing all of this on day one. No serious person expects that. The key is understanding the map: which piece solves which problem and how the pieces talk to each other.
+
+Because if you don't have a map, every tool looks like a universal solution. That's how you end up trying to fix a DNS problem with Terraform. Don't ask how I know.
+
+## The DevOps ecosystem
+
+A simple way to understand the ecosystem is to follow a change from the moment it is written to the moment it is observed in production:
+
+```text
+Development → Build → Test → Deploy → Monitor
+
+Git → Jenkins → Docker → Kubernetes → Prometheus
+      GitHub    Registry   Helm         Grafana
+      GitLab    Artifacts  ArgoCD       Alerts
+```
+
+Don't memorize all the names yet. Seriously, don't stress. The list looks like a hardware store where someone mixed screwdrivers, saws, cables, and a welding machine in the same aisle.
+
+What matters is understanding the categories:
+
+- **Version control**: where code and change history live.
+- **CI/CD**: how build, tests, and deploy are automated.
+- **Packaging**: how the application is packaged to run consistently across environments.
+- **Orchestration**: how multiple services and their lifecycle are managed.
+- **Infrastructure as Code**: how infrastructure is described in a versioned way.
+- **Observability**: how you see what is happening inside the system.
+
+Each category answers a different question. That distinction saves you from a classic trap: learning tools without understanding the problem. That produces long résumés and fragile systems. Lots of technology, little judgment. Like buying a professional toolbox to tighten one screw and ending up disassembling the washing machine.
+
+## The course roadmap
+
+This course is designed so the map appears gradually, not as a wall of acronyms on day one.
+
+We'll move through three large phases.
+
+### Phase 1: Traditional DevOps
+
+First we'll build fundamentals:
+
+- Linux and terminal.
+- Processes, services, logs, and basic networking.
+- Bash scripting.
+- Git applied to infrastructure.
+- CI/CD with Jenkins.
+- Docker and containers.
+- Kubernetes.
+- Terraform.
+
+This phase answers the question: **how do I automate and operate the software delivery lifecycle?**
+
+Here you'll get your hands dirty. Good. DevOps without touching a terminal is like learning to swim from a PowerPoint deck.
+
+### Phase 2: SRE
+
+Then we'll move into Site Reliability Engineering:
+
+- Advanced observability.
+- SLOs and error budgets.
+- Incident management.
+- Blameless postmortems.
+- Chaos engineering.
+- Capacity planning.
+- Sustainable on-call.
+
+This phase asks a different question: **how do I make the system reliable without turning the team into a permanent fire brigade?**
+
+SRE introduces a fundamental idea: reliability with numbers. Not “we want it to work well,” but “this service must meet this SLO, and this is the acceptable error margin.” Less heroic intuition, more engineering.
+
+### Phase 3: Platform Engineering
+
+Finally we reach Platform Engineering:
+
+- Golden Paths.
+- Developer Experience.
+- Self-service.
+- Backstage.
+- Service catalog.
+- Internal Developer Platforms.
+- Internal tooling.
+
+This phase answers the mature question: **how do I build a platform so other teams deliver software better without depending on me for every step?**
+
+That shift is huge. You move from putting out fires to designing systems that prevent fires from starting. Or, more realistically, systems that at least keep the fire in a controlled area, with alerts, a runbook, and an extinguisher that didn't expire in 2019.
+
+## What you should take from this first lesson
+
+DevOps is not about tools. It is about reducing friction between building software and operating it in a real environment.
+
+Tools matter, but they are the consequence. Git, Jenkins, Docker, Kubernetes, Terraform, Prometheus, or Backstage make sense when you understand what problem they solve. Without that context, they are just expensive names in an architecture nobody wants to touch.
+
+Keep these ideas:
+
+- DevOps emerged to break silos between Development and Operations.
+- The foundation is collaboration, automation, and fast feedback.
+- DevOps is not a pure role, even though roles called DevOps Engineer exist.
+- SRE and Platform Engineering are related evolutions, not magic words.
+- The course will move from real fundamentals to modern internal platforms, without jumping straight into deep YAML.
+
+---
+
+**💡 Challenge**: Think of a real or imaginary project you know. Write a short note describing how a change is delivered today: who writes the code, how it is tested, how it is deployed, where logs are checked, and how the team knows it works. If at any point your answer is “I don't know” or “someone does it manually,” perfect: you just found a future lesson in this course.
+
+In the next tutorial we'll prepare the working environment. We'll compare local virtual machines, cloud environments, and WSL2, then set up a Linux base so you can start using the terminal without relying on dark magic or “it was already configured on my laptop.”
+
+Never stop coding!


### PR DESCRIPTION
## What

Adds the first lesson of the DevOps, SRE and Platform Engineering course (ES/EN) — Introduction to the DevOps World.

## Content

- **The problem before DevOps**: Dev/Ops silos, "it works on my machine", deployments as special events
- **What DevOps is**: Culture and practices, not tools — collaboration, automation, and fast feedback
- **DevOps vs SRE vs Platform Engineering**: How each focus answers a different question about delivery, reliability, and developer platforms
- **The DevOps ecosystem**: Categories (version control, CI/CD, packaging, orchestration, IaC, observability) rather than memorizing tool names
- **Course roadmap**: Three phases — Traditional DevOps (Linux → Jenkins → Docker → K8s → Terraform), SRE (SLOs, error budgets, incidents), Platform Engineering (Golden Paths, Backstage, IDPs)

## Files

- `src/content/tutorials/introduction-devops-world.mdx` (EN)
- `src/content/tutorials/introduccion-mundo-devops.mdx` (ES)
