### PR TITLE
feat(content): add iteration and refinement AI dialogue tutorial with refinement loop and checkpoint strategies

### DIFF
--- a/src/content/tutorials/iteracion-refinamiento-dialogo-ia.mdx
+++ b/src/content/tutorials/iteracion-refinamiento-dialogo-ia.mdx
@@ -1,0 +1,397 @@
+---
+title: "Iteración y refinamiento: el diálogo con la IA"
+post_slug: "iteracion-refinamiento-dialogo-ia"
+date: "2026-07-14"
+excerpt: "Aprende a refinar respuestas de IA sin perder el objetivo: cuándo iterar, cuándo empezar de cero y cómo mantener conversaciones largas bajo control."
+language: "es"
+categories: ["ia"]
+course: "ia-para-programadores"
+order: 11
+cover: "/images/tutorials/cabecera-ia-para-programadores-curso.jpg"
+i18n: "iteration-refinement-ai-dialogue"
+---
+
+Le pides a la IA una función pequeña. Una cosa tranquila. Una función de esas que caben en pantalla y no hacen ruido.
+
+Tres mensajes después, la función tiene logging, validación, caché, métricas, soporte para zonas horarias, una clase `Manager`, dos excepciones custom y una sensación muy clara de que alguien ha perdido el control de la obra.
+
+¿Cuándo pasó? ¿En qué prompt exacto dejó de ser una función y empezó a parecer una startup en fase seed? ¿Fuiste tú? ¿Fue la IA? ¿Fue el entusiasmo? Sí.
+
+Trabajar con IA no es escribir un prompt perfecto y esperar que caiga código del cielo con olor a café recién hecho. Es un **diálogo de refinamiento**. Pides algo, evalúas la respuesta, corriges, ajustas, recortas, vuelves a pedir. Si lo haces bien, mejoras el resultado paso a paso. Si lo haces mal, acabas con una conversación larga, contradictoria y un código que ya no recuerda por qué nació.
+
+En el [tutorial anterior vimos cómo generar código con IA sin pedir “hazme cosas” y rezar](/es/tutoriales/prompts-para-generar-codigo-ia). Hoy toca la parte que viene justo después: qué hacer cuando la primera respuesta no es suficiente. Que será casi siempre. Sorpresa moderada.
+
+## La primera respuesta rara vez es la buena
+
+La primera respuesta de la IA suele ser un **borrador**. A veces es un buen borrador. A veces es un borrador con zapatos de payaso. Pero sigue siendo un punto de partida, no una sentencia tallada en piedra.
+
+Esto es importante porque mucha gente trata la primera respuesta como si fuera un examen: si está mal, “la IA no sirve”; si está bien, se copia; si está medio bien, se copia igual pero con cara de preocupación. Ninguna de esas opciones es trabajar bien.
+
+Un flujo más sano es este:
+
+```text
+Ronda 1:
+"Crea una versión básica que funcione. Prioriza claridad sobre optimización."
+
+Ronda 2:
+"Ahora añade el caso de borde donde la lista viene vacía."
+
+Ronda 3:
+"Esta versión recorre la lista dos veces. Refactorízala para hacerlo en una sola pasada."
+
+Ronda 4:
+"El código funciona, pero los nombres no explican la intención. Mejora nombres sin cambiar comportamiento."
+
+Ronda 5:
+"Añade tests para el caso normal, lista vacía y valores duplicados."
+```
+
+Fíjate en la estructura: cada ronda cambia **una cosa concreta**. No dices “mejóralo”. “Mejóralo” es una caja negra. Puede significar rendimiento, legibilidad, arquitectura, seguridad, naming, tests o que la IA decida meter un patrón Strategy porque hoy se levantó con ganas de Enterprise Java.
+
+Refinar bien significa dirigir. No empujar vagamente.
+
+## El loop de refinamiento
+
+El patrón básico tiene cuatro pasos:
+
+1. **Pedir** una versión concreta
+2. **Evaluar** qué está bien y qué no
+3. **Corregir** una dimensión específica
+4. **Verificar** que no se ha roto lo anterior
+
+La parte que la gente se salta es la tercera o la cuarta. Normalmente las dos, porque somos optimistas hasta que producción nos educa.
+
+Mira este ejemplo:
+
+```text
+Quiero una función en Python que reciba una lista de precios y devuelva el total
+con IVA incluido. El IVA debe ser configurable. Prioriza claridad.
+```
+
+La IA podría devolver algo así:
+
+```python
+def calculate_total_with_tax(prices, tax_rate=0.21):
+    total = 0
+    for price in prices:
+        total += price
+    return total + (total * tax_rate)
+```
+
+No está mal. Pero quizá quieres type hints y validación:
+
+```text
+Mantén la misma lógica, pero añade type hints.
+Si algún precio es negativo, lanza ValueError.
+No cambies el nombre de la función.
+```
+
+Ese `No cambies el nombre de la función` parece una tontería hasta que no lo pones. Entonces la IA decide que `calculate_total_with_tax` ahora se llama `compute_invoice_amount` porque suena más profesional. Y sí, suena más profesional. También acaba de romper todos tus tests.
+
+Una respuesta refinada podría ser:
+
+```python
+def calculate_total_with_tax(prices: list[float], tax_rate: float = 0.21) -> float:
+    for price in prices:
+        if price < 0:
+            raise ValueError("Prices cannot be negative")
+
+    total = sum(prices)
+    return total + (total * tax_rate)
+```
+
+Mejor. Ahora verificas:
+
+```text
+Comprueba si el cambio mantiene el comportamiento anterior.
+Compara la versión original y la nueva en estos casos:
+1. [10, 20]
+2. []
+3. [0]
+4. [-5]
+
+Formato:
+- Caso
+- Resultado original
+- Resultado nuevo
+- Diferencia relevante
+```
+
+Este paso no es ceremonial. Es el equivalente a mirar a ambos lados antes de cruzar. La mayoría de días no pasa nada. El día que pasa, agradeces no haber cruzado mirando el móvil.
+
+## Cambia una cosa cada vez
+
+La regla de oro del refinamiento es sencilla: **una dimensión por ronda**.
+
+No hagas esto:
+
+```text
+Hazlo más rápido, más limpio, añade tests, maneja errores, usa mejor arquitectura,
+explica los cambios y deja todo listo para producción.
+```
+
+Ese prompt parece productivo. En realidad es meter seis conversaciones en una y esperar que ninguna se pise. ¿Qué pasa si el resultado empeora? ¿Fue por la optimización? ¿Por la arquitectura? ¿Por los tests? ¿Por la luna en Capricornio? Buena suerte depurando eso.
+
+Hazlo así:
+
+```text
+Primero, revisa solo la legibilidad.
+No cambies comportamiento.
+No optimices todavía.
+Devuelve únicamente la versión refactorizada y una lista de cambios de naming.
+```
+
+Después:
+
+```text
+Ahora revisa rendimiento.
+Mantén el mismo comportamiento y la misma interfaz pública.
+Señala cualquier trade-off antes de cambiar el código.
+```
+
+Y después:
+
+```text
+Ahora añade tests.
+No modifiques la implementación salvo que encuentres un bug real.
+```
+
+Esto no es ir más lento. Es evitar reconstruir el mueble entero porque apretaste tres tornillos a la vez y ahora la puerta cierra como si tuviera resentimiento.
+
+El refinamiento bueno deja rastro. Sabes qué cambió, por qué cambió y qué no debía cambiar.
+
+## Cuándo refinar y cuándo empezar de cero
+
+Aquí viene una decisión que separa el uso principiante de la IA del uso profesional: no toda conversación merece ser salvada.
+
+Refina cuando la base es buena:
+
+- La idea general encaja
+- El código funciona en el camino feliz
+- La estructura tiene sentido
+- Los problemas son localizados
+- Puedes describir claramente qué quieres cambiar
+
+Por ejemplo:
+
+```text
+La solución general me vale.
+Refina solo el manejo de errores: ahora mismo devuelve None en silencio,
+pero quiero que lance ValueError con un mensaje claro.
+No cambies la firma de la función.
+```
+
+Empieza de cero cuando la base está torcida:
+
+- La arquitectura no encaja con tu proyecto
+- La IA asumió requisitos falsos
+- La conversación ya mezcla varias decisiones contradictorias
+- Has corregido tres veces lo mismo y sigue reapareciendo
+- El código funciona, pero por accidente y con olor a sótano húmedo
+
+Ahí toca cortar:
+
+```text
+Vamos a empezar de cero.
+Ignora el enfoque anterior.
+
+Nuevo objetivo:
+[descripción clara]
+
+Restricciones:
+- [restricción 1]
+- [restricción 2]
+- [restricción 3]
+
+No reutilices código de la respuesta anterior salvo que lo pida explícitamente.
+Antes de escribir código, resume el diseño propuesto en 5 bullets.
+```
+
+Ese “ignora el enfoque anterior” no es magia, pero ayuda. La parte importante es que le das una especificación nueva y limpia. No intentas arreglar una conversación que ya parece un hilo de Slack de 73 mensajes donde nadie sabe si seguimos hablando del bug original.
+
+Si te cuesta decidir, usa esta regla: si puedes explicar el cambio en una frase, refina. Si necesitas explicar toda la historia de por qué llegaste ahí, empieza de cero.
+
+## Cómo gestionar conversaciones largas
+
+Las conversaciones largas con IA tienen un problema: el contexto se va diluyendo. No desaparece de golpe, pero pierde fuerza. Lo importante compite con detalles antiguos, cambios descartados, ejemplos temporales y esa respuesta de hace veinte minutos donde pediste “solo una prueba rápida”. Sí, esa prueba rápida ahora vive en el contexto como un mueble heredado.
+
+Para mantener el control, usa **checkpoints**.
+
+Cada cierto número de rondas, pide un resumen operativo:
+
+```text
+Resume el estado actual de la solución.
+
+Formato:
+1. Objetivo original
+2. Decisiones tomadas
+3. Requisitos actuales
+4. Restricciones que NO deben cambiar
+5. Código o archivos afectados
+6. Pendientes
+```
+
+Luego revisa el resumen. Esto es importante: **no aceptes el resumen sin leerlo**. La IA puede resumir con seguridad cosas que nunca decidiste. Es una habilidad muy humana, por cierto; también ocurre en reuniones.
+
+Si el resumen es correcto, úsalo como nuevo punto de partida:
+
+```text
+Usa este resumen como contexto principal para las siguientes respuestas.
+Si algo contradice mensajes anteriores, prioriza este resumen.
+```
+
+Y si vas a abrir una conversación nueva, pega tu propio resumen:
+
+```text
+Contexto de trabajo:
+- Estoy implementando [feature]
+- Ya decidimos [decisión]
+- No queremos [restricción]
+- El comportamiento esperado es [comportamiento]
+- El problema actual es [problema]
+
+Tarea:
+Ayúdame a continuar desde aquí.
+```
+
+Esto reduce muchísimo el ruido. No porque la IA tenga “memoria perfecta”, sino porque le estás poniendo el mapa delante otra vez. Y créeme: en conversaciones largas, el mapa no es opcional. Es la diferencia entre llegar al destino y terminar optimizando una función que ya no se usa.
+
+## La plantilla de refinamiento
+
+Guarda esta plantilla. Es simple, pero evita el 80% del caos:
+
+```text
+Objetivo original:
+[qué quería conseguir]
+
+Respuesta actual:
+[pega la parte relevante, no toda la novela]
+
+Qué está bien:
+- [punto 1]
+- [punto 2]
+
+Qué quiero cambiar:
+- [cambio concreto]
+
+Restricciones:
+- No cambies [interfaz / nombre / comportamiento / formato]
+- Mantén [convención / estilo / dependencia]
+- No añadas [cosa que no quieres]
+
+Formato de respuesta:
+1. Explica brevemente el cambio
+2. Devuelve la versión refinada
+3. Lista qué se mantuvo igual
+4. Señala cualquier trade-off
+```
+
+Ejemplo:
+
+```text
+Objetivo original:
+Crear una función que agrupe usuarios por país.
+
+Respuesta actual:
+[pegar función]
+
+Qué está bien:
+- La salida tiene la forma correcta
+- El caso normal funciona
+
+Qué quiero cambiar:
+- Manejar usuarios sin país usando la clave "unknown"
+
+Restricciones:
+- No cambies el nombre group_users_by_country
+- No cambies el formato de salida
+- No añadas dependencias
+- No conviertas esto en una clase
+
+Formato de respuesta:
+1. Explica brevemente el cambio
+2. Devuelve la función refinada
+3. Lista qué se mantuvo igual
+4. Señala cualquier trade-off
+```
+
+La frase “No conviertas esto en una clase” merece estar en un museo. No porque las clases sean malas, sino porque la IA tiene tendencia a vestir de gala problemas que iban perfectamente en camiseta.
+
+## Pide diferencias, no solo versiones nuevas
+
+Cuando refinamos, solemos pedir “dame la versión mejorada”. Eso está bien, pero a veces falta una pieza: entender **qué cambió**.
+
+Pide un diff conceptual:
+
+```text
+Antes de darme el código final, resume los cambios respecto a la versión anterior:
+- Qué cambió
+- Qué se mantiene igual
+- Por qué el cambio mejora la solución
+- Qué riesgo introduce, si alguno
+```
+
+Esto te obliga a revisar con criterio. Si la IA dice “se mantiene igual la firma” y ves que cambió la firma, ya sabes que no puedes confiar en esa respuesta sin mirar. Buenísimo: has encontrado el problema antes de pegar código.
+
+También puedes pedir que marque solo las líneas relevantes:
+
+```text
+Devuelve únicamente las partes modificadas.
+No repitas el archivo entero salvo que sea necesario.
+```
+
+Esto es especialmente útil cuando trabajas con archivos grandes. Si cada respuesta repite 300 líneas, tu conversación se llena de ruido y tú acabas haciendo scroll como si buscaras una cláusula escondida en un contrato de telefonía.
+
+Menos texto no siempre significa menos calidad. A veces significa menos superficie para que algo se rompa sin que lo veas.
+
+## No dejes que la IA mueva la portería
+
+El mayor peligro del refinamiento no es que la IA se equivoque. Eso ya lo esperamos. El peligro real es que cambie el objetivo poco a poco y tú no te des cuenta.
+
+Empiezas con:
+
+```text
+Quiero validar un email.
+```
+
+Cinco rondas después estás hablando de usuarios, dominios permitidos, normalización, verificación DNS, rate limiting y un servicio de notificaciones. Todo puede ser razonable. También puede ser completamente innecesario.
+
+Por eso conviene repetir el objetivo original durante la conversación:
+
+```text
+Recuerda el objetivo: validar el formato de un email en el frontend.
+No estamos implementando registro de usuarios.
+No añadas verificación de dominio.
+No introduzcas llamadas de red.
+```
+
+Esto no es ser borde. Es dirigir. La IA no tiene el coste emocional de mantener un sistema simple. Tú sí. Tú vas a mantener ese código cuando el entusiasmo se vaya y solo quede el repositorio.
+
+Una buena señal de alarma: si una respuesta introduce una abstracción que no pediste, pausa. Pregunta:
+
+```text
+¿Por qué has introducido esta abstracción?
+¿Qué problema concreto resuelve en este caso?
+¿Cuál sería la versión más simple sin ella?
+```
+
+A veces la abstracción estará justificada. Muchas veces no. Y ahí tienes que hacer de arquitecto, no de espectador. La IA propone; tú decides. Si inviertes ese orden, el código empieza a tener pinta de casa diseñada por alguien que cobra por número de pasillos.
+
+## Conceptos clave de esta lección
+
+- La primera respuesta de la IA suele ser un borrador, no el resultado final
+- Refinar bien significa cambiar una dimensión concreta por ronda
+- “Mejóralo” es demasiado vago; pide cambios específicos y verificables
+- Refina cuando la base es buena; empieza de cero cuando el enfoque está torcido
+- En conversaciones largas, usa checkpoints y resúmenes revisados por ti
+- Pide qué cambió y qué se mantuvo igual, no solo una versión nueva
+- Repite el objetivo original para evitar que la conversación mueva la portería
+- La IA propone; tú diriges y decides
+
+---
+
+**💡 Reto:** Coge una respuesta de IA que hayas usado recientemente y haz una ronda de refinamiento controlada. Cambia una sola cosa: legibilidad, rendimiento, error handling o tests. Antes de aceptar el resultado, pide qué cambió, qué se mantuvo igual y qué riesgo introduce.
+
+El refinamiento es donde la IA deja de ser una máquina de respuestas y se convierte en una herramienta de trabajo real. Pero todavía falta una pieza crítica: entender y verificar el código que genera. En el próximo tutorial veremos cómo revisar línea por línea, detectar red flags y no acabar confiando en código que funciona solo porque Dios es bueno.
+
+¡Nunca dejes de programar!

