### PR TITLE
chore(dependabot): allow major version updates for core tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,22 +21,6 @@ updates:
     labels:
       - "dependencies"
       - "automated"
-    # No groups - individual PRs per dependency for easier debugging
-    # and selective merging when some updates break tests
-    # Keep major updates manual for high-impact tooling.
-    # @astrojs/mdx 6.x is validated against Astro 6.4.x, so future major
-    # bumps should be evaluated together with Astro core upgrades.
-    ignore:
-      - dependency-name: "astro"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@astrojs/mdx"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "typescript"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "playwright"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "vitest"
-        update-types: ["version-update:semver-major"]
 
   # Maintain GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Remove the `ignore` list for semver-major updates on `astro`, `@astrojs/mdx`, `typescript`, `playwright` and `vitest` in `.github/dependabot.yml`, so dependabot can propose major upgrades that are reviewed and merged when ready.

Each major bump will still land in its own PR (no grouping), making it easy to revert individually if a major breaks the build.