### PR TITLE
feat(content): add Docker Compose networking tutorial with service names, custom networks, and isolation

### DIFF
--- a/src/content/tutorials/docker-compose-networking.mdx
+++ b/src/content/tutorials/docker-compose-networking.mdx
@@ -1,0 +1,360 @@
+---
+title: "Docker Compose networking: networks, services, and isolation"
+post_slug: "docker-compose-networking"
+date: "2026-07-08"
+excerpt: "Learn Docker Compose networking: default networks, service names, ports, custom networks, external networks, and aliases without chasing changing IPs."
+language: "en"
+categories: ["docker"]
+course: "mastering-docker-from-scratch"
+order: 16
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "networking-docker-compose"
+---
+
+There is a very Docker Compose moment: Postgres is running, the API is running, the logs look reasonable, and the API still says it can't connect to `localhost:5432`.
+
+You check `docker compose ps`. Postgres is `Up`. You check the `docker-compose.yml`. The port is there. You stare at the screen with that specific mix of suspicion and tiredness that only appears when a tool is technically telling the truth in the least helpful way possible.
+
+Is Postgres down? No. Is the port wrong? Maybe, but probably not. Is `localhost` a trap with good branding? Exactly.
+
+In Docker Compose, each container lives in its own little network world. Once you understand that, the rest stops feeling like dark magic with YAML.
+
+## Compose's default network
+
+When you run `docker compose up`, Compose automatically creates a network for the project. If your directory is called `myapp`, that network is usually named something like `myapp_default`.
+
+All services in the `docker-compose.yml` join that network by default.
+
+```yaml
+services:
+  api:
+    image: myapp/api
+
+  db:
+    image: postgres:16-alpine
+```
+
+Even though you didn't write `networks:` anywhere, Compose did some work for you:
+
+```bash
+docker compose up -d
+docker network ls
+```
+
+You'll see a network like this:
+
+```text
+NETWORK ID     NAME            DRIVER    SCOPE
+abc123def456   myapp_default   bridge    local
+```
+
+Inside that network, services can find each other by **service name**. The API can connect to Postgres using `db` as the hostname.
+
+```text
+postgresql://myapp:secret@db:5432/myapp
+```
+
+Don't use the container IP. Container IPs can change when services are recreated. Using container IPs in Compose is like writing down where you parked three weeks ago on a napkin: technically useful for a few minutes.
+
+Use service names.
+
+## `localhost` inside a container is not your machine
+
+This is the main trap.
+
+From your machine, `localhost` means your machine.
+
+From inside a container, `localhost` means that container.
+
+```yaml
+services:
+  api:
+    image: myapp/api
+    environment:
+      DATABASE_URL: postgresql://myapp:secret@localhost:5432/myapp
+
+  db:
+    image: postgres:16-alpine
+```
+
+That is wrong for container-to-container communication. The API will look for Postgres inside the API container itself. Spoiler: it is not there. If it were, you'd have another problem, probably with a suspicious architecture smell.
+
+The correct version uses the service name:
+
+```yaml
+services:
+  api:
+    image: myapp/api
+    environment:
+      DATABASE_URL: postgresql://myapp:secret@db:5432/myapp
+
+  db:
+    image: postgres:16-alpine
+```
+
+Mental model:
+
+| Connecting from          | Correct host                         |
+| ------------------------ | ------------------------------------ |
+| Your browser to the API  | `localhost` if the port is published |
+| API to Postgres          | `db`                                 |
+| API to Redis             | `redis`                              |
+| One container to another | The service name                     |
+
+Don't stress if this feels counterintuitive at first. `localhost` has spent years looking innocent while ruining entire afternoons with a smile.
+
+## `ports` is not how containers talk to each other
+
+Another classic confusion: thinking you need to publish a port so another container can connect to it.
+
+You don't.
+
+```yaml
+services:
+  api:
+    build: ./api
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: postgresql://myapp:secret@db:5432/myapp
+
+  db:
+    image: postgres:16-alpine
+```
+
+The `ports: "3000:3000"` line publishes the API port to your machine. It lets you open `http://localhost:3000` from your browser.
+
+But the API does not need Postgres to have `ports: "5432:5432"` to connect to `db:5432`. Both services are already on the internal Compose network.
+
+This matters for security. If you publish Postgres like this:
+
+```yaml
+services:
+  db:
+    image: postgres:16-alpine
+    ports:
+      - "5432:5432"
+```
+
+You're exposing the database to the host. In development that can be useful if you want to connect with TablePlus, DBeaver, local `psql`, or another external tool. But don't do it “just in case”. “Just in case” in infrastructure is a polite way of saying “I'll leave this door open and see what happens”.
+
+If only the API needs to talk to the database, don't publish the port.
+
+## Custom networks: separate rooms
+
+The default network is fine for small projects. All services can see each other and life goes on.
+
+But in a more realistic application, you might have:
+
+- `web`: frontend or reverse proxy.
+- `api`: backend.
+- `db`: database.
+- `redis`: cache.
+
+There is no reason for `web` to connect directly to `db`. The frontend talks to the API. The API talks to the database. The database should not be standing in the lobby waving at the entire building.
+
+You can model that with custom networks:
+
+```yaml
+services:
+  web:
+    image: nginx:alpine
+    ports:
+      - "8080:80"
+    networks:
+      - frontend
+
+  api:
+    image: myapp/api
+    networks:
+      - frontend
+      - backend
+
+  db:
+    image: postgres:16-alpine
+    networks:
+      - backend
+
+networks:
+  frontend:
+  backend:
+```
+
+Now the rules are clear:
+
+| Service | Networks              | Can talk to |
+| ------- | --------------------- | ----------- |
+| `web`   | `frontend`            | `api`       |
+| `api`   | `frontend`, `backend` | `web`, `db` |
+| `db`    | `backend`             | `api`       |
+
+`web` and `db` do not share a network, so they cannot resolve each other by name or connect directly. This does not replace authentication, firewalls, permissions, or common sense, but it reduces surface area. And reducing surface area is one of those boring things that prevents interesting incidents. Interesting incidents are overrated.
+
+## `expose` vs `ports`
+
+Compose also has `expose`:
+
+```yaml
+services:
+  api:
+    image: myapp/api
+    expose:
+      - "3000"
+```
+
+`expose` documents that a service listens on a port for other services on the network, but it does not publish that port to your machine.
+
+In practice, services on the same network can connect to a container port even if you don't write `expose`. That's why many teams don't use it. It can be useful as documentation inside the `docker-compose.yml`, but don't confuse it with security.
+
+The important difference:
+
+| Field    | Publishes to host | Main use                            |
+| -------- | ----------------- | ----------------------------------- |
+| `ports`  | Yes               | Access from your machine or outside |
+| `expose` | No                | Document internal ports             |
+
+If you want to open something from the browser, use `ports`. If only containers talk to each other, you usually don't need anything.
+
+## External networks
+
+Sometimes you want several Compose projects to share a network. For example, a common reverse proxy (`traefik`, `nginx`, `caddy`) routing multiple local apps or services on the same server.
+
+First create the network manually:
+
+```bash
+docker network create shared-proxy
+```
+
+Then declare it as external:
+
+```yaml
+services:
+  app:
+    image: myapp/api
+    networks:
+      - shared-proxy
+
+networks:
+  shared-proxy:
+    external: true
+```
+
+`external: true` means: “Compose, don't create this network; it already exists, use it.”
+
+If the network doesn't exist, Compose fails. And that's good. Better to fail than silently create a new network and leave you wondering for half an hour why the proxy can't see your app. Docker already has enough material to confuse you without extra help.
+
+## Network aliases
+
+By default, each service resolves by its name: `api`, `db`, `redis`.
+
+Sometimes you want additional names. That's what **aliases** are for.
+
+```yaml
+services:
+  api:
+    image: myapp/api
+    networks:
+      backend:
+        aliases:
+          - api-service
+          - internal-api
+
+  worker:
+    image: myapp/worker
+    networks:
+      - backend
+
+networks:
+  backend:
+```
+
+From `worker`, these hostnames point to the `api` service:
+
+```text
+api
+api-service
+internal-api
+```
+
+Use this carefully. An alias can help when a legacy application expects a specific hostname. But if you start adding three names per service “for convenience”, you'll end up with a tiny home-made DNS system inside YAML. Like having five nicknames for the same person in a group chat: funny until someone new tries to understand the conversation.
+
+## Complete example
+
+A reasonable stack with reverse proxy, API, database, and cache:
+
+```yaml
+services:
+  web:
+    image: nginx:alpine
+    ports:
+      - "8080:80"
+    networks:
+      - frontend
+
+  api:
+    build: ./api
+    environment:
+      DATABASE_URL: postgresql://myapp:secret@db:5432/myapp
+      REDIS_URL: redis://redis:6379
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - frontend
+      - backend
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: myapp
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: myapp
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U myapp -d myapp"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    networks:
+      - backend
+
+  redis:
+    image: redis:7-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+    networks:
+      - backend
+
+volumes:
+  db-data:
+
+networks:
+  frontend:
+  backend:
+```
+
+Notice three details:
+
+- Only `web` publishes a port to the host.
+- `api` talks to `db` and `redis` using service names.
+- `db` and `redis` are not on `frontend`, so `web` cannot talk to them directly.
+
+This does not turn your app into Fort Knox. But you're no longer putting every service in the same room with a sticky note that says “be nice”.
+
+## Practical challenge
+
+Take the `docker-compose.yml` from the previous tutorial and split it into two networks: `frontend` and `backend`. The API should be on both. Postgres and Redis should only be on `backend`. If you have a web or proxy service, put it only on `frontend` and publish only its port.
+
+Then verify that your internal URLs use service names (`db`, `redis`, `api`) and not `localhost`. If you find a `localhost` inside an environment variable used between containers, don't look at it fondly: change it.
+
+---
+
+You now have the right mental map: Compose creates a default network, services discover each other by name, `ports` is for reaching your machine, and custom networks let you isolate what should not talk directly. In the next tutorial we'll close the Compose module with best practices: environment-specific files, secrets, resource limits, logging, and the small details that separate a useful `docker-compose.yml` from one that looks written during a power outage.
+
+Never stop coding!

