### PR TITLE
ci(audit): cache bun dependencies in the audit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,14 @@ jobs:
         with:
           bun-version: 1.3.6
 
+      - name: Cache Bun dependencies
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 


### PR DESCRIPTION
The audit job was missing the `actions/cache` step that every other job uses, so it always reinstalled all dependencies from scratch instead of restoring from the lockfile-keyed cache. The runtime difference was small but the inconsistency made the job look like an outlier in CI logs.

Matches the cache configuration used by lint, unit-tests, e2e-tests, build and lighthouse.