### PR TITLE
feat(content): add SQL From Zero to DBA course announcement with categories and course definitions

### DIFF
--- a/src/content/categories/sql-en.json
+++ b/src/content/categories/sql-en.json
@@ -1,0 +1,6 @@
+{
+  "name": "SQL",
+  "category_slug": "sql",
+  "language": "en",
+  "i18n": "sql"
+}

--- a/src/content/categories/sql-es.json
+++ b/src/content/categories/sql-es.json
@@ -1,0 +1,6 @@
+{
+  "name": "SQL",
+  "category_slug": "sql",
+  "language": "es",
+  "i18n": "sql"
+}

--- a/src/content/courses/sql-de-cero-a-dba.json
+++ b/src/content/courses/sql-de-cero-a-dba.json
@@ -1,0 +1,7 @@
+{
+  "name": "SQL: de cero a DBA",
+  "course_slug": "sql-de-cero-a-dba",
+  "language": "es",
+  "description": "Aprende SQL y PostgreSQL desde cero hasta desarrollar criterio de DBA: modelo relacional, consultas, joins, agregaciones, índices, rendimiento, transacciones, seguridad, ORMs y operación en producción.",
+  "i18n": "sql-from-zero-to-dba"
+}

--- a/src/content/courses/sql-from-zero-to-dba.json
+++ b/src/content/courses/sql-from-zero-to-dba.json
@@ -1,0 +1,7 @@
+{
+  "name": "SQL: From Zero to DBA",
+  "course_slug": "sql-from-zero-to-dba",
+  "language": "en",
+  "description": "Learn SQL and PostgreSQL from zero to DBA-level judgment: relational modeling, queries, joins, aggregations, indexes, performance, transactions, security, ORMs, and production operations.",
+  "i18n": "sql-de-cero-a-dba"
+}

