### PR TITLE
docs(license): add MIT LICENSE and dual-license README section

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Javi Palacios
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ src/
 
 This project is dual-licensed:
 
-- **Code** (Astro components, scripts, workflows, and all source files in `src/`, `scripts/`, and `.github/`) is licensed under the [MIT License](LICENSE).
-- **Written content** (tutorials, book reviews, blog posts, and other authored text) is additionally available under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/) (CC BY 4.0).
+- **Code** (Astro components, scripts, workflows, and all source files in `src/`, `scripts/`, and `.github/`, **excluding `src/content/`**) is licensed under the [MIT License](LICENSE).
+- **Written content** (tutorials, book reviews, blog posts, and other authored text in `src/content/`) is licensed under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/) (CC BY 4.0).
 
 You may use the code under MIT terms. You may reuse, adapt, and redistribute the written content under CC BY 4.0 with appropriate attribution to the original author.

--- a/README.md
+++ b/README.md
@@ -109,5 +109,9 @@ src/
 
 ## License
 
-**Code:** MIT License  
-**Content:** © 2026 Francisco Javier Palacios Pérez - All Rights Reserved
+This project is dual-licensed:
+
+- **Code** (Astro components, scripts, workflows, and all source files in `src/`, `scripts/`, and `.github/`) is licensed under the [MIT License](LICENSE).
+- **Written content** (tutorials, book reviews, blog posts, and other authored text) is additionally available under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/) (CC BY 4.0).
+
+You may use the code under MIT terms. You may reuse, adapt, and redistribute the written content under CC BY 4.0 with appropriate attribution to the original author.


### PR DESCRIPTION
Add MIT LICENSE and dual-license README section.

The previous README mentioned 'MIT License' for the code, but no
LICENSE file existed, so the code was not actually under an executable
MIT grant.

This commit:

- Adds a LICENSE file at the repo root with the standard MIT text
  and Copyright (c) 2026 Javi Palacios.
- Updates the README's License section to document a dual-license
  model: code under MIT, written content under CC BY 4.0.

After this is merged, the repo will be unambiguously open source,
which enables tools like CodeRabbit to recognise the project under
their OSS plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a MIT License file to the project.
  * Updated the README’s licensing section to reflect dual licensing: code under MIT, and written content under CC BY 4.0 with attribution required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->