### PR TITLE
chore(dependabot): block typescript major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,13 @@ updates:
     labels:
       - "dependencies"
       - "automated"
+    # Block typescript major bumps until typescript-eslint publishes a version
+    # compatible with typescript 7.x. typescript-estree@8.63.0 (latest 8.x) reads
+    # `ts.Extension.Cjs` which no longer exists in typescript@7, breaking ESLint
+    # config load with ERR_INTERNAL_ASSERTION.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   # Maintain GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Block `typescript` semver-major dependabot updates until `typescript-eslint` publishes a version compatible with typescript 7.x.

## Why

Reproduced locally on PR #493: `typescript-estree@8.63.0` (latest 8.x) reads `ts.Extension.Cjs` at `dist/create-program/shared.js:59`, which no longer exists in `typescript@7.0.2`. This makes ESLint fail to load its config with `ERR_INTERNAL_ASSERTION` during `bun run lint:check`, breaking the lint job in CI for any future typescript-7 dependabot PR.

The original ERR_INTERNAL_ASSERTION visible in the CI log was a side effect of the real `TypeError: Cannot read properties of undefined (reading 'Cjs')` raised when ESLint tries to load its config and pulls in `typescript-estree`.

## What this PR does

Adds an `ignore` rule in `.github/dependabot.yml` for `typescript` semver-major updates only. Minor and patch updates remain enabled so security fixes keep flowing.

## After merge

PR #493 (`typescript` 5.9.3 → 7.0.2) can be closed — it will not become mergeable until `typescript-eslint` publishes support for typescript 7.