--- a/src/content/posts/presentacion-curso-sql-cero-dba.mdx
+++ b/src/content/posts/presentacion-curso-sql-cero-dba.mdx
@@ -1,0 +1,105 @@
+---
+title: "Presentación del curso SQL: de cero a DBA"
+post_slug: "presentacion-curso-sql-cero-dba"
+date: "2026-07-09"
+excerpt: "¿Tu ORM genera una query lenta y tú solo puedes mirarla con fe? Este curso gratuito te lleva de cero a SQL, PostgreSQL y criterio de DBA."
+language: "es"
+categories: ["programacion"]
+cover: "/images/posts/cabecera-sql-post.jpg"
+i18n: "presentation-sql-zero-dba-course"
+---
+
+Hay un momento muy concreto en la vida de cualquier developer: la aplicación funciona, los tests pasan, el deploy parece sano… y entonces alguien abre un dashboard y pregunta por qué “la página de pedidos tarda 18 segundos”.
+
+Miras el código. Ves un ORM. Ves una relación que carga otra relación que carga otra relación. Abres los logs y aparece una procesión de `SELECT` como si la base de datos estuviera rezando el rosario en modo debug.
+
+¿Es culpa del ORM? A veces. ¿Es culpa de PostgreSQL? Casi nunca. ¿Es culpa de que nadie entiende realmente qué SQL está ejecutando la aplicación? Aquí es donde la sala se queda incómodamente silenciosa.
+
+Bienvenido al curso **SQL: de cero a DBA**: un curso completo y gratuito para aprender SQL y PostgreSQL desde cero absoluto hasta tener criterio real de diseño, consultas, rendimiento, seguridad y operación de bases de datos. No “sé hacer un `SELECT`”. No “Prisma me lo genera”. Entenderlo de verdad.
+
+### Por qué SQL importa más de lo que parece
+
+Durante años se ha vendido una idea peligrosa: “no necesitas aprender SQL porque usas un ORM”. Suena cómodo. También suena como decir que no necesitas aprender a conducir porque tu coche tiene sensores de aparcamiento.
+
+Los ORMs son útiles. Muchísimo. Pero generan SQL. Y cuando ese SQL es lento, incorrecto o peligroso, alguien tiene que leerlo sin poner la misma cara que pondrías al abrir un mueble de IKEA y encontrar tres bolsas de tornillos, dos manuales y una pieza metálica que no aparece en ningún dibujo.
+
+SQL no es solo sintaxis. Es el lenguaje con el que preguntas cosas a tus datos, modelas relaciones, proteges invariantes, optimizas consultas, evitas corrupción silenciosa y descubres si ese `UPDATE` sin `WHERE` está a punto de convertir producción en una experiencia educativa no solicitada.
+
+El objetivo del curso es construir ese mapa completo: desde qué es una base de datos hasta leer un `EXPLAIN ANALYZE`, entender índices, diseñar esquemas, trabajar con transacciones, detectar N+1, usar window functions y saber cuándo un ORM está ayudando y cuándo está llevando una motosierra a una operación de precisión.
+
+### Qué hace diferente a este curso
+
+Muchos cursos de SQL fallan por el mismo motivo: enseñan comandos como si fueran recetas sueltas.
+
+`SELECT`, `WHERE`, `JOIN`, `GROUP BY`, `INDEX`. Todo ordenado, todo aparentemente claro, todo muy bonito… hasta que aparece `NULL`, una query con cinco joins, una migración en producción o una tabla con diez millones de filas que decide recordarte que la teoría no paga la factura de CPU.
+
+Este curso va por otro camino:
+
+- **Conceptos antes que sintaxis**: primero entendemos qué problema resuelve una base de datos, qué es el modelo relacional y por qué una tabla no es “un Excel con esteroides”. Luego escribimos SQL.
+- **PostgreSQL desde el principio**: usaremos PostgreSQL 18 con Docker, `psql` como herramienta principal y pgAdmin como apoyo visual. CLI primero; el ratón puede venir, pero no conduce.
+- **Rendimiento desde pronto, no como apéndice final**: los problemas de performance aparecen desde los primeros módulos: `LIKE '%texto'`, `OFFSET`, subqueries correlacionadas, casts implícitos, joins sin índice. La base de datos no espera al módulo avanzado para volverse lenta.
+- **Schema design en serio**: normalización, claves primarias, foreign keys, constraints, nombres, documentación y migraciones. Diseñar tablas es arquitectura, no rellenar formularios hasta que algo compile.
+- **ORMs sin religión**: aprenderás qué resuelven, qué esconden, cuándo ayudan y cuándo tienes que escribir SQL tú mismo porque el generador ha decidido improvisar jazz con tus datos.
+- **Mentalidad de producción**: backups, locks, transacciones, índices, seguridad, permisos, monitoring, vacuum, replicación y ese tipo de temas que parecen aburridos hasta que dejan de serlo a las tres de la mañana.
+
+La idea es simple: no quiero que termines el curso diciendo “sé SQL”. Quiero que puedas abrir una query ajena, leerla, respirar hondo y decir: “vale, ya veo dónde va a doler”. Eso es criterio.
+
+### Qué vas a aprender
+
+El curso tiene **75 lecciones en 12 módulos más un proyecto final**, diseñado para llevarte desde cero hasta un nivel cercano a DBA junior con mucho criterio de aplicación real:
+
+1. **Qué es una base de datos**: por qué existen, qué problema resuelven, PostgreSQL con Docker, tablas, filas, columnas, primary keys, `NULL` y tus primeros datos.
+2. **Tus primeras queries con `SELECT`**: columnas, aliases, tipos de datos, strings, fechas, números y la maravillosa lógica de tres valores de `NULL`, que no es rara: es SQL siendo SQL.
+3. **Filtrado, ordenación y consultas multi-paso**: `WHERE`, `ORDER BY`, `LIMIT`, `CASE`, subqueries, CTEs y el orden real de ejecución de una query.
+4. **Modelado relacional**: normalización, relaciones, foreign keys, primary keys, constraints, diseño de esquemas y documentación de base de datos.
+5. **Joins**: `INNER`, `LEFT`, `FULL`, `CROSS`, self joins, rendimiento de joins y el clásico producto cartesiano accidental, que es como abrir una bolsa de confeti dentro del servidor.
+6. **Agregaciones y reporting**: `COUNT`, `SUM`, `GROUP BY`, `HAVING`, window functions, rankings, running totals, percentiles y preguntas reales de negocio.
+7. **Modificar datos sin destruir el mundo**: `INSERT`, `UPDATE`, `DELETE`, transactions, locks, concurrencia y migraciones seguras.
+8. **Índices y performance**: B-tree, GIN, GiST, BRIN, partial indexes, covering indexes, `EXPLAIN ANALYZE`, query plans, keyset pagination y optimización con método.
+9. **SQL avanzado**: views, materialized views, stored procedures, triggers, JSONB, arrays, range types, lateral joins, seguridad, roles, permisos y SQL injection.
+10. **ORMs**: qué son, cómo generan SQL, lazy loading, eager loading, N+1, migrations generadas y cuándo usar ORM, query builder o SQL puro.
+11. **PostgreSQL DBA essentials**: arquitectura interna, backups, recovery, replication, high availability, PgBouncer, monitoring, vacuum, bloat y extensiones como `pg_stat_statements`, `pg_trgm` o `pgvector`.
+12. **Más allá de lo relacional**: NoSQL, document databases, Redis, Cassandra, graph databases, time-series, NewSQL, vector databases y cuándo cada herramienta tiene sentido.
+
+El proyecto final será **BookShelf**, una plataforma ficticia para registrar libros, reseñas, seguidores y recomendaciones. Diseñarás el schema, cargarás datos, escribirás queries reales, analizarás rendimiento, añadirás índices, usarás RLS, crearás una materialized view y documentarás decisiones. O sea: una base de datos con suficiente realidad como para que deje de parecer un ejercicio de juguete.
+
+### ¿Necesito conocimientos previos?
+
+De bases de datos, no. El curso empieza desde cero absoluto: qué es una base de datos, por qué no basta con guardar un CSV y qué significa realmente tener datos persistentes, consultables y relacionados.
+
+Lo que sí necesitas:
+
+- Saber moverte mínimamente por la terminal. No hace falta vivir en ella, pero sí dejar de mirarla como si fuera una cueva con WiFi.
+- Tener Docker instalado y entender lo básico de contenedores y volúmenes. Si aún no lo tienes claro, el curso [Domina Docker desde cero](/es/cursos/domina-docker-desde-cero) encaja justo antes de este, especialmente hasta la lección de volúmenes y persistencia.
+- Ganas de entender, no solo de copiar queries que “parecen funcionar”.
+- Paciencia con `NULL`. No porque sea difícil. Porque tiene personalidad.
+
+Si vienes de backend, analytics, DevOps o cualquier entorno donde haya datos, vas a reconocer muchos problemas. Si empiezas desde cero, mejor todavía: aprenderás el modelo mental antes de acumular supersticiones, que en bases de datos abundan. Algunas incluso tienen documentación corporativa.
+
+### Una advertencia honesta
+
+SQL parece pequeño desde fuera. Cuatro comandos, unas tablas, un par de joins y listo. Esa es la trampa.
+
+La profundidad está en los detalles: cuándo una query usa índice, por qué `COUNT(*)` y `COUNT(column)` no cuentan lo mismo, qué pasa si filtras mal un `LEFT JOIN`, por qué una migración aparentemente inocente bloquea una tabla, cómo elegir una primary key, cuándo un índice ayuda y cuándo convierte los writes en una procesión lenta con velas.
+
+Este curso no promete que “domines bases de datos en un fin de semana”. Eso es marketing con una camiseta de PostgreSQL. Lo que promete es un camino progresivo, práctico y con contexto para que entiendas por qué cada concepto existe y qué problema resuelve.
+
+Porque una base de datos no es una caja donde tiras JSON hasta que alguien inventa un dashboard. Es una pieza central de tu sistema. Si la modelas mal, todo lo demás paga intereses. Si la entiendes bien, tu aplicación respira mejor.
+
+### De escribir queries a pensar en datos
+
+La evolución del curso es deliberada.
+
+Primero aprenderás a preguntar: `SELECT`, `WHERE`, funciones, filtros. Después aprenderás a estructurar: tablas, relaciones, constraints, joins. Luego aprenderás a resumir y analizar: agregaciones, window functions, reporting. Más adelante vendrá lo que separa a quien usa SQL de quien entiende bases de datos: transacciones, locks, índices, planes de ejecución, seguridad, migraciones, backups y operación.
+
+Al final, no quiero que SQL te parezca “esa cosa que hay debajo del ORM”. Quiero que lo veas como lo que es: una herramienta precisa para pensar sobre datos. A veces elegante. A veces peligrosa. A veces con `NULL` mirándote desde una esquina como si no hubiese roto nada.
+
+Y cuando entiendes eso, cambia cómo programas. Cambia cómo diseñas. Cambia cómo revisas código. Cambia incluso cómo lees un ticket que dice “la página carga lenta” sin empezar directamente a culpar a la red, al frontend o a Mercurio.
+
+Y antes de cerrar: un saludo a Marisa, mi profesora de bases de datos. Si me estás leyendo, que sepas que presté atención en tus clases. Tardé años en convertirlo en curso, pero la semilla estaba ahí.
+
+---
+
+**Primera lección disponible el 10 de julio**: “Por qué necesitamos bases de datos”.
+
+¡Nunca dejes de programar!

