### PR TITLE
refactor(synopsis): remove unused sanitizer

### DIFF
--- a/src/__tests__/utils/synopsis.test.ts
+++ b/src/__tests__/utils/synopsis.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { processSynopsis, sanitizeSynopsis } from "../../utils/synopsis";
+import { processSynopsis } from "../../utils/synopsis";
 
 describe("processSynopsis", () => {
   it("converts italic markdown to <em> tags", () => {
@@ -88,54 +88,5 @@ describe("processSynopsis", () => {
     expect(output).toContain("<em>b</em>");
     expect(output).toContain("<strong>c</strong>");
     expect(output).toContain("&lt;script&gt;");
-  });
-});
-
-describe("sanitizeSynopsis", () => {
-  it("removes italic markdown", () => {
-    const input = "Maestro del _nonsense_, Lewis Carroll";
-    const output = sanitizeSynopsis(input);
-    expect(output).toBe("Maestro del nonsense, Lewis Carroll");
-  });
-
-  it("removes bold markdown", () => {
-    const input = "This is **bold** text";
-    const output = sanitizeSynopsis(input);
-    expect(output).toBe("This is bold text");
-  });
-
-  it("converts literal \\n to spaces", () => {
-    const input = "Line one\\nLine two";
-    const output = sanitizeSynopsis(input);
-    expect(output).toBe("Line one Line two");
-  });
-
-  it("removes HTML tags", () => {
-    const input = "This is <em>italic</em> and <strong>bold</strong>";
-    const output = sanitizeSynopsis(input);
-    expect(output).toBe("This is italic and bold");
-  });
-
-  it("normalizes whitespace", () => {
-    const input = "Multiple    spaces   here";
-    const output = sanitizeSynopsis(input);
-    expect(output).toBe("Multiple spaces here");
-  });
-
-  it("returns empty string for empty input", () => {
-    expect(sanitizeSynopsis("")).toBe("");
-  });
-
-  it("handles complex real synopsis", () => {
-    const input =
-      "Maestro del _nonsense_, Lewis Carroll traspasó en estos textos.\\n\\nAcompañado de las ilustraciones **originales** de John Tenniel.";
-    const output = sanitizeSynopsis(input);
-
-    expect(output).not.toContain("_");
-    expect(output).not.toContain("**");
-    expect(output).not.toContain("\\n");
-    expect(output).not.toContain("<");
-    expect(output).toContain("nonsense");
-    expect(output).toContain("originales");
   });
 });

--- a/src/utils/synopsis.ts
+++ b/src/utils/synopsis.ts
@@ -47,22 +47,3 @@ export function processSynopsis(synopsis: string): string {
   // Return trimmed HTML (keep multiple <p> tags for multi-paragraph synopsis)
   return html.trim();
 }
-
-/**
- * Sanitize synopsis for plain text usage (meta tags, etc.)
- * Removes all markdown and HTML formatting
- *
- * @param synopsis - Raw synopsis string
- * @returns Plain text without formatting
- */
-export function sanitizeSynopsis(synopsis: string): string {
-  if (!synopsis) return "";
-
-  return synopsis
-    .replace(/\\n/g, " ") // Replace literal \\n with space
-    .replace(/\*\*(.+?)\*\*/g, "$1") // Remove **bold**
-    .replace(/_(.+?)_/g, "$1") // Remove _italic_
-    .replace(/<[^>]*>/g, "") // Remove HTML tags
-    .replace(/\s+/g, " ") // Normalize whitespace
-    .trim();
-}


### PR DESCRIPTION
## Summary

Remove the unused synopsis sanitizer that triggered CodeQL alert #9.

## Changes

- Remove `sanitizeSynopsis` and its tests.
- Keep the production `processSynopsis` XSS protection unchanged.

## Validation

- [x] 1,724 unit tests passed.
- [x] `git diff --check`

## Risk / Follow-up

CodeQL should close alert #9 after the change reaches `master` and the full scan runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synopsis rendering by safely escaping HTML before processing Markdown.
  - Prevented raw HTML from being rendered while preserving supported Markdown formatting.

- **Refactor**
  - Simplified synopsis processing by removing an unused sanitization pathway and its associated tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->