--- a/src/content/tutorials/iteration-refinement-ai-dialogue.mdx
+++ b/src/content/tutorials/iteration-refinement-ai-dialogue.mdx
@@ -1,0 +1,397 @@
+---
+title: "Iteration and refinement: the AI dialogue"
+post_slug: "iteration-refinement-ai-dialogue"
+date: "2026-07-14"
+excerpt: "Learn how to refine AI responses without losing the goal: when to iterate, when to start fresh, and how to keep long conversations under control."
+language: "en"
+categories: ["ai"]
+course: "ai-for-developers"
+order: 11
+cover: "/images/tutorials/cabecera-ia-para-programadores-curso.jpg"
+i18n: "iteracion-refinamiento-dialogo-ia"
+---
+
+You ask AI for a small function. Nothing dramatic. A quiet little function that fits on screen and minds its own business.
+
+Three messages later, the function has logging, validation, caching, metrics, timezone support, a `Manager` class, two custom exceptions, and the unmistakable feeling that someone has lost control of the construction site.
+
+When did that happen? Which exact prompt turned a function into a seed-stage startup? Was it you? Was it the AI? Was it enthusiasm? Yes.
+
+Working with AI is not about writing one perfect prompt and waiting for code to fall from the sky smelling faintly of fresh coffee. It's a **refinement dialogue**. You ask for something, evaluate the answer, correct it, tighten it, cut it down, and ask again. Done well, the result improves step by step. Done badly, you end up with a long, contradictory conversation and code that no longer remembers why it was born.
+
+In the [previous lesson we looked at generating code with AI without asking “make me things” and hoping for the best](/en/tutorials/prompts-for-code-generation-ai). Now comes the part immediately after that: what to do when the first answer is not enough. Which is most of the time. Mild surprise.
+
+## The first answer is rarely the right one
+
+The first AI response is usually a **draft**. Sometimes a good draft. Sometimes a draft wearing clown shoes. But still a starting point, not a stone tablet carried down from a mountain.
+
+This matters because many people treat the first answer like a pass/fail exam: if it's wrong, “AI is useless”; if it's right, they copy it; if it's half-right, they copy it anyway but with a worried expression. None of those is a professional workflow.
+
+A healthier flow looks like this:
+
+```text
+Round 1:
+"Create a basic working version. Prioritize clarity over optimization."
+
+Round 2:
+"Now handle the edge case where the list is empty."
+
+Round 3:
+"This version loops over the list twice. Refactor it to use a single pass."
+
+Round 4:
+"The code works, but the names don't explain intent. Improve names without changing behavior."
+
+Round 5:
+"Add tests for the normal case, empty list, and duplicate values."
+```
+
+Notice the structure: each round changes **one specific thing**. You don't say “improve it.” “Improve it” is a black box. It could mean performance, readability, architecture, security, naming, tests, or the AI deciding to introduce a Strategy pattern because apparently today we are doing Enterprise Java.
+
+Good refinement means directing. Not vaguely nudging.
+
+## The refinement loop
+
+The basic pattern has four steps:
+
+1. **Ask** for a concrete version
+2. **Evaluate** what works and what doesn't
+3. **Correct** one specific dimension
+4. **Verify** that the previous behavior still holds
+
+The part people skip is the third or the fourth. Usually both, because humans are optimistic until production educates them.
+
+Look at this example:
+
+```text
+I want a Python function that receives a list of prices and returns the total
+including tax. The tax rate should be configurable. Prioritize clarity.
+```
+
+AI might return this:
+
+```python
+def calculate_total_with_tax(prices, tax_rate=0.21):
+    total = 0
+    for price in prices:
+        total += price
+    return total + (total * tax_rate)
+```
+
+Not bad. But maybe you want type hints and validation:
+
+```text
+Keep the same logic, but add type hints.
+If any price is negative, raise ValueError.
+Do not change the function name.
+```
+
+That `Do not change the function name` looks silly until you don't include it. Then the AI decides `calculate_total_with_tax` is now called `compute_invoice_amount` because it sounds more professional. And yes, it does sound more professional. It also just broke all your tests.
+
+A refined answer might be:
+
+```python
+def calculate_total_with_tax(prices: list[float], tax_rate: float = 0.21) -> float:
+    for price in prices:
+        if price < 0:
+            raise ValueError("Prices cannot be negative")
+
+    total = sum(prices)
+    return total + (total * tax_rate)
+```
+
+Better. Now verify:
+
+```text
+Check whether the change preserves the previous behavior.
+Compare the original version and the new one for these cases:
+1. [10, 20]
+2. []
+3. [0]
+4. [-5]
+
+Format:
+- Case
+- Original result
+- New result
+- Relevant difference
+```
+
+This step is not ceremonial. It's the equivalent of looking both ways before crossing the street. Most days nothing happens. On the day something does, you're glad you weren't crossing while staring at your phone.
+
+## Change one thing at a time
+
+The golden rule of refinement is simple: **one dimension per round**.
+
+Don't do this:
+
+```text
+Make it faster, cleaner, add tests, handle errors, use better architecture,
+explain the changes, and make it production-ready.
+```
+
+That prompt looks productive. It is actually six conversations stuffed into one and asked politely not to collide. What happens if the result gets worse? Was it the optimization? The architecture? The tests? The moon in Capricorn? Good luck debugging that.
+
+Do this instead:
+
+```text
+First, review readability only.
+Do not change behavior.
+Do not optimize yet.
+Return only the refactored version and a list of naming changes.
+```
+
+Then:
+
+```text
+Now review performance.
+Keep the same behavior and the same public interface.
+Point out any trade-off before changing the code.
+```
+
+Then:
+
+```text
+Now add tests.
+Do not modify the implementation unless you find a real bug.
+```
+
+This is not slower. It's how you avoid rebuilding the whole cabinet because you tightened three screws at once and now the door closes like it has unresolved resentment.
+
+Good refinement leaves a trail. You know what changed, why it changed, and what was not supposed to change.
+
+## When to refine and when to start fresh
+
+Here's a decision that separates beginner AI usage from professional AI usage: not every conversation deserves to be rescued.
+
+Refine when the base is good:
+
+- The general idea fits
+- The code works on the happy path
+- The structure makes sense
+- The problems are localized
+- You can clearly describe what you want changed
+
+For example:
+
+```text
+The general solution works for me.
+Refine only the error handling: right now it silently returns None,
+but I want it to raise ValueError with a clear message.
+Do not change the function signature.
+```
+
+Start fresh when the foundation is crooked:
+
+- The architecture doesn't fit your project
+- The AI assumed false requirements
+- The conversation now mixes contradictory decisions
+- You've corrected the same thing three times and it keeps coming back
+- The code works, but by accident and with a damp basement smell
+
+That's when you cut:
+
+```text
+Let's start over.
+Ignore the previous approach.
+
+New goal:
+[clear description]
+
+Constraints:
+- [constraint 1]
+- [constraint 2]
+- [constraint 3]
+
+Do not reuse code from the previous response unless I explicitly ask for it.
+Before writing code, summarize the proposed design in 5 bullets.
+```
+
+“Ignore the previous approach” is not magic, but it helps. The important part is that you provide a clean new specification. You are not trying to patch a conversation that now looks like a 73-message Slack thread where nobody knows whether we're still discussing the original bug.
+
+If you're unsure, use this rule: if you can explain the change in one sentence, refine. If you need to explain the entire history of how you got there, start fresh.
+
+## Managing long conversations
+
+Long AI conversations have a problem: context gets diluted. It doesn't disappear all at once, but it loses weight. Important decisions compete with old details, discarded changes, temporary examples, and that response from twenty minutes ago where you asked for “just a quick test.” Yes, that quick test now lives in the context like inherited furniture.
+
+To stay in control, use **checkpoints**.
+
+Every few rounds, ask for an operational summary:
+
+```text
+Summarize the current state of the solution.
+
+Format:
+1. Original goal
+2. Decisions made
+3. Current requirements
+4. Constraints that must NOT change
+5. Code or files affected
+6. Pending work
+```
+
+Then review the summary. This matters: **do not accept the summary without reading it**. AI can confidently summarize things you never decided. Very human skill, actually; it also happens in meetings.
+
+If the summary is correct, use it as the new anchor:
+
+```text
+Use this summary as the main context for the next responses.
+If anything contradicts earlier messages, prioritize this summary.
+```
+
+And if you're opening a new conversation, paste your own summary:
+
+```text
+Working context:
+- I'm implementing [feature]
+- We already decided [decision]
+- We don't want [constraint]
+- The expected behavior is [behavior]
+- The current problem is [problem]
+
+Task:
+Help me continue from here.
+```
+
+This reduces noise dramatically. Not because AI has “perfect memory,” but because you're putting the map back in front of it. And trust me: in long conversations, the map is not optional. It's the difference between reaching the destination and optimizing a function nobody uses anymore.
+
+## The refinement template
+
+Save this template. It's simple, but it prevents 80% of the chaos:
+
+```text
+Original goal:
+[what I wanted to achieve]
+
+Current response:
+[paste the relevant part, not the whole novel]
+
+What works:
+- [point 1]
+- [point 2]
+
+What I want changed:
+- [specific change]
+
+Constraints:
+- Do not change [interface / name / behavior / format]
+- Keep [convention / style / dependency]
+- Do not add [thing you don't want]
+
+Response format:
+1. Briefly explain the change
+2. Return the refined version
+3. List what stayed the same
+4. Mention any trade-off
+```
+
+Example:
+
+```text
+Original goal:
+Create a function that groups users by country.
+
+Current response:
+[paste function]
+
+What works:
+- The output shape is correct
+- The normal case works
+
+What I want changed:
+- Handle users without a country using the key "unknown"
+
+Constraints:
+- Do not change the name group_users_by_country
+- Do not change the output format
+- Do not add dependencies
+- Do not turn this into a class
+
+Response format:
+1. Briefly explain the change
+2. Return the refined function
+3. List what stayed the same
+4. Mention any trade-off
+```
+
+The sentence “Do not turn this into a class” belongs in a museum. Not because classes are bad, but because AI has a habit of putting formal clothes on problems that were perfectly fine in a t-shirt.
+
+## Ask for differences, not just new versions
+
+When refining, we often ask for “the improved version.” That's fine, but one piece is often missing: understanding **what changed**.
+
+Ask for a conceptual diff:
+
+```text
+Before giving me the final code, summarize the changes from the previous version:
+- What changed
+- What stayed the same
+- Why the change improves the solution
+- What risk it introduces, if any
+```
+
+This forces you to review with judgment. If the AI says “the signature stayed the same” and you can see the signature changed, you now know not to trust that answer without inspection. Excellent: you found the problem before pasting code.
+
+You can also ask it to show only the relevant changes:
+
+```text
+Return only the modified parts.
+Do not repeat the whole file unless necessary.
+```
+
+This is especially useful when working with large files. If every response repeats 300 lines, your conversation fills with noise and you end up scrolling like you're searching for a hidden clause in a phone contract.
+
+Less text does not always mean less quality. Sometimes it means less surface area for things to break unnoticed.
+
+## Don't let AI move the goalposts
+
+The biggest danger in refinement is not that AI makes a mistake. We already expect that. The real danger is that it slowly changes the goal and you don't notice.
+
+You start with:
+
+```text
+I want to validate an email.
+```
+
+Five rounds later you're discussing users, allowed domains, normalization, DNS verification, rate limiting, and a notification service. All of it may be reasonable. It may also be completely unnecessary.
+
+That's why it's useful to repeat the original goal during the conversation:
+
+```text
+Remember the goal: validate the format of an email on the frontend.
+We are not implementing user registration.
+Do not add domain verification.
+Do not introduce network calls.
+```
+
+This is not being rude. It's directing. AI does not pay the maintenance cost of keeping a system simple. You do. You will maintain that code when the excitement is gone and only the repository remains.
+
+A good warning sign: if a response introduces an abstraction you didn't ask for, pause. Ask:
+
+```text
+Why did you introduce this abstraction?
+What concrete problem does it solve in this case?
+What would the simplest version look like without it?
+```
+
+Sometimes the abstraction will be justified. Often it won't. That's where you need to act like an architect, not a spectator. AI proposes; you decide. If you reverse that order, your code starts looking like a house designed by someone paid per hallway.
+
+## Key concepts from this lesson
+
+- The first AI response is usually a draft, not the final result
+- Good refinement changes one concrete dimension per round
+- “Improve it” is too vague; ask for specific, verifiable changes
+- Refine when the base is good; start fresh when the approach is crooked
+- In long conversations, use checkpoints and summaries you actually review
+- Ask what changed and what stayed the same, not just for a new version
+- Repeat the original goal to prevent the conversation from moving the goalposts
+- AI proposes; you direct and decide
+
+---
+
+**💡 Challenge:** Take an AI response you've used recently and run one controlled refinement round. Change only one thing: readability, performance, error handling, or tests. Before accepting the result, ask what changed, what stayed the same, and what risk it introduces.
+
+Refinement is where AI stops being an answer machine and starts becoming a real working tool. But one critical piece is still missing: understanding and verifying the code it generates. In the next lesson we'll review code line by line, spot red flags, and avoid trusting code that works only because God is good.
+
+Never stop coding!


### PR DESCRIPTION
## What

Adds the iteration and refinement AI dialogue tutorial (lesson 11 of the AI for Developers course) in both Spanish and English.

## Content

- **The first answer is a draft**: Treating AI output as a starting point, not a final result
- **The refinement loop**: Ask → Evaluate → Correct → Verify — one dimension per round
- **Change one thing at a time**: Avoid mixing readability, performance, tests, and architecture in a single prompt
- **When to refine vs start fresh**: Decision criteria — localized problems vs broken foundations
- **Managing long conversations**: Checkpoints with operational summaries, reviewing before accepting, opening new conversations with context blocks
- **The refinement template**: Ready-to-use prompt structure with original goal, constraints, and response format
- **Ask for diffs**: Conceptual diff of what changed, what stayed the same, and what risk is introduced
- **Don't let AI move the goalposts**: Repeating the original goal, questioning unsolicited abstractions

## Files

- src/content/tutorials/iteration-refinement-ai-dialogue.mdx (EN)
- src/content/tutorials/iteracion-refinamiento-dialogo-ia.mdx (ES)