--- a/src/content/posts/presentation-sql-zero-dba-course.mdx
+++ b/src/content/posts/presentation-sql-zero-dba-course.mdx
@@ -1,0 +1,105 @@
+---
+title: "Introducing the SQL: From Zero to DBA Course"
+post_slug: "presentation-sql-zero-dba-course"
+date: "2026-07-09"
+excerpt: "Your ORM generated a slow query and all you can do is stare at it with hope? This free course takes you from zero to SQL, PostgreSQL, and DBA-level judgment."
+language: "en"
+categories: ["programming"]
+cover: "/images/posts/cabecera-sql-post.jpg"
+i18n: "presentacion-curso-sql-cero-dba"
+---
+
+There is a very specific moment in every developer's life: the application works, the tests pass, the deploy looks healthy… and then someone opens a dashboard and asks why “the orders page takes 18 seconds to load.”
+
+You check the code. You see an ORM. You see one relationship loading another relationship loading another relationship. You open the logs and a procession of `SELECT` statements appears, like the database is performing a debugging ritual with candles.
+
+Is it the ORM's fault? Sometimes. Is it PostgreSQL's fault? Almost never. Is it because nobody actually understands the SQL the application is running? This is where the room gets uncomfortably quiet.
+
+Welcome to **SQL: From Zero to DBA**: a complete, free course to learn SQL and PostgreSQL from absolute zero to real judgment around schema design, queries, performance, security, and database operations. Not “I can write a `SELECT`.” Not “Prisma generates it for me.” Actually understanding it.
+
+### Why SQL matters more than it looks
+
+For years, a dangerous idea has been floating around: “you don't need to learn SQL because you use an ORM.” Comfortable, yes. Also a bit like saying you don't need to learn how to drive because your car has parking sensors.
+
+ORMs are useful. Very useful. But they generate SQL. And when that SQL is slow, wrong, or dangerous, someone has to read it without making the same face you make when opening IKEA furniture and finding three bags of screws, two manuals, and one metal piece that appears in none of the drawings.
+
+SQL is not just syntax. It's the language you use to ask questions of your data, model relationships, protect invariants, optimize queries, avoid silent corruption, and discover whether that `UPDATE` without a `WHERE` clause is about to turn production into an unsolicited learning experience.
+
+The goal of this course is to build the whole map: from what a database is to reading `EXPLAIN ANALYZE`, understanding indexes, designing schemas, working with transactions, detecting N+1 problems, using window functions, and knowing when an ORM is helping and when it has brought a chainsaw to precision surgery.
+
+### What makes this course different?
+
+Many SQL courses fail for the same reason: they teach commands as disconnected recipes.
+
+`SELECT`, `WHERE`, `JOIN`, `GROUP BY`, `INDEX`. Everything organized, everything apparently clear, everything nice and tidy… until `NULL` shows up, or a query with five joins, or a production migration, or a table with ten million rows politely reminds you that theory does not pay the CPU bill.
+
+This course takes a different route:
+
+- **Concepts before syntax**: first we understand what problem databases solve, what the relational model is, and why a table is not “Excel with stronger opinions.” Then we write SQL.
+- **PostgreSQL from the start**: we'll use PostgreSQL 18 with Docker, `psql` as the main tool, and pgAdmin as a visual helper. CLI first; the mouse may come along, but it doesn't drive.
+- **Performance early, not as an appendix**: performance problems appear from the first modules: `LIKE '%text'`, `OFFSET`, correlated subqueries, implicit casts, joins without indexes. The database does not wait for the advanced module to become slow.
+- **Serious schema design**: normalization, primary keys, foreign keys, constraints, naming, documentation, and migrations. Designing tables is architecture, not filling forms until something compiles.
+- **ORMs without religion**: you'll learn what they solve, what they hide, when they help, and when you need to write SQL yourself because the generator decided to improvise jazz with your data.
+- **Production mindset**: backups, locks, transactions, indexes, security, permissions, monitoring, vacuum, replication, and all those topics that sound boring until they stop being boring at 3 AM.
+
+The idea is simple: I don't want you to finish the course saying “I know SQL.” I want you to open someone else's query, read it, take a deep breath, and say: “right, I can see where this is going to hurt.” That's judgment.
+
+### What will I learn?
+
+The course has **75 lessons across 12 modules plus a final project**, designed to take you from zero to near junior-DBA level with strong application-level judgment:
+
+1. **What a database is**: why databases exist, what problem they solve, PostgreSQL with Docker, tables, rows, columns, primary keys, `NULL`, and your first data.
+2. **Your first `SELECT` queries**: columns, aliases, data types, strings, dates, numbers, and the delightful three-valued logic of `NULL`, which is not weird: it's SQL being SQL.
+3. **Filtering, sorting, and multi-step queries**: `WHERE`, `ORDER BY`, `LIMIT`, `CASE`, subqueries, CTEs, and the real execution order of a query.
+4. **Relational modeling**: normalization, relationships, foreign keys, primary keys, constraints, schema design, and database documentation.
+5. **Joins**: `INNER`, `LEFT`, `FULL`, `CROSS`, self joins, join performance, and the accidental Cartesian product, which is basically opening a confetti cannon inside your server.
+6. **Aggregations and reporting**: `COUNT`, `SUM`, `GROUP BY`, `HAVING`, window functions, rankings, running totals, percentiles, and real business questions.
+7. **Changing data without destroying the world**: `INSERT`, `UPDATE`, `DELETE`, transactions, locks, concurrency, and safe migrations.
+8. **Indexes and performance**: B-tree, GIN, GiST, BRIN, partial indexes, covering indexes, `EXPLAIN ANALYZE`, query plans, keyset pagination, and systematic optimization.
+9. **Advanced SQL**: views, materialized views, stored procedures, triggers, JSONB, arrays, range types, lateral joins, security, roles, permissions, and SQL injection.
+10. **ORMs**: what they are, how they generate SQL, lazy loading, eager loading, N+1, generated migrations, and when to use an ORM, a query builder, or raw SQL.
+11. **PostgreSQL DBA essentials**: internal architecture, backups, recovery, replication, high availability, PgBouncer, monitoring, vacuum, bloat, and extensions like `pg_stat_statements`, `pg_trgm`, and `pgvector`.
+12. **Beyond relational databases**: NoSQL, document databases, Redis, Cassandra, graph databases, time-series, NewSQL, vector databases, and when each tool makes sense.
+
+The final project is **BookShelf**, a fictional platform for tracking books, reviews, followers, and recommendations. You'll design the schema, load data, write real queries, analyze performance, add indexes, use RLS, create a materialized view, and document decisions. In other words: a database with enough reality in it to stop feeling like a toy exercise.
+
+### Do I need prior knowledge?
+
+Database knowledge? No. The course starts from absolute zero: what a database is, why saving a CSV is not enough, and what it really means to have persistent, queryable, related data.
+
+What you do need:
+
+- Basic comfort with the terminal. You don't need to live there, but you should stop looking at it like it's a cave with Wi-Fi.
+- Docker installed and a basic understanding of containers and volumes. If that is still shaky, the [Mastering Docker from Scratch](/en/courses/mastering-docker-from-scratch) course fits perfectly before this one, especially up to the volumes and persistence lesson.
+- A desire to understand, not just copy queries that “seem to work.”
+- Patience with `NULL`. Not because it's hard. Because it has personality.
+
+If you come from backend, analytics, DevOps, or any environment where data exists, you'll recognize many of the problems. If you're starting from zero, even better: you'll learn the mental model before collecting superstitions, which databases have in generous supply. Some even come with corporate documentation.
+
+### An honest warning
+
+SQL looks small from the outside. Four commands, a few tables, a couple of joins, done. That's the trap.
+
+The depth is in the details: when a query uses an index, why `COUNT(*)` and `COUNT(column)` don't count the same thing, what happens when you filter a `LEFT JOIN` incorrectly, why an apparently innocent migration locks a table, how to choose a primary key, when an index helps, and when it turns writes into a slow candlelit procession.
+
+This course does not promise that you'll “master databases in a weekend.” That's marketing wearing a PostgreSQL T-shirt. What it promises is a progressive, practical path with enough context for you to understand why each concept exists and what problem it solves.
+
+Because a database is not a box where you throw JSON until someone invents a dashboard. It's a central piece of your system. Model it badly, and everything else pays interest. Understand it well, and your application breathes better.
+
+### From writing queries to thinking in data
+
+The course progression is deliberate.
+
+First you'll learn to ask: `SELECT`, `WHERE`, functions, filters. Then you'll learn to structure: tables, relationships, constraints, joins. After that you'll learn to summarize and analyze: aggregations, window functions, reporting. Later comes what separates someone who uses SQL from someone who understands databases: transactions, locks, indexes, execution plans, security, migrations, backups, and operations.
+
+By the end, I don't want SQL to feel like “that thing underneath the ORM.” I want you to see it for what it is: a precise tool for thinking about data. Sometimes elegant. Sometimes dangerous. Sometimes with `NULL` staring at you from a corner like it didn't break anything.
+
+And once you understand that, it changes how you code. It changes how you design. It changes how you review code. It even changes how you read a ticket saying “the page is slow” without immediately blaming the network, the frontend, or Mercury being in retrograde.
+
+And before closing: a quick hello to Marisa, my database teacher. If you're reading this, know that I did pay attention in your classes. It took me years to turn it into a course, but the seed was there.
+
+---
+
+**First lesson available July 10th**: “Why Do We Need Databases?”.
+
+Never stop coding!


### PR DESCRIPTION
## What

Adds the announcement post for the SQL: From Zero to DBA course (ES/EN) with required categories and course definitions.

## Content

- **Course announcement**: 75 lessons across 12 modules plus a final project — from SQL fundamentals to PostgreSQL DBA operations
- **Course structure**: Database fundamentals → SELECT queries → Filtering/sorting → Relational modeling → Joins → Aggregations → Data modification → Indexes/performance → Advanced SQL → ORMs → DBA essentials → Beyond relational → BookShelf capstone project
- **Philosophy**: Concepts before syntax, PostgreSQL from the start, performance early, serious schema design, ORMs without religion, production mindset

## Files

- `src/content/posts/presentation-sql-zero-dba-course.mdx` (EN)
- `src/content/posts/presentacion-curso-sql-cero-dba.mdx` (ES)
- `src/content/categories/sql-en.json` / `sql-es.json`
- `src/content/courses/sql-from-zero-to-dba.json` (EN)
- `src/content/courses/sql-de-cero-a-dba.json` (ES)
