### PR TITLE
feat(content): add Docker Compose volumes and data persistence tutorial with named volumes, bind mounts, and backups

### DIFF
--- a/src/content/tutorials/docker-compose-volumes-data-persistence.mdx
+++ b/src/content/tutorials/docker-compose-volumes-data-persistence.mdx
@@ -1,0 +1,413 @@
+---
+title: "Docker Compose volumes and data persistence"
+post_slug: "docker-compose-volumes-data-persistence"
+date: "2026-07-07"
+excerpt: "Learn Docker Compose volumes: named volumes, bind mounts, database persistence, development workflows, and backups without praying to the container gods."
+language: "en"
+categories: ["docker"]
+course: "mastering-docker-from-scratch"
+order: 15
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "volumenes-persistencia-datos-docker-compose"
+---
+
+Docker has a very effective teaching method: you start Postgres, insert data, stop the container, start it again, and everything is still there. Nice. You gain confidence. You clean things up. You run the wrong command. You open the app again and the database is emptier than a sprint retrospective where everyone says “all good”.
+
+Where did the data live? Inside the container? Somewhere in Docker? In a secret folder guarded by a small daemon with trust issues?
+
+Take a breath. Docker doesn't hate your data. Containers are disposable by design. If you want persistence, you need to declare it explicitly. That's what **volumes** are for.
+
+## The problem: containers are not hard drives
+
+A container has its own filesystem. You can write files, modify data, create directories, and feel like everything is under control. The catch is that this writable layer belongs to the container.
+
+Remove the container, and those changes go with it.
+
+```bash
+docker run --name temp-postgres -e POSTGRES_PASSWORD=secret -d postgres:16-alpine
+docker rm -f temp-postgres
+```
+
+The container is gone. Its writable changes are gone too.
+
+That's not a bug. That's the model. Containers should be safe to destroy and recreate. The image contains the application; the data lives outside.
+
+Think of a container as a moving van. Useful, necessary, maybe smelling vaguely of cheap air freshener. But you don't store your lease, family photos, and the only copy of your production database inside the van. Those go in labeled boxes.
+
+In Docker, those boxes are volumes.
+
+## The three volume types you'll actually use
+
+In Compose, a service can mount several kinds of storage:
+
+```yaml
+services:
+  app:
+    image: myapp
+    volumes:
+      - app-data:/app/data
+      - ./src:/app/src
+      - /app/temp
+      - ./config:/app/config:ro
+
+volumes:
+  app-data:
+```
+
+Those four lines are not the same thing. Treating them as interchangeable is how you end up staring at `docker volume ls` like you're reading ancient ruins.
+
+### Named volumes
+
+```yaml
+services:
+  app:
+    image: myapp
+    volumes:
+      - app-data:/app/data
+
+volumes:
+  app-data:
+```
+
+A **named volume** is storage managed by Docker. You give it a name (`app-data`), and Docker decides where it physically lives on the host.
+
+This is the default choice for data you want to keep: databases, uploaded files, persistent caches, internal application state.
+
+The upside: it works consistently across Linux, macOS, and Windows. You don't depend on a specific host path.
+
+The downside: the files are not sitting neatly inside your project directory. Docker stores them internally. If you're like me when I started, that creates a very specific anxiety: “I know my data exists, but I don't know where it lives.” Correct. Welcome to the club.
+
+You can inspect volumes with:
+
+```bash
+docker volume ls
+docker volume inspect myproject_app-data
+```
+
+Compose usually prefixes volume names with the project name. If your directory is called `myproject` and your volume is `app-data`, the real volume might be `myproject_app-data`. Docker isn't trying to be mysterious. It just has a gift for making simple things look slightly like infrastructure archaeology.
+
+### Bind mounts
+
+```yaml
+services:
+  app:
+    image: myapp
+    volumes:
+      - ./src:/app/src
+```
+
+A **bind mount** mounts a host directory into the container. Here, `./src` on your machine appears as `/app/src` inside the container.
+
+This is excellent for development: edit code in your editor, the container sees the change immediately, the dev server reloads, and for one beautiful second software feels like it was designed by someone on your side.
+
+```yaml
+services:
+  api:
+    build: ./api
+    volumes:
+      - ./api/src:/app/src
+    command: npm run dev
+```
+
+But bind mounts depend on the host filesystem. If `./api/src` exists on your laptop but not on the server, deployment fails. If file synchronization is slow on macOS, you'll feel it. If someone changes the path, the container does not develop intuition.
+
+The practical rule:
+
+- **Development**: bind mounts for source code and local configuration.
+- **Persistent data**: named volumes.
+- **Production**: avoid mounting source code from the host unless you have a VERY clear reason.
+
+Not “interesting”. Clear.
+
+### Anonymous volumes
+
+```yaml
+services:
+  app:
+    image: myapp
+    volumes:
+      - /app/temp
+```
+
+An **anonymous volume** has no explicit name. Docker creates one automatically for `/app/temp`.
+
+This can be useful for internal container paths, but for important data it's a trap with good lighting. The volume exists, yes, but you didn't choose a stable name for it. Weeks later, you'll see a list of long IDs and have to guess which one contains what.
+
+It's like having a drawer full of unlabelled cables. One of them is definitely important. Good luck finding the right charger before USB invents another connector.
+
+For data you want to keep and understand, use named volumes.
+
+### Read-only volumes
+
+```yaml
+services:
+  app:
+    image: myapp
+    volumes:
+      - ./config:/app/config:ro
+```
+
+The `:ro` suffix mounts the volume as **read-only**. The container can read `/app/config`, but it can't write there.
+
+Use this for configuration, certificates, static files, or anything the container should not modify. If an application only needs to read a file, don't give it write access. Least privilege applies locally too. Your laptop is not a moral exception.
+
+## Database persistence
+
+The most common Compose case is a database.
+
+```yaml
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: myapp
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: myapp
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+volumes:
+  db-data:
+```
+
+Postgres stores its data in `/var/lib/postgresql/data`. By mounting `db-data` there, the data lives in the volume, not in the container's writable layer.
+
+Now you can remove and recreate the container without losing the database:
+
+```bash
+docker compose down
+docker compose up -d
+```
+
+The container changes. The volume remains.
+
+But pay attention: `down` and `down -v` are not polite cousins. `docker compose down` removes containers and networks, but keeps named volumes. `docker compose down -v` also removes the volumes declared by Compose.
+
+```bash
+docker compose down     # Keeps named volumes
+docker compose down -v  # Removes named volumes too
+```
+
+That `-v` is tiny, quiet, and destructive. Like a red button without a safety cover. Use it when you deliberately want to delete data: resetting a local database, cleaning a test environment, starting from scratch.
+
+Don't use it as “general cleanup” if the data matters.
+
+For other databases, the idea is the same: mount the volume where the image stores its data.
+
+```yaml
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_PASSWORD: secret
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  mongo:
+    image: mongo:7
+    volumes:
+      - mongo-data:/data/db
+
+  mysql:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: secret
+    volumes:
+      - mysql-data:/var/lib/mysql
+
+volumes:
+  postgres-data:
+  mongo-data:
+  mysql-data:
+```
+
+The path changes depending on the image. The pattern doesn't.
+
+## Initialization scripts
+
+Many official database images can run initialization scripts the first time the database is created.
+
+With Postgres, anything mounted into `/docker-entrypoint-initdb.d` runs when the data directory is initialized:
+
+```yaml
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: myapp
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: myapp
+    volumes:
+      - db-data:/var/lib/postgresql/data
+      - ./init-scripts:/docker-entrypoint-initdb.d:ro
+
+volumes:
+  db-data:
+```
+
+For example:
+
+```sql
+-- init-scripts/01-create-tables.sql
+CREATE TABLE IF NOT EXISTS notes (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+```
+
+Important detail: these scripts run when the data directory is empty. If the volume already exists and Postgres has already initialized, they do not run again.
+
+Feeling the “but I changed the SQL and nothing happened” moment? Good. The volume already had data. Docker is not going to wipe your database because you edited a file. That would be helpful in a deeply criminal way.
+
+To test initialization changes locally:
+
+```bash
+docker compose down -v
+docker compose up -d
+```
+
+That deletes the volume and forces a fresh initialization. Deliberate, visible, consequences included.
+
+## Development vs production
+
+Volumes also separate two very different needs: fast development and stable runtime behavior.
+
+In development, you want hot reload:
+
+```yaml
+# docker-compose.dev.yml
+services:
+  api:
+    build:
+      context: ./api
+      target: development
+    volumes:
+      - ./api/src:/app/src
+      - ./api/package.json:/app/package.json:ro
+      - /app/node_modules
+    command: npm run dev
+```
+
+The `- /app/node_modules` line creates an anonymous volume so the container's `node_modules` directory doesn't get overwritten by the host. This trick exists because JavaScript decided dependencies should have more emotional mass than the actual project. We're not fixing that today.
+
+In production, you don't mount source code from your machine. You build an image and only mount the data that must persist:
+
+```yaml
+# docker-compose.prod.yml
+services:
+  api:
+    build:
+      context: ./api
+      target: production
+    volumes:
+      - api-data:/app/data
+    command: npm start
+
+volumes:
+  api-data:
+```
+
+Then combine files depending on the environment:
+
+```bash
+# Development
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+
+# Production
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+The base `docker-compose.yml` describes the shared stack, and the environment-specific files override what changes. Just like with [Git](/en/courses/mastering-git-from-scratch), you commit what describes the project and keep machine-specific details out.
+
+## Backups: persistence is not a backup
+
+A persistent volume is not a backup. Say it with me: **persistence is not backup**.
+
+A named volume survives container recreation. It does not protect you from `docker compose down -v`, manual deletion, data corruption, an overconfident script, or you on a Friday afternoon thinking “this definitely won't break anything”.
+
+For databases, the best backup is usually the database's own tool. For Postgres:
+
+```bash
+docker compose exec db pg_dump -U myapp myapp > backup.sql
+```
+
+That runs `pg_dump` inside the `db` container and writes the output to your machine. Clear, portable, and database-aware.
+
+You can also make a low-level copy of a volume using a temporary container:
+
+```bash
+docker run --rm \
+  -v myproject_db-data:/data:ro \
+  -v "$(pwd)":/backup \
+  alpine \
+  tar czf /backup/db-data-backup.tar.gz -C /data .
+```
+
+What's happening here:
+
+- `myproject_db-data:/data:ro` mounts the volume read-only.
+- `"$(pwd)":/backup` mounts your current directory as the backup destination.
+- `tar czf` archives the volume contents.
+- `--rm` removes the temporary container when it exits.
+
+If you've spent years fighting shell quotes, you noticed `"$(pwd)"`. If not, don't worry: Bash will get its own course later, because this topic deserves more than “copy this and trust me”. That's not decoration. It keeps the command from breaking when the path contains spaces. The shell is always waiting for a chance to remind you that quotes are not optional.
+
+To restore into an empty volume:
+
+```bash
+docker volume create myproject_db-data
+
+docker run --rm \
+  -v myproject_db-data:/data \
+  -v "$(pwd)":/backup:ro \
+  alpine \
+  tar xzf /backup/db-data-backup.tar.gz -C /data
+```
+
+For databases that are actively running, don't blindly copy files while the engine is writing. It might help in development. In production, use `pg_dump`, consistent snapshots, or the official tooling for your database. Faith can move mountains, but it does not guarantee transactional integrity.
+
+## Cleanup without destroying what matters
+
+These Compose and Docker commands have very different effects:
+
+```bash
+docker compose stop
+docker compose down
+docker compose down -v
+docker volume ls
+docker volume rm myproject_db-data
+docker volume prune
+```
+
+Human translation:
+
+| Command                   | What it does                                         |
+| ------------------------- | ---------------------------------------------------- |
+| `docker compose stop`     | Stops containers, removes nothing                    |
+| `docker compose down`     | Removes containers and networks, keeps named volumes |
+| `docker compose down -v`  | Removes containers, networks, and project volumes    |
+| `docker volume rm <name>` | Removes one specific volume                          |
+| `docker volume prune`     | Removes volumes not used by any container            |
+
+`docker volume prune` asks for confirmation, but it does not know which volume was “emotionally important”. It only knows whether a container is currently using it. If you have an old volume with data you care about and no container is attached to it right now, it can be removed.
+
+Before deleting, inspect:
+
+```bash
+docker volume inspect myproject_db-data
+```
+
+And if you're unsure, back it up first. Boring advice. So is wearing a seatbelt, until the day it stops being boring.
+
+## Practical challenge
+
+Create a `docker-compose.yml` with Postgres and a fake API or any lightweight image you know. Add a named volume for Postgres, start the stack, create some data, run `docker compose down`, then start it again and confirm the data is still there.
+
+After that, back up the volume using the temporary `alpine` container. You don't need an enterprise backup system yet; just understand the flow: volume → `.tar.gz` archive → restore into an empty volume.
+
+---
+
+You can now treat Docker Compose data with the respect it deserves: outside the container, with clear names, with clean separation between development and production, and with backups that don't depend on crossed fingers. In the next tutorial we'll go into Docker Compose networking: default networks, custom networks, service isolation, and why your database should not be cheerfully waving at the entire stack.
+
+Never stop coding!

--- a/src/content/tutorials/volumenes-persistencia-datos-docker-compose.mdx
+++ b/src/content/tutorials/volumenes-persistencia-datos-docker-compose.mdx
@@ -1,0 +1,413 @@
+---
+title: "Volúmenes y persistencia de datos en Docker Compose"
+post_slug: "volumenes-persistencia-datos-docker-compose"
+date: "2026-07-07"
+excerpt: "Aprende a usar volúmenes con Docker Compose: named volumes, bind mounts, datos de bases de datos, entornos de desarrollo y backups sin rezar a los dioses del contenedor."
+language: "es"
+categories: ["docker"]
+course: "domina-docker-desde-cero"
+order: 15
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "docker-compose-volumes-data-persistence"
+---
+
+Hay una experiencia muy educativa en Docker: arrancas Postgres, guardas datos, paras el contenedor, lo vuelves a levantar y todo sigue ahí. Bien. Te vienes arriba. Haces limpieza. Ejecutas el comando equivocado. Vuelves a abrir la aplicación y la base de datos está más vacía que tu motivación un lunes con reunión a las 9.
+
+¿Dónde estaban los datos? ¿En el contenedor? ¿En Docker? ¿En una carpeta secreta? ¿Se han ido a vivir con los calcetines que desaparecen en la lavadora?
+
+Respira. No es que Docker odie tus datos. Es que los contenedores son desechables por diseño. Si quieres persistencia, tienes que declararla explícitamente. Y ahí entran los **volúmenes**.
+
+## El problema: los contenedores no son discos duros
+
+Un contenedor tiene su propio sistema de ficheros. Puedes escribir dentro, crear ficheros, modificar datos y sentir que todo está bajo control. El problema es que ese sistema de ficheros pertenece al contenedor.
+
+Si eliminas el contenedor, eliminas también esa capa escribible.
+
+```bash
+docker run --name temp-postgres -e POSTGRES_PASSWORD=secret -d postgres:16-alpine
+docker rm -f temp-postgres
+```
+
+El contenedor se va. Sus cambios también.
+
+Esto no es un bug. Es la gracia del modelo: los contenedores deben poder destruirse y recrearse sin drama. La imagen contiene la aplicación; los datos viven fuera.
+
+Es como hacer una mudanza: el contenedor es la furgoneta. Útil, necesaria, incluso con olor a ambientador barato. Pero no deberías guardar ahí el contrato de alquiler, las fotos familiares y la única copia de la base de datos de producción. Eso va en cajas etiquetadas.
+
+En Docker, esas cajas son los volúmenes.
+
+## Los tres tipos de volumen que vas a usar
+
+En Compose, la sección `volumes` de un servicio puede montar varios tipos de almacenamiento:
+
+```yaml
+services:
+  app:
+    image: myapp
+    volumes:
+      - app-data:/app/data
+      - ./src:/app/src
+      - /app/temp
+      - ./config:/app/config:ro
+
+volumes:
+  app-data:
+```
+
+Aquí hay cuatro casos distintos, y conviene separarlos mentalmente porque mezclarlos es la receta perfecta para perder una tarde mirando `docker volume ls` con cara de arqueólogo.
+
+### Named volumes
+
+```yaml
+services:
+  app:
+    image: myapp
+    volumes:
+      - app-data:/app/data
+
+volumes:
+  app-data:
+```
+
+Un **named volume** es almacenamiento gestionado por Docker. Tú le das un nombre (`app-data`) y Docker decide dónde guardarlo físicamente en el host.
+
+Es la opción normal para datos que quieres conservar: bases de datos, ficheros subidos por usuarios, cachés persistentes, datos internos de una aplicación.
+
+La ventaja: funciona igual en Linux, macOS y Windows. No dependes de que exista una ruta concreta en el host.
+
+La desventaja: no ves el contenido directamente en tu proyecto. Docker lo guarda en su zona interna. Si eres como yo cuando empecé, esto genera una inquietud muy específica: “sé que mis datos existen, pero no sé dónde están guardados”. Bienvenido. Es normal.
+
+Puedes inspeccionar un volumen así:
+
+```bash
+docker volume ls
+docker volume inspect myproject_app-data
+```
+
+Compose suele prefijar el nombre del volumen con el nombre del proyecto. Si tu carpeta se llama `myproject` y defines `app-data`, el volumen real puede llamarse `myproject_app-data`. Docker no estaba intentando ser misterioso; solo estaba siendo Docker, que a veces se parece bastante.
+
+### Bind mounts
+
+```yaml
+services:
+  app:
+    image: myapp
+    volumes:
+      - ./src:/app/src
+```
+
+Un **bind mount** monta una carpeta del host dentro del contenedor. En este ejemplo, `./src` en tu máquina aparece como `/app/src` dentro del contenedor.
+
+Esto es perfecto para desarrollo: editas código en tu editor, el contenedor ve los cambios al instante, tu servidor recarga, y por un momento todo parece diseñado por alguien que quería ayudarte.
+
+```yaml
+services:
+  api:
+    build: ./api
+    volumes:
+      - ./api/src:/app/src
+    command: npm run dev
+```
+
+Pero un bind mount depende de la estructura del host. Si en tu máquina existe `./api/src` y en el servidor no, el despliegue falla. Si en macOS el rendimiento de sincronización no es ideal, lo notas. Si alguien cambia la ruta, el contenedor no tiene telepatía.
+
+Por eso la regla práctica es sencilla:
+
+- **Desarrollo**: bind mounts para código y configuración local.
+- **Datos persistentes**: named volumes.
+- **Producción**: evita montar código fuente desde el host salvo que tengas una razón MUY clara.
+
+No “creativa”. Clara.
+
+### Anonymous volumes
+
+```yaml
+services:
+  app:
+    image: myapp
+    volumes:
+      - /app/temp
+```
+
+Un **anonymous volume** no tiene nombre explícito. Docker crea uno automáticamente para montar `/app/temp`.
+
+Esto puede ser útil para casos internos, pero para datos importantes es una trampa con buena iluminación. El volumen existe, sí, pero no tiene un nombre estable que tú hayas elegido. Cuando vuelvas semanas después, verás una lista de IDs largos y tendrás que adivinar cuál contiene qué.
+
+Como funciona tener un cajón lleno de cables sin etiquetar: seguro que alguno es importante, pero buena suerte encontrando el cargador correcto antes de que envejezca el estándar USB otra vez.
+
+Para datos que quieras conservar y entender, usa named volumes.
+
+### Volúmenes de solo lectura
+
+```yaml
+services:
+  app:
+    image: myapp
+    volumes:
+      - ./config:/app/config:ro
+```
+
+El sufijo `:ro` monta el volumen en modo **read-only**. El contenedor puede leer `/app/config`, pero no escribir ahí.
+
+Esto es útil para configuración, certificados, ficheros estáticos o cualquier cosa que el contenedor no debería modificar. Si una aplicación solo necesita leer un fichero, no le des permiso para escribirlo. Principio de mínimo privilegio, incluso en local. Sí, también en tu portátil. Tu portátil no es una excepción moral.
+
+## Persistencia de bases de datos
+
+El caso más común: una base de datos en Compose.
+
+```yaml
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: myapp
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: myapp
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+volumes:
+  db-data:
+```
+
+Postgres guarda sus datos en `/var/lib/postgresql/data`. Al montar `db-data` ahí, los datos viven en el volumen, no en la capa escribible del contenedor.
+
+Ahora puedes eliminar y recrear el contenedor sin perder la base de datos:
+
+```bash
+docker compose down
+docker compose up -d
+```
+
+El contenedor cambia. El volumen sigue.
+
+Pero atención: `down` y `down -v` no son primos educados. `docker compose down` elimina contenedores y redes, pero conserva los named volumes. `docker compose down -v` elimina también los volúmenes declarados por Compose.
+
+```bash
+docker compose down     # Keeps named volumes
+docker compose down -v  # Removes named volumes too
+```
+
+Ese `-v` es pequeño, discreto y destructivo. Como un botón rojo sin tapa de seguridad. Úsalo cuando quieras borrar datos deliberadamente: reiniciar una base de datos local, limpiar un entorno de pruebas, empezar desde cero.
+
+No lo uses como “limpieza general” si hay datos que te importan.
+
+Para otras bases de datos, la idea es la misma: montar el volumen en el directorio donde la imagen guarda sus datos.
+
+```yaml
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_PASSWORD: secret
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  mongo:
+    image: mongo:7
+    volumes:
+      - mongo-data:/data/db
+
+  mysql:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: secret
+    volumes:
+      - mysql-data:/var/lib/mysql
+
+volumes:
+  postgres-data:
+  mongo-data:
+  mysql-data:
+```
+
+La ruta cambia según la imagen. El patrón no.
+
+## Scripts de inicialización
+
+Muchas imágenes oficiales permiten ejecutar scripts de inicialización la primera vez que se crea la base de datos.
+
+En Postgres, todo lo que montes en `/docker-entrypoint-initdb.d` se ejecuta al inicializar un volumen vacío:
+
+```yaml
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: myapp
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: myapp
+    volumes:
+      - db-data:/var/lib/postgresql/data
+      - ./init-scripts:/docker-entrypoint-initdb.d:ro
+
+volumes:
+  db-data:
+```
+
+Y podrías tener algo así:
+
+```sql
+-- init-scripts/01-create-tables.sql
+CREATE TABLE IF NOT EXISTS notes (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+```
+
+La parte importante: estos scripts se ejecutan cuando el directorio de datos está vacío. Si el volumen ya existe y Postgres ya fue inicializado, no se vuelven a ejecutar.
+
+¿Sensación de “pero yo cambié el SQL y no pasa nada”? Correcto. El volumen ya tenía datos. Docker no va a borrar tu base de datos porque editaste un fichero. Sería servicial de una forma bastante criminal.
+
+Para probar cambios de inicialización en local:
+
+```bash
+docker compose down -v
+docker compose up -d
+```
+
+Ahí sí: borras el volumen y fuerzas una inicialización nueva. Deliberado, visible y con las consecuencias claras.
+
+## Desarrollo vs producción
+
+Los volúmenes también separan dos necesidades muy distintas: desarrollar rápido y ejecutar de forma estable.
+
+En desarrollo quieres hot reload:
+
+```yaml
+# docker-compose.dev.yml
+services:
+  api:
+    build:
+      context: ./api
+      target: development
+    volumes:
+      - ./api/src:/app/src
+      - ./api/package.json:/app/package.json:ro
+      - /app/node_modules
+    command: npm run dev
+```
+
+La línea `- /app/node_modules` crea un volumen anónimo para evitar que el `node_modules` del contenedor sea pisado por el del host. Este truco existe porque JavaScript decidió que las dependencias debían ocupar más espacio emocional que el propio proyecto. No vamos a arreglar eso hoy.
+
+En producción, en cambio, no montas el código fuente desde tu máquina. Construyes una imagen y solo montas los datos que deben persistir:
+
+```yaml
+# docker-compose.prod.yml
+services:
+  api:
+    build:
+      context: ./api
+      target: production
+    volumes:
+      - api-data:/app/data
+    command: npm start
+
+volumes:
+  api-data:
+```
+
+Y combinas ficheros según el entorno:
+
+```bash
+# Development
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+
+# Production
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+La idea es que `docker-compose.yml` contenga la base común y los ficheros específicos añadan o sobrescriban detalles. Igual que con [Git](/es/cursos/domina-git-desde-cero), versionas lo que describe el proyecto y dejas fuera lo que pertenece a una máquina concreta.
+
+## Backups: porque persistir no es hacer copia
+
+Un volumen persistente no es un backup. Repite conmigo: **persistencia no es backup**.
+
+Un named volume sobrevive a recrear contenedores. No te protege de `docker compose down -v`, de borrar el volumen manualmente, de corrupción de datos, de un script con demasiada confianza ni de ti un viernes por la tarde pensando “esto seguro que no rompe nada”.
+
+Para bases de datos, el backup más correcto suele ser usar la herramienta propia de la base de datos. Por ejemplo, con Postgres:
+
+```bash
+docker compose exec db pg_dump -U myapp myapp > backup.sql
+```
+
+Ese comando ejecuta `pg_dump` dentro del contenedor `db` y guarda el resultado en tu máquina. Es claro, portable y entiende el formato de la base de datos.
+
+También puedes hacer una copia de bajo nivel del volumen usando un contenedor temporal:
+
+```bash
+docker run --rm \
+  -v myproject_db-data:/data:ro \
+  -v "$(pwd)":/backup \
+  alpine \
+  tar czf /backup/db-data-backup.tar.gz -C /data .
+```
+
+Qué está pasando aquí:
+
+- `myproject_db-data:/data:ro` monta el volumen en modo solo lectura.
+- `"$(pwd)":/backup` monta tu carpeta actual como destino del backup.
+- `tar czf` empaqueta el contenido del volumen.
+- `--rm` elimina el contenedor temporal al terminar.
+
+Si llevas años peleándote con comillas en shell, habrás notado `"$(pwd)"`. Si no, no te preocupes: Bash tendrá su propio curso más adelante, porque este tema merece algo más que “copia esto y confía”. No es decoración. Es para que el comando no se rompa si la ruta contiene espacios. El shell siempre está esperando una oportunidad para recordarte que las comillas no son opcionales.
+
+Para restaurar en un volumen vacío:
+
+```bash
+docker volume create myproject_db-data
+
+docker run --rm \
+  -v myproject_db-data:/data \
+  -v "$(pwd)":/backup:ro \
+  alpine \
+  tar xzf /backup/db-data-backup.tar.gz -C /data
+```
+
+Para bases de datos en uso, no hagas backups de ficheros a lo loco mientras el motor está escribiendo. Para desarrollo puede sacarte de un apuro. Para producción, usa `pg_dump`, snapshots consistentes o la herramienta oficial de tu base de datos. La fe mueve montañas, pero no garantiza integridad transaccional.
+
+## Limpieza sin destruir lo importante
+
+Con Compose, estos comandos tienen efectos muy distintos:
+
+```bash
+docker compose stop
+docker compose down
+docker compose down -v
+docker volume ls
+docker volume rm myproject_db-data
+docker volume prune
+```
+
+La traducción humana:
+
+| Comando                   | Qué hace                                             |
+| ------------------------- | ---------------------------------------------------- |
+| `docker compose stop`     | Para contenedores, no elimina nada                   |
+| `docker compose down`     | Elimina contenedores y redes, conserva named volumes |
+| `docker compose down -v`  | Elimina contenedores, redes y volúmenes del proyecto |
+| `docker volume rm <name>` | Elimina un volumen concreto                          |
+| `docker volume prune`     | Elimina volúmenes no usados por ningún contenedor    |
+
+`docker volume prune` pide confirmación, pero no sabe qué volumen “era importante emocionalmente”. Solo sabe si está en uso. Si tienes un volumen viejo con datos que quieres conservar y ningún contenedor lo usa ahora mismo, puede caer.
+
+Antes de borrar, inspecciona:
+
+```bash
+docker volume inspect myproject_db-data
+```
+
+Y si tienes dudas, haz backup primero. Es aburrido. También lo es llevar cinturón de seguridad hasta el día en que deja de serlo.
+
+## Reto práctico
+
+Crea un `docker-compose.yml` con Postgres y una API falsa o cualquier imagen ligera que conozcas. Añade un named volume para Postgres, arranca la stack, crea algún dato, ejecuta `docker compose down` y vuelve a levantarla para comprobar que el dato sigue ahí.
+
+Después haz una copia del volumen con el contenedor temporal de `alpine`. No hace falta que montes un sistema de backup empresarial; basta con entender el flujo: volumen → archivo `.tar.gz` → restauración en un volumen vacío.
+
+---
+
+Con esto ya puedes tratar los datos en Docker Compose con el respeto que merecen: fuera del contenedor, con nombres claros, con diferencias limpias entre desarrollo y producción, y con backups que no dependen de cruzar los dedos. En el siguiente tutorial entraremos en networking en Docker Compose: redes por defecto, redes personalizadas, aislamiento entre servicios y por qué tu base de datos no debería estar saludando alegremente a todo el mundo.
+
+¡Nunca dejes de programar!


### PR DESCRIPTION
## What

Adds the Docker Compose volumes and data persistence tutorial (lesson 15 of the Docker course) in both Spanish and English.

## Content

- **The problem**: Containers' writable layer disappears with the container — data must live outside
- **Volume types**: Named volumes (persistent, Docker-managed), bind mounts (host paths for dev), anonymous volumes (auto-created, unlabeled), read-only volumes (`:ro`)
- **Database persistence**: Postgres, Mongo, and MySQL examples with their respective data directories
- **Initialization scripts**: `/docker-entrypoint-initdb.d` for Postgres — run once on empty volume
- **Development vs production**: Separate compose files, bind mounts for hot reload, anonymous volumes for `node_modules`
- **Backups**: `pg_dump` for database-aware backups, `alpine` container for raw volume tar backup/restore
- **Cleanup**: `stop` vs `down` vs `down -v` — what each preserves or removes

## Files

- `src/content/tutorials/docker-compose-volumes-data-persistence.mdx` (EN)
- `src/content/tutorials/volumenes-persistencia-datos-docker-compose.mdx` (ES)