--- a/src/content/tutorials/networking-docker-compose.mdx
+++ b/src/content/tutorials/networking-docker-compose.mdx
@@ -1,0 +1,360 @@
+---
+title: "Networking en Docker Compose: redes, servicios y aislamiento"
+post_slug: "networking-docker-compose"
+date: "2026-07-08"
+excerpt: "Aprende cómo funciona el networking en Docker Compose: red por defecto, service names, ports, redes personalizadas, external networks y aliases sin perderte en IPs que cambian."
+language: "es"
+categories: ["docker"]
+course: "domina-docker-desde-cero"
+order: 16
+cover: "/images/tutorials/cabecera-docker-curso.jpg"
+i18n: "docker-compose-networking"
+---
+
+Hay un momento muy Docker Compose: tienes Postgres arrancado, la API arrancada, los logs parecen razonables, y aun así la API dice que no puede conectar a `localhost:5432`.
+
+Miras `docker compose ps`. Postgres está `Up`. Miras el `docker-compose.yml`. El puerto está ahí. Miras la pantalla con esa mezcla de sospecha y cansancio que solo aparece cuando una herramienta te está diciendo técnicamente la verdad, pero de la forma menos útil posible.
+
+¿Está Postgres caído? No. ¿Está mal el puerto? Puede, pero seguramente no. ¿Es `localhost` una trampa con buena reputación? Exacto.
+
+En Docker Compose, cada contenedor vive en su propio pequeño mundo de red. Si entiendes eso, el resto deja de parecer magia negra con YAML.
+
+## La red por defecto de Compose
+
+Cuando ejecutas `docker compose up`, Compose crea automáticamente una red para el proyecto. Si tu carpeta se llama `myapp`, esa red suele llamarse algo como `myapp_default`.
+
+Todos los servicios del `docker-compose.yml` se conectan a esa red por defecto.
+
+```yaml
+services:
+  api:
+    image: myapp/api
+
+  db:
+    image: postgres:16-alpine
+```
+
+Aunque no hayas escrito `networks:` en ninguna parte, Compose ha hecho trabajo por ti:
+
+```bash
+docker compose up -d
+docker network ls
+```
+
+Verás una red parecida a esta:
+
+```text
+NETWORK ID     NAME            DRIVER    SCOPE
+abc123def456   myapp_default   bridge    local
+```
+
+Dentro de esa red, los servicios pueden encontrarse usando su **service name**. La API puede conectar a Postgres usando `db` como hostname.
+
+```text
+postgresql://myapp:secret@db:5432/myapp
+```
+
+No uses la IP del contenedor. Las IPs pueden cambiar cuando recreas servicios. Usar IPs de contenedor en Compose es como apuntar en una servilleta dónde aparcaste el coche hace tres semanas: técnicamente fue información útil durante unos minutos.
+
+Usa nombres de servicio.
+
+## `localhost` dentro de un contenedor no es tu máquina
+
+Aquí está la trampa principal.
+
+Desde tu máquina, `localhost` significa tu máquina.
+
+Desde dentro de un contenedor, `localhost` significa ese contenedor.
+
+```yaml
+services:
+  api:
+    image: myapp/api
+    environment:
+      DATABASE_URL: postgresql://myapp:secret@localhost:5432/myapp
+
+  db:
+    image: postgres:16-alpine
+```
+
+Eso está mal para comunicación entre contenedores. La API buscará Postgres dentro del propio contenedor de la API. Spoiler: no está ahí. Si lo estuviera, tendrías otro problema, probablemente con acento de arquitectura improvisada.
+
+La versión correcta usa el nombre del servicio:
+
+```yaml
+services:
+  api:
+    image: myapp/api
+    environment:
+      DATABASE_URL: postgresql://myapp:secret@db:5432/myapp
+
+  db:
+    image: postgres:16-alpine
+```
+
+La regla mental:
+
+| Desde dónde conectas | Host correcto                       |
+| -------------------- | ----------------------------------- |
+| Tu navegador al API  | `localhost` si publicaste el puerto |
+| API a Postgres       | `db`                                |
+| API a Redis          | `redis`                             |
+| Un contenedor a otro | El service name                     |
+
+No te agobies si esto te parece contraintuitivo al principio. `localhost` lleva años pareciendo una palabra inocente mientras arruina tardes enteras con una sonrisa.
+
+## `ports` no es para que los contenedores se hablen
+
+Otra confusión clásica: creer que necesitas publicar un puerto para que otro contenedor pueda conectarse.
+
+No.
+
+```yaml
+services:
+  api:
+    build: ./api
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: postgresql://myapp:secret@db:5432/myapp
+
+  db:
+    image: postgres:16-alpine
+```
+
+El `ports: "3000:3000"` publica el puerto de la API hacia tu máquina. Sirve para que puedas abrir `http://localhost:3000` desde el navegador.
+
+Pero la API no necesita que Postgres tenga `ports: "5432:5432"` para conectar con `db:5432`. Ambos servicios están en la misma red interna de Compose.
+
+Esto es importante por seguridad. Si publicas Postgres así:
+
+```yaml
+services:
+  db:
+    image: postgres:16-alpine
+    ports:
+      - "5432:5432"
+```
+
+Estás exponiendo la base de datos al host. En desarrollo puede ser útil si quieres conectar con TablePlus, DBeaver, `psql` local o cualquier herramienta externa. Pero no lo hagas “por si acaso”. El “por si acaso” en infraestructura es una forma elegante de decir “aquí dejo una puerta abierta y ya veremos”.
+
+Si solo la API necesita hablar con la base de datos, no publiques el puerto.
+
+## Redes personalizadas: separar habitaciones
+
+La red por defecto está bien para proyectos pequeños. Todos los servicios se ven entre sí y listo.
+
+Pero en una aplicación algo más realista, quizá tienes:
+
+- `web`: frontend o reverse proxy.
+- `api`: backend.
+- `db`: base de datos.
+- `redis`: caché.
+
+No hay ninguna razón para que `web` pueda conectar directamente a `db`. El frontend habla con la API. La API habla con la base de datos. La base de datos no debería estar en el portal saludando a todo el edificio.
+
+Puedes modelarlo con redes personalizadas:
+
+```yaml
+services:
+  web:
+    image: nginx:alpine
+    ports:
+      - "8080:80"
+    networks:
+      - frontend
+
+  api:
+    image: myapp/api
+    networks:
+      - frontend
+      - backend
+
+  db:
+    image: postgres:16-alpine
+    networks:
+      - backend
+
+networks:
+  frontend:
+  backend:
+```
+
+Ahora las reglas son claras:
+
+| Servicio | Redes                 | Puede hablar con |
+| -------- | --------------------- | ---------------- |
+| `web`    | `frontend`            | `api`            |
+| `api`    | `frontend`, `backend` | `web`, `db`      |
+| `db`     | `backend`             | `api`            |
+
+`web` y `db` no comparten red, así que no pueden resolverse por nombre ni conectarse directamente. Esto no sustituye autenticación, firewall, permisos ni sentido común, pero reduce superficie. Y reducir superficie es una de esas cosas aburridas que te ahorran incidentes interesantes. Los incidentes interesantes están sobrevalorados.
+
+## `expose` vs `ports`
+
+Compose también tiene `expose`:
+
+```yaml
+services:
+  api:
+    image: myapp/api
+    expose:
+      - "3000"
+```
+
+`expose` documenta que un servicio escucha en un puerto para otros servicios de la red, pero no lo publica en tu máquina.
+
+En la práctica, los servicios en la misma red pueden conectar al puerto del contenedor aunque no escribas `expose`. Por eso muchos equipos ni lo usan. Puede ser útil como documentación dentro del `docker-compose.yml`, pero no lo confundas con seguridad.
+
+La diferencia importante:
+
+| Campo    | Publica al host | Uso principal                          |
+| -------- | --------------- | -------------------------------------- |
+| `ports`  | Sí              | Acceder desde tu máquina o desde fuera |
+| `expose` | No              | Documentar puertos internos            |
+
+Si quieres abrir algo desde el navegador, usa `ports`. Si solo se hablan contenedores, normalmente no necesitas nada.
+
+## External networks
+
+A veces quieres que varios proyectos Compose compartan una red. Por ejemplo, un reverse proxy común (`traefik`, `nginx`, `caddy`) que enruta varias aplicaciones locales o varios servicios en un mismo servidor.
+
+Primero creas la red manualmente:
+
+```bash
+docker network create shared-proxy
+```
+
+Luego la declaras como externa:
+
+```yaml
+services:
+  app:
+    image: myapp/api
+    networks:
+      - shared-proxy
+
+networks:
+  shared-proxy:
+    external: true
+```
+
+`external: true` significa: “Compose, no crees esta red; ya existe, úsala”.
+
+Si la red no existe, Compose fallará. Y eso está bien. Mejor fallar que inventarse una red nueva y dejarte media hora preguntándote por qué el proxy no ve tu aplicación. Docker ya tiene suficiente material para confundirte sin ayuda extra.
+
+## Network aliases
+
+Por defecto, cada servicio se resuelve por su nombre: `api`, `db`, `redis`.
+
+A veces quieres nombres adicionales. Ahí entran los **aliases**.
+
+```yaml
+services:
+  api:
+    image: myapp/api
+    networks:
+      backend:
+        aliases:
+          - api-service
+          - internal-api
+
+  worker:
+    image: myapp/worker
+    networks:
+      - backend
+
+networks:
+  backend:
+```
+
+Desde `worker`, estos hostnames apuntan al servicio `api`:
+
+```text
+api
+api-service
+internal-api
+```
+
+Úsalo con cuidado. Un alias puede ayudar cuando una aplicación legacy espera un hostname concreto. Pero si empiezas a poner tres nombres por servicio “por comodidad”, acabarás con un pequeño DNS doméstico dentro del YAML. Como tener cinco motes para la misma persona en un grupo de WhatsApp: divertido hasta que alguien nuevo intenta entender la conversación.
+
+## Ejemplo completo
+
+Un stack razonable con reverse proxy, API, base de datos y caché:
+
+```yaml
+services:
+  web:
+    image: nginx:alpine
+    ports:
+      - "8080:80"
+    networks:
+      - frontend
+
+  api:
+    build: ./api
+    environment:
+      DATABASE_URL: postgresql://myapp:secret@db:5432/myapp
+      REDIS_URL: redis://redis:6379
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - frontend
+      - backend
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: myapp
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: myapp
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U myapp -d myapp"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    networks:
+      - backend
+
+  redis:
+    image: redis:7-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+    networks:
+      - backend
+
+volumes:
+  db-data:
+
+networks:
+  frontend:
+  backend:
+```
+
+Fíjate en tres detalles:
+
+- Solo `web` publica un puerto al host.
+- `api` habla con `db` y `redis` usando service names.
+- `db` y `redis` no están en `frontend`, así que `web` no puede hablarles directamente.
+
+Esto no convierte tu aplicación en Fort Knox. Pero ya no estás poniendo todos los servicios en la misma sala con una etiqueta que dice “sed buenos”.
+
+## Reto práctico
+
+Coge el `docker-compose.yml` del tutorial anterior y sepáralo en dos redes: `frontend` y `backend`. La API debe estar en ambas. Postgres y Redis solo en `backend`. Si tienes un servicio web o proxy, ponlo solo en `frontend` y publica únicamente su puerto.
+
+Después verifica que tus URLs internas usan service names (`db`, `redis`, `api`) y no `localhost`. Si encuentras un `localhost` dentro de una variable de entorno entre contenedores, no lo mires con cariño: cámbialo.
+
+---
+
+Con esto ya tienes el mapa mental correcto: Compose crea una red por defecto, los servicios se descubren por nombre, `ports` es para salir hacia tu máquina, y las redes personalizadas te permiten aislar lo que no debería hablar directamente. En el siguiente tutorial cerraremos el módulo de Compose con buenas prácticas: ficheros por entorno, secrets, resource limits, logging y esos pequeños detalles que separan un `docker-compose.yml` útil de uno que parece escrito durante un apagón.
+
+¡Nunca dejes de programar!


### PR DESCRIPTION
## What

Adds the Docker Compose networking tutorial (lesson 16 of the Docker course) in both Spanish and English.

## Content

- **Default Compose network**: Automatic `project_default` network, service name DNS resolution
- **The `localhost` trap**: Inside a container `localhost` means itself — use service names for inter-container communication
- **`ports` vs internal access**: `ports` publishes to the host; containers on the same network connect directly without published ports
- **Custom networks**: `frontend`/`backend` separation for service isolation — control which services can reach each other
- **`expose` vs `ports`**: Documenting internal ports vs publishing to the host
- **External networks**: Sharing a network across Compose projects with `external: true`
- **Network aliases**: Additional hostnames for a service on a specific network
- **Complete example**: Reverse proxy (nginx), API, Postgres, and Redis with properly isolated networks

## Files

- `src/content/tutorials/docker-compose-networking.mdx` (EN)
- `src/content/tutorials/networking-docker-compose.mdx` (ES)
